### PR TITLE
Fix the case when a valid homeserver url can't be extracted from the MXID

### DIFF
--- a/changelog.d/182.bugfix
+++ b/changelog.d/182.bugfix
@@ -1,0 +1,1 @@
+Fix the case when a valid homeserver url can't be extracted from the MXID

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -38,6 +38,7 @@ import org.matrix.rustcomponents.sdk.AuthenticationService
 import org.matrix.rustcomponents.sdk.Client
 import org.matrix.rustcomponents.sdk.ClientBuilder
 import org.matrix.rustcomponents.sdk.Session
+import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
@@ -63,23 +64,21 @@ class RustMatrixAuthenticationService @Inject constructor(
     }
 
     override suspend fun restoreSession(sessionId: SessionId) = withContext(coroutineDispatchers.io) {
-        sessionStore.getSession(sessionId.value)
-            ?.let { sessionData ->
-                try {
-                    ClientBuilder()
-                        .basePath(baseDirectory.absolutePath)
-                        .homeserverUrl(sessionData.homeserverUrl)
-                        .username(sessionData.userId)
-                        .build().apply {
-                            restoreSession(sessionData.toSession())
-                        }
-                } catch (throwable: Throwable) {
-                    logError(throwable)
-                    null
-                }
-            }?.let {
-                createMatrixClient(it)
+        val sessionData = sessionStore.getSession(sessionId.value)
+        if (sessionData != null) {
+            try {
+                val client = ClientBuilder()
+                    .basePath(baseDirectory.absolutePath)
+                    .homeserverUrl(sessionData.homeserverUrl)
+                    .username(sessionData.userId)
+                    .use { it.build() }
+                client.restoreSession(sessionData.toSession())
+                createMatrixClient(client)
+            } catch (throwable: Throwable) {
+                logError(throwable)
+                null
             }
+        } else null
     }
 
     override fun getHomeserverDetails(): StateFlow<MatrixHomeServerDetails?> = currentHomeserver
@@ -102,9 +101,9 @@ class RustMatrixAuthenticationService @Inject constructor(
                 Timber.e(failure, "Fail login")
                 throw failure
             }
-            val session = client.session()
-            sessionStore.storeData(session.toSessionData())
-            SessionId(session.userId)
+            val sessionData = client.use { it.session().toSessionData() }
+            sessionStore.storeData(sessionData)
+            SessionId(sessionData.userId)
         }
 
     private fun createMatrixClient(client: Client): MatrixClient {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -68,6 +68,7 @@ class RustMatrixAuthenticationService @Inject constructor(
                 try {
                     ClientBuilder()
                         .basePath(baseDirectory.absolutePath)
+                        .homeserverUrl(sessionData.homeserverUrl)
                         .username(sessionData.userId)
                         .build().apply {
                             restoreSession(sessionData.toSession())


### PR DESCRIPTION
## Changes

We now provide the actual homeserver url to the Rust SDK's  `ClientBuilder`.

## Steps to test:

1. Set the home server to `https://large-account.lab.element.dev`.
2. Log in with the test account credentials (ping me if you don't know them).

If you get past the log in screen (although the room list would take ages to load) it's working.