### PR TITLE
Fix behaviour of Enter and Tab hardware keys in TextFields

### DIFF
--- a/changelog.d/216.bugfix
+++ b/changelog.d/216.bugfix
@@ -1,0 +1,1 @@
+Make sure `Modifier.onTabOrEnterKeyFocusNext` doesn't add line breaks or tabs to TextFields.

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/root/LoginRootView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/root/LoginRootView.kt
@@ -244,8 +244,8 @@ internal fun LoginForm(
             readOnly = !interactionEnabled,
             modifier = Modifier
                 .fillMaxWidth()
-                .testTag(TestTags.loginEmailUsername)
-                .onTabOrEnterKeyFocusNext(focusManager),
+                .onTabOrEnterKeyFocusNext(focusManager)
+                .testTag(TestTags.loginEmailUsername),
             label = {
                 Text(text = stringResource(StringR.string.ex_login_username_hint))
             },
@@ -284,8 +284,8 @@ internal fun LoginForm(
             readOnly = !interactionEnabled,
             modifier = Modifier
                 .fillMaxWidth()
-                .testTag(TestTags.loginPassword)
-                .onTabOrEnterKeyFocusNext(focusManager),
+                .onTabOrEnterKeyFocusNext(focusManager)
+                .testTag(TestTags.loginPassword),
             onValueChange = {
                 passwordFieldState = it
                 eventSink(LoginRootEvents.SetPassword(it))

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/OutlinedTextField.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/OutlinedTextField.kt
@@ -99,8 +99,10 @@ fun OutlinedTextField(
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun Modifier.onTabOrEnterKeyFocusNext(focusManager: FocusManager): Modifier = onPreviewKeyEvent { event ->
-    if (event.type == KeyEventType.KeyUp && (event.key == Key.Tab || event.key == Key.Enter)) {
-        focusManager.moveFocus(FocusDirection.Down)
+    if (event.key == Key.Tab || event.key == Key.Enter) {
+        if (event.type == KeyEventType.KeyUp) {
+            focusManager.moveFocus(FocusDirection.Down)
+        }
         true
     } else {
         false


### PR DESCRIPTION
## Changes

Make sure to consume both key up and key down events for Enter and Tab hardware keys in TextFields using `Modifier.onTabOrEnterKeyFocusNext`.

## Why

If we only consumed the key down event as we were doing, the Tab and Enter characters were still being added to the TextFields even if the focus was moved to the next item in its parent. This is especially annoying when using the app in an emulator. 

However, If we consume both events no character is added.

## Tests

Using an emulator, complete the login form using only a keyboard and using the Enter key to go to the next field/button.