### PR TITLE
Configure Dependabot.

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Updates for Github Actions used in the repo
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "vector-im/element-x-android-reviewers"
+  # Updates for Gradle dependencies used in the app
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 200
+    reviewers:
+      - "vector-im/element-x-android-reviewers"


### PR DESCRIPTION
Closes #6 

Note: Dependabot does not work on Gradle Catalog, but there is an open PR to add it: https://github.com/dependabot/dependabot-core/pull/6249

This is not urgent on our side and it does not prevent from merging this. Hopefully it will be supported one day and we will see PRs coming!