### PR TITLE
Configure Diawi and split APK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,5 +37,5 @@ jobs:
             app/build/outputs/apk/debug/app-debug.apk
       - name: Compile release sources
         run: ./gradlew compileReleaseSources $CI_GRADLE_ARG_PROPERTIES
-      - name: Compile nighlty sources
+      - name: Compile nightly sources
         run: ./gradlew compileNightlySources $CI_GRADLE_ARG_PROPERTIES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,22 @@ jobs:
           name: elementx-debug
           path: |
             app/build/outputs/apk/debug/app-debug.apk
+      - uses: rnkdsh/action-upload-diawi@v1.3.1
+        id: diawi
+        with:
+          token: ${{ secrets.DIAWI_TOKEN }}
+          file: app/build/outputs/apk/debug/app-arm64-v8a-debug.apk
+      - name: Add or update PR comment with QR Code to download APK.
+        uses: NejcZdovc/comment-pr@v1
+        with:
+          message: |
+            :iphone: Scan the QR code below to install the build (arm64 only) for this PR.
+            ![QR code](${{ steps.diawi.outputs['qrcode'] }})
+            If you can't scan the QR code you can install the build via this link: ${{ steps.diawi.outputs['url'] }}
+          # Enables to identify and update existing Ad-hoc release message on new commit in the PR
+          identifier: "GITHUB_COMMENT_QR_CODE"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile release sources
         run: ./gradlew compileReleaseSources $CI_GRADLE_ARG_PROPERTIES
       - name: Compile nightly sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Ensure we are building the branch and not the branch after being merged on develop
+          # https://github.com/actions/checkout/issues/881
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
       - name: Assemble debug APK
         run: ./gradlew assembleDebug $CI_GRADLE_ARG_PROPERTIES
       - name: Upload debug APKs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           name: elementx-debug
           path: |
-            app/build/outputs/apk/debug/app-debug.apk
+            app/build/outputs/apk/debug/*.apk
       - uses: rnkdsh/action-upload-diawi@v1.3.1
         id: diawi
         with:

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: mobile-dev-inc/action-maestro-cloud@v1.3.1
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
-          app-file: app/build/outputs/apk/debug/app-debug.apk
+          app-file: app/build/outputs/apk/debug/app-universal-debug.apk
           env: |
             USERNAME=maestroelement
             PASSWORD=${{ secrets.MATRIX_MAESTRO_ACCOUNT_PASSWORD }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+@file:Suppress("UnstableApiUsage")
+
+import com.android.build.api.variant.FilterConfiguration.FilterType.ABI
 import extension.allFeatures
 import extension.allLibraries
 
@@ -44,6 +47,28 @@ android {
 
         vectorDrawables {
             useSupportLibrary = true
+        }
+
+        // Keep abiFilter for the universalApk
+        ndk {
+            abiFilters += listOf("armeabi-v7a", "x86", "arm64-v8a", "x86_64")
+        }
+
+        // Ref: https://developer.android.com/studio/build/configure-apk-splits.html#configure-abi-split
+        splits {
+            // Configures multiple APKs based on ABI.
+            abi {
+                // Enables building multiple APKs per ABI.
+                isEnable = true
+                // By default all ABIs are included, so use reset() and include to specify that we only
+                // want APKs for armeabi-v7a, x86, arm64-v8a and x86_64.
+                // Resets the list of ABIs that Gradle should create APKs for to none.
+                reset()
+                // Specifies a list of ABIs that Gradle should create APKs for.
+                include("armeabi-v7a", "x86", "arm64-v8a", "x86_64")
+                // Generate a universal APK that includes all ABIs, so user who installs from CI tool can use this one by default.
+                isUniversalApk = true
+            }
         }
     }
 
@@ -134,6 +159,32 @@ android {
             getByName(name) {
                 kotlin.srcDir("build/generated/ksp/$name/kotlin")
             }
+        }
+    }
+}
+
+androidComponents {
+    // map for the version codes last digit
+    // x86 must have greater values than arm
+    // 64 bits have greater value than 32 bits
+    val abiVersionCodes = mapOf(
+        "armeabi-v7a" to 1,
+        "arm64-v8a" to 2,
+        "x86" to 3,
+        "x86_64" to 4,
+    )
+
+    onVariants { variant ->
+        // Assigns a different version code for each output APK
+        // other than the universal APK.
+        variant.outputs.forEach { output ->
+            val name = output.filters.find { it.filterType == ABI }?.identifier
+
+            // Stores the value of abiCodes that is associated with the ABI for this variant.
+            val abiCode = abiVersionCodes[name] ?: 0
+            // Assigns the new version code to output.versionCode, which changes the version code
+            // for only the output APK, not for the variant itself.
+            output.versionCode.set((output.versionCode.get() ?: 0) * 10 + abiCode)
         }
     }
 }


### PR DESCRIPTION
This PR:
- configure Diawi so that arm64 APK are uploaded there and a comment is added to the PR with a handy QR code to download the app
- split the output into 4 APK, one per arch. Mainly because APK must be < 75MB to be uploaded to Diawi using a free plan, but we would need to do that at some point anyway.

APK versionCodes are as expected, see below:

```shell
> $ANDROID_HOME/build-tools/30.0.2/aapt dump badging ./app/build/outputs/apk/debug/app-arm64-v8a-debug.apk |grep package 
package: name='io.element.android.x.debug' versionCode='12' versionName='1.0' compileSdkVersion='33' compileSdkVersionCodename='13'
> $ANDROID_HOME/build-tools/30.0.2/aapt dump badging ./app/build/outputs/apk/debug/app-armeabi-v7a-debug.apk |grep package 
package: name='io.element.android.x.debug' versionCode='11' versionName='1.0' compileSdkVersion='33' compileSdkVersionCodename='13'
> $ANDROID_HOME/build-tools/30.0.2/aapt dump badging ./app/build/outputs/apk/debug/app-x86-debug.apk |grep package  
package: name='io.element.android.x.debug' versionCode='13' versionName='1.0' compileSdkVersion='33' compileSdkVersionCodename='13'
> $ANDROID_HOME/build-tools/30.0.2/aapt dump badging ./app/build/outputs/apk/debug/app-x86_64-debug.apk |grep package 
package: name='io.element.android.x.debug' versionCode='14' versionName='1.0' compileSdkVersion='33' compileSdkVersionCodename='13'
> $ANDROID_HOME/build-tools/30.0.2/aapt dump badging ./app/build/outputs/apk/debug/app-universal-debug.apk |grep package  
package: name='io.element.android.x.debug' versionCode='10' versionName='1.0' compileSdkVersion='33' compileSdkVersionCodename='13'
```
