### PR TITLE
Remove roadmap section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ ElementX leverages the [Matrix Rust SDK](https://github.com/matrix-org/matrix-ru
 
 We're doing this as a way to share code between platforms and while we've seen promising results it's still in the experimental stage and bound to change.
 
-## Roadmap
-
-We are aiming to have a fast and fully functional personal messaging application by the end of year 2023.
-
 ## Contributing
 
 Please see our [contribution guide](CONTRIBUTING.md).


### PR DESCRIPTION
We don't currently have a public roadmap and the current wording might set the wrong expectations. The EX iOS repository doesn't have this section either. So I think it'll be good to remove it for now.

CC @ara4n 