### PR TITLE
Try to improve Danger rule for PNGs to ignore screenshots

### DIFF
--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -110,7 +110,6 @@ if (hasChangedViews) {
 const hasPngs = editedFiles.filter(file => {
     file.toLowerCase().endsWith(".png") && !file.includes("snapshots/images/") // Exclude screenshots
 }).length > 0
-}
 if (hasPngs) {
     warn("You seem to have made changes to some images. Please consider using an vector drawable.")
 }

--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -107,7 +107,10 @@ if (hasChangedViews) {
 }
 
 // Check for pngs on resources
-const hasPngs = editedFiles.filter(file => file.toLowerCase().endsWith(".png")).length > 0
+const hasPngs = editedFiles.filter(file => {
+    file.toLowerCase().endsWith(".png") && !file.includes("snapshots/images/") // Exclude screenshots
+}).length > 0
+}
 if (hasPngs) {
     warn("You seem to have made changes to some images. Please consider using an vector drawable.")
 }


### PR DESCRIPTION
Modify `dangerfile.js` to ignore screenshots when checking for new `png` files in the project.