### PR TITLE
Kotlin 1.8 + cleanup

### DIFF
--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -1,4 +1,4 @@
-name: Meastro
+name: Maestro
 
 on:
   pull_request: { }
@@ -12,7 +12,7 @@ env:
 
 jobs:
   maestro-cloud:
-    name: Meastro test suite
+    name: Maestro test suite
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     strategy:

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -43,7 +43,7 @@ Start the ElementX app and run this command to help writing test.
 maestro studio
 ```
 
-Note that sometimes, this prevent running the test. So kill the `meastro studio` process to be able to run the test again.
+Note that sometimes, this prevent running the test. So kill the `maestro studio` process to be able to run the test again.
 
 Also, if updating the application code, do not forget to deploy again the application before running the maestro tests.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,7 +117,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.2"
+        kotlinCompilerExtensionVersion = "1.4.0"
     }
     packagingOptions {
         resources {
@@ -174,8 +174,6 @@ dependencies {
 
     // https://developer.android.com/studio/write/java8-support#library-desugaring-versions
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.2")
-    implementation(libs.compose.destinations)
-    ksp(libs.compose.destinations.processor)
     implementation(libs.appyx.core)
 
     implementation(libs.androidx.corektx)

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,3 +41,7 @@ android.nonTransitiveRClass=true
 signing.element.nightly.storePassword=Secret
 signing.element.nightly.keyId=Secret
 signing.element.nightly.keyPassword=Secret
+
+# Customise the Lint version to use a more recent version than the one bundled with AGP
+# https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
+android.experimental.lint.version=8.0.0-alpha10

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@
 # Project
 android_gradle_plugin = "7.3.1"
 firebase_gradle_plugin = "3.0.2"
-kotlin = "1.7.20"
-ksp = "1.7.20-1.0.7"
-molecule = "0.6.1"
+kotlin = "1.8.0"
+ksp = "1.8.0-1.0.8"
+molecule = "0.7.0"
 
 # AndroidX
 material = "1.6.1"
@@ -20,8 +20,7 @@ activity_compose = "1.6.1"
 startup = "1.1.1"
 
 # Compose
-compose_compiler = "1.3.2"
-compose_bom = "2022.11.00"
+compose_bom = "2023.01.00"
 
 # Coroutines
 coroutines = "1.6.4"
@@ -41,12 +40,11 @@ test_hamcrest = "2.2"
 test_orchestrator = "1.4.1"
 
 #other
-coil = "2.2.1"
+coil = "2.2.2"
 datetime = "0.4.0"
 wysiwyg = "0.7.0.1"
 serialization_json = "1.4.1"
 showkase = "1.0.0-beta14"
-compose_destinations = "1.7.23-beta"
 jsoup = "1.15.3"
 appyx = "1.0.1"
 seismic = "1.0.3"
@@ -54,8 +52,8 @@ dependencycheck = "7.4.4"
 stem = "2.2.3"
 
 # DI
-dagger = "2.43"
-anvil = "2.4.2"
+dagger = "2.44.2"
+anvil = "2.4.4"
 
 # quality
 detekt = "1.22.0"
@@ -83,7 +81,6 @@ androidx_activity_compose = { module = "androidx.activity:activity-compose", ver
 androidx_startup = { module = "androidx.startup:startup-runtime", version.ref = "startup" }
 
 androidx_compose_bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose_bom" }
-androidx_compose_foundation = { group = "androidx.compose.foundation", name = "foundation" }
 
 # Coroutines
 coroutines_core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -119,8 +116,6 @@ coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil_compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
 serialization_json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization_json" }
-compose_destinations = { module = "io.github.raamcosta.compose-destinations:animations-core", version.ref = "compose_destinations" }
-compose_destinations_processor = { module = "io.github.raamcosta.compose-destinations:ksp", version.ref = "compose_destinations" }
 showkase = { module = "com.airbnb.android:showkase", version.ref = "showkase" }
 showkase_processor = { module = "com.airbnb.android:showkase-processor", version.ref = "showkase" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }

--- a/libraries/architecture/build.gradle.kts
+++ b/libraries/architecture/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 android {
-    namespace = "io.element.android.x.libraries.presentation"
+    namespace = "io.element.android.x.architecture"
 }
 
 dependencies {

--- a/libraries/matrix/build.gradle.kts
+++ b/libraries/matrix/build.gradle.kts
@@ -19,7 +19,7 @@
 plugins {
     id("io.element.android-library")
     alias(libs.plugins.anvil)
-    kotlin("plugin.serialization") version "1.7.20"
+    kotlin("plugin.serialization") version "1.8.0"
 }
 
 android {

--- a/plugins/src/main/kotlin/Versions.kt
+++ b/plugins/src/main/kotlin/Versions.kt
@@ -15,11 +15,7 @@
  */
 
 import org.gradle.api.JavaVersion
-import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.jvm.toolchain.JavaLanguageVersion
-
-val VersionCatalog.composeVersion: String
-    get() = findVersion("compose_compiler").get().requiredVersion
 
 object Versions {
     const val versionCode = 100100

--- a/plugins/src/main/kotlin/extension/CommonExtension.kt
+++ b/plugins/src/main/kotlin/extension/CommonExtension.kt
@@ -49,7 +49,7 @@ fun CommonExtension<*, *, *, *>.composeConfig() {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.2"
+        kotlinCompilerExtensionVersion = "1.4.0"
     }
 
     packagingOptions {

--- a/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
+++ b/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
@@ -32,7 +32,7 @@ fun DependencyHandlerScope.commonDependencies() {
  * Dependencies used by all the modules with composable items
  */
 fun DependencyHandlerScope.composeDependencies() {
-    val composeBom = platform("androidx.compose:compose-bom:2022.11.00")
+    val composeBom = platform("androidx.compose:compose-bom:2023.01.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
     implementation("androidx.compose.ui:ui")
@@ -42,7 +42,6 @@ fun DependencyHandlerScope.composeDependencies() {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
     implementation("androidx.activity:activity-compose:1.6.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
     implementation("com.airbnb.android:showkase:1.0.0-beta14")


### PR DESCRIPTION
Dependabot is not able to upgrade several dep at a time, so this has to be done manually.

+ some cleanup.