### PR TITLE
Attempt to check org/group membership before danger complains about signoff.

### DIFF
--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -88,7 +88,25 @@ const allowList = [
     "yostyle",
 ]
 
-const requiresSignOff = !allowList.includes(user)
+// We ignore signoff requirements for employees of Element
+// as copyright assignment is covered by our employee contracts.
+
+var memberOfElement
+
+try {
+   github.api.rest.orgs.checkPublicMembership({
+      org: "vector-im",
+      username: user
+   })
+   memberOfElement = true
+} catch (err) {
+   // Raises an error if 404 is returned = not member
+   memberOfElement = false
+}
+
+
+
+const requiresSignOff = !allowList.includes(user) || !memberOfElement
 
 if (requiresSignOff) {
     const hasPRBodySignOff = pr.body.includes(signOff)

--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -105,19 +105,24 @@ function signoff_unneeded(reason) {
 if (allowList.includes(user)) {
     signoff_unneeded("allow-list")
 } else {
-    github.api.rest.orgs.checkMembershipForUser({
+//  github.api.rest.orgs.checkMembershipForUser({
+//      org: "vector-im",
+//      username: user,
+//   }).then((result) => {
+    github.api.rest.teams.getMembershipForUserInOrg({
         org: "vector-im",
+        team_slug: "vector-core",
         username: user,
     }).then((result) => {
-        if (result.status == 204) {
-            signoff_unneeded("org-member")
+        if (result.status == 204 || result.status == 200) {
+            signoff_unneeded("team-member")
         }
         else {
-            signoff_needed("not-org-member")
+            signoff_needed("not-team-member")
         }
     }).catch((error) => { 
         if (error.response.status == 404) {
-            signoff_needed("not-org-member");
+            signoff_needed("not-team-member");
         } else {
             console.log(error); signoff_needed("error") 
         }


### PR DESCRIPTION
Rather than maintaining an allow-list of users who have the ability to skip the signoff for other reasons (eg, contract with the company), we can check for membership of the internal group that matches.

This should allow us to reduce the size of the allow-list to just those unexpected cases, eg bots.