### PR TITLE
Add support for autofilling login text fields

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/root/LoginRootView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/root/LoginRootView.kt
@@ -51,16 +51,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.AutofillNode
 import androidx.compose.ui.autofill.AutofillType
-import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalAutofill
-import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -86,6 +79,7 @@ import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.theme.components.TextField
 import io.element.android.libraries.designsystem.theme.components.TopAppBar
+import io.element.android.libraries.designsystem.theme.components.autofill
 import io.element.android.libraries.designsystem.theme.components.onTabOrEnterKeyFocusNext
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.testtags.TestTags
@@ -365,27 +359,4 @@ private fun ContentToPreview(state: LoginRootState) {
         state = state,
         onBackPressed = {}
     )
-}
-
-@OptIn(ExperimentalComposeUiApi::class)
-fun Modifier.autofill(autofillTypes: List<AutofillType>, onFill: (String) -> Unit) = composed {
-    val autofillNode = AutofillNode(autofillTypes, onFill = onFill)
-    LocalAutofillTree.current += autofillNode
-
-    val autofill = LocalAutofill.current
-
-    this
-        .onGloballyPositioned {
-            // Inform autofill framework of where our composable is so it can show the popup in the right place
-            autofillNode.boundingBox = it.boundsInWindow()
-        }
-        .onFocusChanged {
-            autofill?.run {
-                if (it.isFocused) {
-                    requestAutofillForNode(autofillNode)
-                } else {
-                    cancelAutofillForNode(autofillNode)
-                }
-            }
-        }
 }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/TextField.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/TextField.kt
@@ -29,8 +29,17 @@ import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillNode
+import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalAutofill
+import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -117,4 +126,27 @@ private fun ContentToPreview() {
             }
         }
     }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun Modifier.autofill(autofillTypes: List<AutofillType>, onFill: (String) -> Unit) = composed {
+    val autofillNode = AutofillNode(autofillTypes, onFill = onFill)
+    LocalAutofillTree.current += autofillNode
+
+    val autofill = LocalAutofill.current
+
+    this
+        .onGloballyPositioned {
+            // Inform autofill framework of where our composable is so it can show the popup in the right place
+            autofillNode.boundingBox = it.boundsInWindow()
+        }
+        .onFocusChanged {
+            autofill?.run {
+                if (it.isFocused) {
+                    requestAutofillForNode(autofillNode)
+                } else {
+                    cancelAutofillForNode(autofillNode)
+                }
+            }
+        }
 }


### PR DESCRIPTION
Support autofilling login text fields via Android Autofill with the experimental AndroidX Compose API for it.

Based on https://bryanherbst.com/2021/04/13/compose-autofill/ (with permission).

As I was trying out a prebuilt APK of Element X for Android, I noticed that the login fields could not be autofilled, which seems rather unfortunate since I assume many other users besides myself would like to use the autofill function of their favourite password manager (via Android Autofill).

This implementation of autofill support comes with some minor caveats:
* unlike with traditional Android UI components, the `TextField`s don't have their background changed automatically after a successful autofill (this can be easily added though, if wanted)
* no autofill context menu, unlike with traditional UI components (could probably also be added, if wanted)
* this API is subject to future change, and is marked experimental accordingly (it does however seem to currently be the best way to get autofill working). This being only a temporary API is mentioned here: https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/package-summary#LocalAutofillTree(), where the docs reference `b/138604305` which I presume is some issue tracker reference for "Autofill Semantics" the issue belonging to which I have been unable to find

