### PR TITLE
Deactivate dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
     reviewers:
       - "vector-im/element-x-android-reviewers"
   # Updates for Gradle dependencies used in the app
@@ -18,5 +20,7 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 200
+    ignore:
+      - dependency-name: "*"
     reviewers:
       - "vector-im/element-x-android-reviewers"

--- a/docs/_developer_onboarding.md
+++ b/docs/_developer_onboarding.md
@@ -260,8 +260,7 @@ We are using [Gradle version catalog](https://docs.gradle.org/current/userguide/
 All the dependencies (including android artifact, gradle plugin, etc.) should be declared in [../gradle/libs.versions.toml](libs.versions.toml) file.
 Some dependency, mainly because they are not shared can be declared in `build.gradle.kts` files.
 
-[Dependabot](https://github.com/dependabot) is set up on the project. This tool will automatically create Pull Request to upgrade our dependencies one by one.
-**Note** Dependabot does not support yet Gradle version catalog. This is tracked by [this issue](https://github.com/dependabot/dependabot-core/issues/3121).
+[Renovate](https://github.com/apps/renovate) is set up on the project. This tool will automatically create Pull Request to upgrade our dependencies one by one. A [dependency dashboard issue](https://github.com/vector-im/element-x-android/issues/150) is maintained by the tool and allow to perform some actions.
 
 ### Test
 

--- a/docs/pull_request.md
+++ b/docs/pull_request.md
@@ -15,7 +15,7 @@
       * [When create split PR?](#when-create-split-pr?)
       * [Avoid fixing other unrelated issue in a big PR](#avoid-fixing-other-unrelated-issue-in-a-big-pr)
     * [Bots](#bots)
-      * [Dependabot](#dependabot)
+      * [Renovate](#renovate)
       * [Gradle wrapper](#gradle-wrapper)
       * [Sync analytics plan](#sync-analytics-plan)
 * [Reviewing PR](#reviewing-pr)
@@ -135,9 +135,9 @@ It's also applicable for code rework (such as renaming for instance), or code fo
 
 Some bots can create PR, but they still have to be reviewed by the team
 
-##### Dependabot
+##### Renovate
 
-Dependabot is a tool which maintain all our external dependencies up to date. A dedicated PR is created for each new available release for one of our external dependency.Dependabot
+Renovate is a tool which maintain all our external dependencies up to date. A dedicated PR is created for each new available release for one of our external dependencies.
 
 To review such PR, you have to
  - **IMPORTANT** check the diff files (as always).
@@ -146,7 +146,7 @@ To review such PR, you have to
  - If the code does not compile (API break for instance), you have to checkout the branch and push new commits
  - Do some smoke test, depending of the library which has been upgraded
 
-For some reason dependabot sometimes does not upgrade some dependencies. In this case, and when detected, the upgrade has to be done manually.
+For some reasons (like for instance a change in package declaration) the tool sometimes does not upgrade some dependencies. In this case, and when detected, the upgrade has to be done manually.
 
 ##### Gradle wrapper
 


### PR DESCRIPTION
We are now relying on Renovate. But Dependabot is tied to the project, and I do not want to fully switch the alerts off:

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/3940906/224680017-94d963c5-e175-4bbc-844e-a9b4770ba4b7.png">

So just tweak the configuration file and hopefully it will be enough (we will now once the PR is merged)

Also try to skip the CI on this PR:

[ci skip]

^ does not seem to work (even if I have seen that in other PR on other project and would be very handy), it has to be in the commit message. https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs