### PR TITLE
Prevent R8/ProGuard from optimising sqlcipher

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -9,6 +9,10 @@
 -keep class com.sun.jna.** { *; }
 -keep class * implements com.sun.jna.** { *; }
 
+# Prevent the sqlcipher library from being obfuscated/optimised when building in
+# release mode, as it causes the library to raise exceptions.
+-keep class net.sqlcipher.** { *; }
+
 # kotlinx.serialization
 
 # Kotlin serialization looks up the generated serializer classes through a function on companion

--- a/changelog.d/130.bugfix
+++ b/changelog.d/130.bugfix
@@ -1,0 +1,1 @@
+Prevent a crash on startup related to sqlcipher when the app was built in release mode.


### PR DESCRIPTION
This fixes a crash on startup when running the app in release mode. R8 only runs when building the app in the release variant.

The crash would generate the following stacktrace:

<details>

<summary>Click to view logs</summary>

```
2023-03-03 12:13:07.461 27036-27036 io.element.android.x    io.element.android.x                 A  thread.cc:2468] No pending exception expected: java.lang.NoSuchFieldError: no "J" field "mNativeHandle" in class "Lnet/sqlcipher/database/SQLiteDatabase;" or its superclasses
                                                                                                    thread.cc:2468]   at java.lang.String java.lang.Runtime.nativeLoad(java.lang.String, java.lang.ClassLoader, java.lang.Class) (Runtime.java:-2)
                                                                                                    thread.cc:2468]   at java.lang.String java.lang.Runtime.nativeLoad(java.lang.String, java.lang.ClassLoader) (Runtime.java:1121)
                                                                                                    thread.cc:2468]   at void java.lang.Runtime.loadLibrary0(java.lang.ClassLoader, java.lang.Class, java.lang.String) (Runtime.java:1075)
                                                                                                    thread.cc:2468]   at void java.lang.Runtime.loadLibrary0(java.lang.Class, java.lang.String) (Runtime.java:998)
                                                                                                    thread.cc:2468]   at void java.lang.System.loadLibrary(java.lang.String) (System.java:1661)
                                                                                                    thread.cc:2468]   at void net.sqlcipher.database.SupportHelper.<init>(androidx.sqlite.db.SupportSQLiteOpenHelper$Configuration, byte[], net.sqlcipher.database.SQLiteDatabaseHook, boolean) (SupportHelper.java:29)
                                                                                                    thread.cc:2468]   at java.lang.Object io.element.android.libraries.sessionstorage.di.SessionStorageModule_ProvideMatrixDatabaseFactory.get() (SessionStorageModule_ProvideMatrixDatabaseFactory.kt:58)
                                                                                                    thread.cc:2468]   at java.lang.Object dagger.internal.DoubleCheck.get() (DoubleCheck.java:14)
                                                                                                    thread.cc:2468]   at java.lang.Object io.element.android.libraries.sessionstorage.DatabaseSessionStore_Factory.get() (DatabaseSessionStore_Factory.kt:3)
                                                                                                    thread.cc:2468]   at java.lang.Object dagger.internal.DoubleCheck.get() (DoubleCheck.java:14)
                                                                                                    thread.cc:2468]   at java.lang.Object io.element.android.libraries.matrix.impl.auth.RustMatrixAuthenticationService_Factory.get() (RustMatrixAuthenticationService_Factory.kt:45)
                                                                                                    thread.cc:2468]   at java.lang.Object io.element.android.x.di.MatrixClientsHolder_Factory.get() (MatrixClientsHolder_Factory.java:3)
                                                                                                    thread.cc:2468]   at java.lang.Object dagger.internal.DoubleCheck.get() (DoubleCheck.java:14)
                                                                                                    thread.cc:2468]   at io.element.android.x.di.MatrixClientsHolder io.element.android.x.di.DaggerAppComponent$AppComponentImpl.matrixClientsHolder() (DaggerAppComponent.java:3)
                                                                                                    thread.cc:2468]   at void io.element.android.x.MainActivity.onCreate(android.os.Bundle) (MainActivity.kt:30)
                                                                                                    thread.cc:2468]   at void android.app.Activity.performCreate(android.os.Bundle, android.os.PersistableBundle) (Activity.java:8352)
                                                                                                    thread.cc:2468]   at void android.app.Activity.performCreate(android.os.Bundle) (Activity.java:8331)
                                                                                                    thread.cc:2468]   at void android.app.Instrumentation.callActivityOnCreate(android.app.Activity, android.os.Bundle) (Instrumentation.java:1422)
                                                                                                    thread.cc:2468]   at android.app.Activity android.app.ActivityThread.performLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.content.Intent) (ActivityThread.java:3627)
                                                                                                    thread.cc:2468]   at android.app.Activity android.app.ActivityThread.handleLaunchActivity(android.app.ActivityThread$ActivityClientRecord, android.app.servertransaction.PendingTransactionActions, android.content.Intent) (ActivityThread.java:3783)
                                                                                                    thread.cc:2468]   at void android.app.servertransaction.LaunchActivityItem.execute(android.app.ClientTransactionHandler, android.os.IBinder, android.app.servertransaction.PendingTransactionActions) (LaunchActivityItem.java:101)
                                                                                                    thread.cc:2468]   at void android.app.servertransaction.TransactionExecutor.executeCallbacks(android.app.servertransaction.ClientTransaction) (TransactionExecutor.java:135)
                                                                                                    thread.cc:2468]   at void android.app.servertransaction.TransactionExecutor.execute(android.app.servertransaction.ClientTransaction) (TransactionExecutor.java:95)
                                                                                                    thread.cc:2468]   at void android.app.ActivityThread$H.handleMessage(android.os.Message) (ActivityThread.java:2308)
                                                                                                    thread.cc:2468]   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:106)
                                                                                                    thread.cc:2468]   at boolean android.os.Looper.loopOnce(android.os.Looper, long, int) (Looper.java:201)
                                                                                                    thread.cc:2468]   at void android.os.Looper.loop() (Looper.java:288)
2023-03-03 12:13:07.461 27036-27036 io.element.android.x    io.element.android.x                 A  thread.cc:2468]   at void android.app.ActivityThread.main(java.lang.String[]) (ActivityThread.java:7879)
                                                                                                    thread.cc:2468]   at java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[]) (Method.java:-2)
                                                                                                    thread.cc:2468]   at void com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run() (RuntimeInit.java:548)
                                                                                                    thread.cc:2468]   at void com.android.internal.os.ExecInit.main(java.lang.String[]) (ExecInit.java:49)
                                                                                                    thread.cc:2468]   at void com.android.internal.os.RuntimeInit.nativeFinishInit() (RuntimeInit.java:-2)
                                                                                                    thread.cc:2468]   at void com.android.internal.os.RuntimeInit.main(java.lang.String[]) (RuntimeInit.java:355)
                                                                                                    thread.cc:2468] 
2023-03-03 12:13:07.637 27036-27036 io.element.android.x    io.element.android.x                 A  runtime.cc:675] Runtime aborting...
```

</details>