### PR TITLE
Move `StateMachine` to its own module.

### DIFF
--- a/features/verifysession/impl/build.gradle.kts
+++ b/features/verifysession/impl/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(projects.libraries.designsystem)
     implementation(projects.libraries.elementresources)
     implementation(projects.libraries.uiStrings)
+    implementation(projects.libraries.statemachine)
     implementation(libs.accompanist.flowlayout)
     api(projects.features.verifysession.api)
 

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionStateMachine.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionStateMachine.kt
@@ -17,7 +17,7 @@
 @file:Suppress("WildcardImport")
 package io.element.android.features.verifysession.impl
 
-import io.element.android.libraries.core.statemachine.createStateMachine
+import io.element.android.libraries.statemachine.createStateMachine
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
 import io.element.android.libraries.matrix.api.verification.VerificationEmoji
 import io.element.android.libraries.matrix.api.verification.VerificationFlowState

--- a/libraries/statemachine/build.gradle.kts
+++ b/libraries/statemachine/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO: Remove once https://youtrack.jetbrains.com/issue/KTIJ-19369 is fixed
+@Suppress("DSL_SCOPE_VIOLATION")
+plugins {
+    id("java-library")
+    id("com.android.lint")
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+dependencies {
+    implementation(libs.coroutines.core)
+
+    testImplementation(libs.test.junit)
+    testImplementation(libs.test.truth)
+}

--- a/libraries/statemachine/src/main/kotlin/io/element/android/libraries/statemachine/StateMachine.kt
+++ b/libraries/statemachine/src/main/kotlin/io/element/android/libraries/statemachine/StateMachine.kt
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package io.element.android.libraries.core.statemachine
+package io.element.android.libraries.statemachine
 
-import io.element.android.libraries.core.bool.orFalse
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
@@ -64,7 +63,7 @@ class StateMachine<Event : Any, State : Any>(
     private fun <E : Event> findMatchingRoute(event: E): StateMachineRoute<E, State, State>? {
         val routesForEvent = routes.filter { it.eventType.isInstance(event) }
 
-        return (routesForEvent.firstOrNull { it.fromState?.isInstance(currentState).orFalse() }
+        return (routesForEvent.firstOrNull { it.fromState?.isInstance(currentState) == true }
                 ?: routesForEvent.firstOrNull { it.fromState == null }) as? StateMachineRoute<E, State, State>
     }
 

--- a/libraries/statemachine/src/test/kotlin/io/element/android/libraries/statemachine/StateMachineTests.kt
+++ b/libraries/statemachine/src/test/kotlin/io/element/android/libraries/statemachine/StateMachineTests.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.element.android.libraries.core.statemachine
+package io.element.android.libraries.statemachine
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.fail

--- a/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
+++ b/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
@@ -61,6 +61,7 @@ fun DependencyHandlerScope.allLibrariesImpl() {
     implementation(project(":libraries:dateformatter:impl"))
     implementation(project(":libraries:di"))
     implementation(project(":libraries:session-storage:impl"))
+    implementation(project(":libraries:statemachine"))
 
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,6 +65,7 @@ include(":libraries:encrypted-db")
 include(":libraries:session-storage:api")
 include(":libraries:session-storage:impl")
 include(":libraries:session-storage:impl-memory")
+include(":libraries:statemachine")
 
 include(":services:analytics:api")
 include(":services:analytics:noop")


### PR DESCRIPTION
Move `StateMachine` to its own module, as it didn't really belong in `:libraries:core`.