### PR TITLE
Setup Flipper.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -189,4 +189,8 @@ dependencies {
 
     implementation(libs.showkase)
     ksp(libs.showkase.processor)
+
+    // Flipper, debug builds only
+    debugImplementation(libs.debug.flipper)
+    debugImplementation("com.facebook.soloader:soloader:0.10.5")
 }

--- a/app/src/debug/java/io/element/android/x/flipper/VectorFlipperProxy.kt
+++ b/app/src/debug/java/io/element/android/x/flipper/VectorFlipperProxy.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.x.flipper
+
+import android.content.Context
+import android.os.Build
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.android.utils.FlipperUtils
+import com.facebook.flipper.plugins.crashreporter.CrashReporterPlugin
+import com.facebook.flipper.plugins.inspector.DescriptorMapping
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
+import com.facebook.soloader.SoLoader
+
+class VectorFlipperProxy(
+    private val context: Context,
+) {
+
+    private val isEnabled: Boolean
+        get() {
+            // https://github.com/facebook/flipper/issues/3572
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1) {
+                return false
+            }
+
+            return FlipperUtils.shouldEnableFlipper(context)
+        }
+
+    fun init() {
+        if (!isEnabled) return
+
+        SoLoader.init(context, false)
+
+        val client = AndroidFlipperClient.getInstance(context)
+        client.addPlugin(CrashReporterPlugin.getInstance())
+        client.addPlugin(SharedPreferencesFlipperPlugin(context))
+        client.addPlugin(InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()))
+        client.start()
+    }
+}

--- a/app/src/main/java/io/element/android/x/initializer/FlipperInitializer.kt
+++ b/app/src/main/java/io/element/android/x/initializer/FlipperInitializer.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.x.initializer
+
+import android.content.Context
+import androidx.startup.Initializer
+import io.element.android.x.flipper.VectorFlipperProxy
+
+class FlipperInitializer : Initializer<Unit> {
+
+    override fun create(context: Context) {
+        VectorFlipperProxy(context).init()
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}

--- a/app/src/main/kotlin/io/element/android/x/ElementXApplication.kt
+++ b/app/src/main/kotlin/io/element/android/x/ElementXApplication.kt
@@ -22,6 +22,7 @@ import io.element.android.x.core.di.DaggerComponentOwner
 import io.element.android.x.di.AppComponent
 import io.element.android.x.di.DaggerAppComponent
 import io.element.android.x.initializer.CrashInitializer
+import io.element.android.x.initializer.FlipperInitializer
 import io.element.android.x.initializer.MatrixInitializer
 import io.element.android.x.initializer.TimberInitializer
 
@@ -36,6 +37,7 @@ class ElementXApplication : Application(), DaggerComponentOwner {
         super.onCreate()
         appComponent = DaggerAppComponent.factory().create(applicationContext)
         AppInitializer.getInstance(this).apply {
+            initializeComponent(FlipperInitializer::class.java)
             initializeComponent(CrashInitializer::class.java)
             initializeComponent(TimberInitializer::class.java)
             initializeComponent(MatrixInitializer::class.java)

--- a/app/src/nightly/java/io/element/android/x/flipper/VectorFlipperProxy.kt
+++ b/app/src/nightly/java/io/element/android/x/flipper/VectorFlipperProxy.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.x.flipper
+
+import android.content.Context
+
+/**
+ * No op version for nightly application.
+ */
+class VectorFlipperProxy(
+    @Suppress("UNUSED_PARAMETER") context: Context
+) {
+    fun init() = Unit
+}

--- a/app/src/release/java/io/element/android/x/flipper/VectorFlipperProxy.kt
+++ b/app/src/release/java/io/element/android/x/flipper/VectorFlipperProxy.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.x.flipper
+
+import android.content.Context
+
+/**
+ * No op version for release application.
+ */
+class VectorFlipperProxy(
+    @Suppress("UNUSED_PARAMETER") context: Context
+) {
+    fun init() = Unit
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ appyx = "1.0.1"
 seismic = "1.0.3"
 dependencycheck = "7.4.4"
 stem = "2.2.3"
+flipper = "0.177.0"
 
 # DI
 dagger = "2.43"
@@ -124,7 +125,8 @@ compose_destinations_processor = { module = "io.github.raamcosta.compose-destina
 showkase = { module = "com.airbnb.android:showkase", version.ref = "showkase" }
 showkase_processor = { module = "com.airbnb.android:showkase-processor", version.ref = "showkase" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
-appyx_core = {module = "com.bumble.appyx:core", version.ref = "appyx"}
+appyx_core = { module = "com.bumble.appyx:core", version.ref = "appyx" }
+debug_flipper = { module = "com.facebook.flipper:flipper", version.ref = "flipper" }
 
 # Di
 inject = { module = "javax.inject:javax.inject", version = "1" }
@@ -148,7 +150,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 anvil = { id = "com.squareup.anvil", version.ref = "anvil" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-molecule = {id = "app.cash.molecule", version.ref = "molecule"}
+molecule = { id = "app.cash.molecule", version.ref = "molecule" }
 dependencygraph = { id = "com.savvasdalkitsis.module-dependency-graph", version.ref = "dependencygraph" }
 dependencycheck = { id = "org.owasp.dependencycheck", version.ref = "dependencycheck" }
 stem = { id = "com.likethesalad.stem", version.ref = "stem" }


### PR DESCRIPTION
Closes #40


This is quite limited, since network on DB are handle by the Rust SDK, so this cannot really be plugged to Flipper. Also there is no Plugin to investigate Jetpack Compose structure (and this will not be supported by the core team, see https://github.com/facebook/flipper/issues/2366).

Can still be useful to take screen shot or video, watch logs, inspect shared preferences and investigate crashes.

This PR set up the tool, so later we may add more plugins.