### PR TITLE
Add GitHub actions to update and validate the Gradle Wrapper.

### DIFF
--- a/.github/workflows/gradle-wrapper-update.yml
+++ b/.github/workflows/gradle-wrapper-update.yml
@@ -1,0 +1,18 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1
+        # Skip in forks
+        if: github.repository == 'vector-im/element-x-android'
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: develop

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,14 @@
+name: "Validate Gradle Wrapper"
+on:
+  pull_request: { }
+  push:
+    branches: [ main, develop ]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    # No concurrency required, this is a prerequisite to other actions and should run every time.
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Closes #41 

`Validate Gradle Wrapper / Validation (pull_request)` has to be made mandatory in GitHub settings.