If I understand correctly, Element is moving towards using SSO portals and OAuth as opposed to plain logins (please correct me if I'm wrong), but before that happens, having autofill for the current UI would also be nice :)

I've tested this code successfully on my real phone with API level 33 (Android 13), didn't test with API level 21 (mentioned in [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#tests)), because it's below the currently configured `minSdk` of 23 (specified in `plugins/src/main/kotlin/Versions.kt`), and failed to test with API level 23, because of some to me seemingly unrelated errors (see below).

<details>
<summary>Click to expand logcat output for first error on AVD with API level 23...</summary>

```logcat
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  FATAL EXCEPTION ElementX Version : 1.0Phone : Android SDK built for x86_64 (6695544 6.0 REL)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  Memory statuses 
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  usedSize   6 MB
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  freeSize   0 MB
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  totalSize   6 MB
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  Thread: main, Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{io.element.android.x.debug/io.element.android.x.MainActivity}: java.io.FileNotFoundException: /data/user/0/io.element.android.x.debug/databases/session_database.key: open failed: ENOENT (No such file or directory)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2416)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.app.ActivityThread.-wrap11(ActivityThread.java)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.os.Handler.dispatchMessage(Handler.java:102)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.os.Looper.loop(Looper.java:148)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.app.ActivityThread.main(ActivityThread.java:5417)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at java.lang.reflect.Method.invoke(Native Method)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  Caused by: java.io.FileNotFoundException: /data/user/0/io.element.android.x.debug/databases/session_database.key: open failed: ENOENT (No such file or directory)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at libcore.io.IoBridge.open(IoBridge.java:452)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at java.io.FileOutputStream.<init>(FileOutputStream.java:87)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at java.io.FileOutputStream.<init>(FileOutputStream.java:72)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at androidx.security.crypto.EncryptedFile.openFileOutput(EncryptedFile.java:199)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.encrypteddb.passphrase.RandomSecretPassphraseProvider.getPassphrase(RandomSecretPassphraseProvider.kt:47)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.encrypteddb.SqlCipherDriverFactory.create(SqlCipherDriverFactory.kt:39)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.libraries.sessionstorage.impl.di.SessionStorageModule.provideMatrixDatabase(SessionStorageModule.kt:40)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.libraries.sessionstorage.impl.di.SessionStorageModule_ProvideMatrixDatabaseFactory$Companion.provideMatrixDatabase(SessionStorageModule_ProvideMatrixDatabaseFactory.kt:32)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.libraries.sessionstorage.impl.di.SessionStorageModule_ProvideMatrixDatabaseFactory.get(SessionStorageModule_ProvideMatrixDatabaseFactory.kt:23)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.libraries.sessionstorage.impl.di.SessionStorageModule_ProvideMatrixDatabaseFactory.get(SessionStorageModule_ProvideMatrixDatabaseFactory.kt:20)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.libraries.sessionstorage.impl.DatabaseSessionStore_Factory.get(DatabaseSessionStore_Factory.kt:21)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.libraries.sessionstorage.impl.DatabaseSessionStore_Factory.get(DatabaseSessionStore_Factory.kt:18)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.libraries.matrix.impl.auth.RustMatrixAuthenticationService_Factory.get(RustMatrixAuthenticationService_Factory.kt:28)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.libraries.matrix.impl.auth.RustMatrixAuthenticationService_Factory.get(RustMatrixAuthenticationService_Factory.kt:21)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.appnav.di.MatrixClientsHolder_Factory.get(MatrixClientsHolder_Factory.java:30)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.appnav.di.MatrixClientsHolder_Factory.get(MatrixClientsHolder_Factory.java:11)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.x.di.DaggerAppComponent$AppComponentImpl.matrixClientsHolder(DaggerAppComponent.java:626)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at io.element.android.x.MainActivity.onCreate(MainActivity.kt:40)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.app.Activity.performCreate(Activity.java:6237)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1107)
2023-04-03 21:25:08.781  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2369)
2023-04-03 21:25:08.782  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	... 9 more
2023-04-03 21:25:08.782  4953-4953  VectorUncaughtException io.element.android.x.debug           E  Caused by: android.system.ErrnoException: open failed: ENOENT (No such file or directory)
2023-04-03 21:25:08.782  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at libcore.io.Posix.open(Native Method)
2023-04-03 21:25:08.782  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at libcore.io.BlockGuardOs.open(BlockGuardOs.java:186)
2023-04-03 21:25:08.782  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	at libcore.io.IoBridge.open(IoBridge.java:438)
2023-04-03 21:25:08.782  4953-4953  VectorUncaughtException io.element.android.x.debug           E  	... 33 more
```
</details>

`./gradlew check`, `./gradlew ktlintCheck --continue`, and `./gradlew test` seem to pass. `./gradlew ktlintFormat` also runs without modifying anything.