### PR TITLE
Clear focus when submitting forms to prevent issues with the IME keyboard

### DIFF
--- a/changelog.d/133.bugfix
+++ b/changelog.d/133.bugfix
@@ -1,0 +1,1 @@
+Clear focus on TextFields when submitting forms to prevent issues with the IME keyboard.

--- a/features/login/src/main/kotlin/io/element/android/features/login/changeserver/ChangeServerView.kt
+++ b/features/login/src/main/kotlin/io/element/android/features/login/changeserver/ChangeServerView.kt
@@ -91,6 +91,14 @@ fun ChangeServerView(
         }
     }
     val focusManager = LocalFocusManager.current
+
+    fun submit() {
+        // Clear focus to prevent keyboard issues with textfields
+        focusManager.clearFocus(force = true)
+
+        eventSink(ChangeServerEvents.Submit)
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -174,7 +182,7 @@ fun ChangeServerView(
                         imeAction = ImeAction.Done,
                     ),
                     keyboardActions = KeyboardActions(
-                        onDone = { eventSink(ChangeServerEvents.Submit) }
+                        onDone = { submit() }
                     ),
                     singleLine = true,
                     maxLines = 1,
@@ -215,7 +223,7 @@ fun ChangeServerView(
                 )
                 Spacer(Modifier.height(32.dp))
                 Button(
-                    onClick = { eventSink(ChangeServerEvents.Submit) },
+                    onClick = ::submit,
                     enabled = interactionEnabled && state.submitEnabled,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/features/login/src/main/kotlin/io/element/android/features/login/root/LoginRootScreen.kt
+++ b/features/login/src/main/kotlin/io/element/android/features/login/root/LoginRootScreen.kt
@@ -216,6 +216,14 @@ internal fun LoginForm(
 
     val focusManager = LocalFocusManager.current
     val eventSink = state.eventSink
+
+    fun submit() {
+        // Clear focus to prevent keyboard issues with textfields
+        focusManager.clearFocus(force = true)
+
+        eventSink(LoginRootEvents.Submit)
+    }
+
     Column(modifier) {
         Text(
             text = stringResource(StringR.string.login_form_title),
@@ -294,7 +302,7 @@ internal fun LoginForm(
                 imeAction = ImeAction.Done,
             ),
             keyboardActions = KeyboardActions(
-                onDone = { eventSink(LoginRootEvents.Submit) }
+                onDone = { submit() }
             ),
             singleLine = true,
             maxLines = 1,
@@ -309,7 +317,7 @@ internal fun LoginForm(
 
         // Submit
         Button(
-            onClick = { eventSink(LoginRootEvents.Submit) },
+            onClick = ::submit,
             enabled = interactionEnabled && state.submitEnabled,
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
Fixes #133 by clearing focus when the login and change server forms are submitted. 

The problem was the AlertDialog was somehow breaking the focus state of the last selected TextField.