### PR TITLE
On nightly build (or manual build), additionally upload a copy to browserstack for automation.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,3 +32,9 @@ jobs:
           ELEMENT_ANDROID_NIGHTLY_KEYPASSWORD: ${{ secrets.ELEMENT_ANDROID_NIGHTLY_KEYPASSWORD }}
           ELEMENT_ANDROID_NIGHTLY_STOREPASSWORD: ${{ secrets.ELEMENT_ANDROID_NIGHTLY_STOREPASSWORD }}
           FIREBASE_TOKEN: ${{ secrets.ELEMENT_ANDROID_NIGHTLY_FIREBASE_TOKEN }}
+      - name: Additionally upload Nightly APK to browserstack for testing
+        continue-on-error: true # don't block anything by this upload failing (for now)
+        run: curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_PASSWORD" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@app/build/outputs/apk/nightly/app-nightly.apk" -F "custom_id=eax-nightly"
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.ELEMENT_ANDROID_BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_PASSWORD: ${{ secrets.ELEMENT_ANDROID_BROWSERSTACK_ACCESS_KEY }}

--- a/.github/workflows/nightly_manual.yml
+++ b/.github/workflows/nightly_manual.yml
@@ -21,3 +21,10 @@ jobs:
           ELEMENT_ANDROID_NIGHTLY_KEYPASSWORD: ${{ secrets.ELEMENT_ANDROID_NIGHTLY_KEYPASSWORD }}
           ELEMENT_ANDROID_NIGHTLY_STOREPASSWORD: ${{ secrets.ELEMENT_ANDROID_NIGHTLY_STOREPASSWORD }}
           FIREBASE_TOKEN: ${{ secrets.ELEMENT_ANDROID_NIGHTLY_FIREBASE_TOKEN }}
+      - name: Additionally upload Nightly APK to browserstack for testing
+        continue-on-error: true # don't block anything by this upload failing (for now)
+        run: curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_PASSWORD" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@app/build/outputs/apk/nightly/app-nightly.apk" -F "custom_id=eax-nightly"
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.ELEMENT_ANDROID_BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_PASSWORD: ${{ secrets.ELEMENT_ANDROID_BROWSERSTACK_ACCESS_KEY }}
+


### PR DESCRIPTION
To get some of the trafficlight tests working naturally it would be good for the nightly build of element android X to end up within browserstack so automation tools can consume it.

I tried to see if there was a way to upload "sideways" from the firebase nightly build into browserstack, but it doesn't seem possible at present.

https://www.browserstack.com/docs/app-automate/appium/upload-app-define-custom-id explains how to upload the APK with a custom ID (in this case eax-nightly) so we can refer to the ID as it changes, rather than the per-upload unique identifier.

This will need two secrets adding to the github config: ELEMENT_ANDROID_BROWSERSTACK_USERNAME and ELEMENT_ANDROID_BROWSERSTACK_ACCESS_KEY - I can provide these.

The uploaded APK will only be available internally and is meant for deployment onto virtual or physical devices by browserstack's software, so we can automate device testing outside of a local emulator (no more worrying about setting up virtualization on github actions!)

This should also be nice and fast; I was able to upload to browserstack locally in a few seconds locally with a debug build, like so:

`curl -v -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_PASSWORD" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@app/build/outputs/apk/debug/app-debug.apk" -F "custom_id=eax-nightly"`

One thing I haven't been able to check is whether the nightly APK will end up in that same place in the filesystem - i believe I've followed the pattern correctly, but I'm not 100% sure.