### PR TITLE
Make `ChangeServerPresenter.submit` fail as expected

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/changeserver/ChangeServerPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/changeserver/ChangeServerPresenter.kt
@@ -69,7 +69,7 @@ class ChangeServerPresenter @Inject constructor(private val authenticationServic
     private fun CoroutineScope.submit(homeserverUrl: MutableState<String>, changeServerAction: MutableState<Async<Unit>>) = launch {
         suspend {
             val domain = tryOrNull { URL(homeserverUrl.value) }?.host ?: homeserverUrl.value
-            authenticationService.setHomeserver(domain)
+            authenticationService.setHomeserver(domain).getOrThrow()
             homeserverUrl.value = domain
         }.execute(changeServerAction, errorMapping = ChangeServerError::from)
     }

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/changeserver/ChangeServerPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/changeserver/ChangeServerPresenterTest.kt
@@ -134,6 +134,7 @@ class ChangeServerPresenterTest {
             val initialState = awaitItem()
             authServer.givenChangeServerError(Throwable())
             initialState.eventSink.invoke(ChangeServerEvents.Submit)
+            skipItems(1) // Loading
             val failureState = awaitItem()
             assertThat(failureState.submitEnabled).isFalse()
             assertThat(failureState.changeServerAction).isInstanceOf(Async.Failure::class.java)
@@ -154,6 +155,8 @@ class ChangeServerPresenterTest {
             // Submit will return an error
             authenticationService.givenChangeServerError(A_THROWABLE)
             initialState.eventSink(ChangeServerEvents.Submit)
+
+            skipItems(1) // Loading
 
             // Check an error was returned
             val submittedState = awaitItem()

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/auth/FakeAuthenticationService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/auth/FakeAuthenticationService.kt
@@ -53,20 +53,13 @@ class FakeAuthenticationService : MatrixAuthenticationService {
     }
 
     override suspend fun setHomeserver(homeserver: String): Result<Unit> {
-        changeServerError?.let { throw it }
         delay(100)
-        return Result.success(Unit)
+        return changeServerError?.let { Result.failure(it) } ?: Result.success(Unit)
     }
 
     override suspend fun login(username: String, password: String): Result<SessionId> {
         delay(100)
-        return loginError.let { loginError ->
-            if (loginError == null) {
-                Result.success(A_USER_ID)
-            } else {
-                Result.failure(loginError)
-            }
-        }
+        return loginError?.let { Result.failure(it) } ?: Result.success(A_USER_ID)
     }
 
     fun givenLoginError(throwable: Throwable?) {


### PR DESCRIPTION
`AuthenticationService.setHomeserver` now returns a `Result<Unit>`, so it wasn't throwing an error as we previously expected in `ChangeServerPresenter.submit`. This caused any change in homeserver to be reported to the presenter as successful, even when it wasn't.