### PR TITLE
Fix lint warning

### DIFF
--- a/anvilannotations/build.gradle.kts
+++ b/anvilannotations/build.gradle.kts
@@ -18,6 +18,7 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    id("com.android.lint")
 }
 
 dependencies {

--- a/libraries/core/build.gradle.kts
+++ b/libraries/core/build.gradle.kts
@@ -19,6 +19,7 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     id("java-library")
+    id("com.android.lint")
     alias(libs.plugins.kotlin.jvm)
 }
 

--- a/libraries/di/build.gradle.kts
+++ b/libraries/di/build.gradle.kts
@@ -18,6 +18,7 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    id("com.android.lint")
 }
 
 dependencies {


### PR DESCRIPTION
Small PR to fix this warning:

> Recommended Action: Apply the 'com.android.lint' plugin to java library project ***. to enable lint to analyze those sources.

No issue detected. Also tried to upgrade our lint version (to `android.experimental.lint.version=8.1.0-alpha09`), but this is not possible yet.