### PR TITLE
Revert "Merge pull request #93 from vector-im/feature/bma/upgradeAgp"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,6 @@ jobs:
           # Ensure we are building the branch and not the branch after being merged on develop
           # https://github.com/actions/checkout/issues/881
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
-      - name: Use JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
       - name: Configure gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -24,11 +24,6 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        name: Use JDK 17
-        with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
       - name: Assemble debug APK
         run: ./gradlew assembleDebug $CI_GRADLE_ARG_PROPERTIES
       - uses: mobile-dev-inc/action-maestro-cloud@v1.3.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,11 +16,6 @@ jobs:
     if: ${{ github.repository == 'vector-im/element-x-android' }}
     steps:
       - uses: actions/checkout@v3
-      - name: Use JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
       - name: Install towncrier
         run: |
           python3 -m pip install towncrier

--- a/.github/workflows/nightly_manual.yml
+++ b/.github/workflows/nightly_manual.yml
@@ -13,11 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
       - name: Install towncrier
         run: |
           python3 -m pip install towncrier

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,7 +8,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx3072m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options="-Xmx2g" -Dkotlin.incremental=false
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx3072m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -XX:MaxPermSize=512m -Dkotlin.daemon.jvm.options="-Xmx2g" -Dkotlin.incremental=false
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 2 --no-daemon
 
 jobs:
@@ -21,11 +21,6 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
-      - name: Use JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
       - name: Configure gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -65,11 +60,6 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
-      - name: Use JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
       - name: Configure gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,11 +25,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: 'true'
-      - name: ☕️ Use JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
       - name: Configure gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,7 @@ import extension.allServicesImpl
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     id("io.element.android-compose-application")
+    alias(libs.plugins.stem)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.anvil)
     alias(libs.plugins.ksp)
@@ -139,7 +140,7 @@ android {
         }
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "1.8"
     }
 
     // Waiting for https://github.com/google/ksp/issues/37
@@ -149,10 +150,6 @@ android {
                 kotlin.srcDir("build/generated/ksp/$name/kotlin")
             }
         }
-    }
-
-    buildFeatures {
-        buildConfig = true
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ signing.element.nightly.keyPassword=Secret
 
 # Customise the Lint version to use a more recent version than the one bundled with AGP
 # https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
-android.experimental.lint.version=8.0.0-rc01
+android.experimental.lint.version=8.0.0-alpha10
 
 # Enable test fixture for all modules by default
 android.experimental.enableTestFixtures=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 # Project
-android_gradle_plugin = "8.0.0-rc01"
+android_gradle_plugin = "7.4.2"
 firebase_gradle_plugin = "3.2.0"
 kotlin = "1.8.10"
 ksp = "1.8.10-1.0.9"
@@ -156,6 +156,8 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 dependencygraph = { id = "com.savvasdalkitsis.module-dependency-graph", version.ref = "dependencygraph" }
 dependencycheck = { id = "org.owasp.dependencycheck", version.ref = "dependencycheck" }
+stem = { id = "com.likethesalad.stem", version.ref = "stem" }
+stemlibrary = { id = "com.likethesalad.stem-library", version.ref = "stem" }
 paparazzi = "app.cash.paparazzi:1.2.0"
 sonarqube = "org.sonarqube:4.0.0.2929"
 kover = "org.jetbrains.kotlinx.kover:0.6.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,8 +16,8 @@
 
 #Fri Oct 07 15:02:00 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionSha256Sum=47a5bfed9ef814f90f8debcbbb315e8e7c654109acd224595ea39fca95c5d4da
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+distributionSha256Sum=518a863631feb7452b8f1b3dc2aaee5f388355cc3421bbd0275fbeadd77e84b2
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/libraries/core/build.gradle.kts
+++ b/libraries/core/build.gradle.kts
@@ -23,8 +23,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/libraries/coroutines/build.gradle.kts
+++ b/libraries/coroutines/build.gradle.kts
@@ -21,8 +21,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/libraries/designsystem/build.gradle.kts
+++ b/libraries/designsystem/build.gradle.kts
@@ -24,10 +24,6 @@ plugins {
 android {
     namespace = "io.element.android.libraries.designsystem"
 
-    buildFeatures {
-        buildConfig = true
-    }
-
     dependencies {
         // Should not be there, but this is a POC
         implementation(libs.coil.compose)

--- a/libraries/matrix/api/build.gradle.kts
+++ b/libraries/matrix/api/build.gradle.kts
@@ -25,10 +25,6 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.matrix.api"
-
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 anvil {

--- a/libraries/statemachine/build.gradle.kts
+++ b/libraries/statemachine/build.gradle.kts
@@ -23,8 +23,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/libraries/ui-strings/build.gradle.kts
+++ b/libraries/ui-strings/build.gradle.kts
@@ -18,8 +18,15 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     id("io.element.android-library")
+    alias(libs.plugins.stemlibrary)
 }
 
 android {
     namespace = "io.element.android.libraries.ui.strings"
+}
+
+// forcing the stem string template generator to be cacheable, without this the templates
+// are regenerated causing the app module to recompile its sources
+tasks.withType(com.likethesalad.android.templates.common.tasks.BaseTask::class.java) {
+    outputs.cacheIf { true }
 }

--- a/plugins/src/main/kotlin/Versions.kt
+++ b/plugins/src/main/kotlin/Versions.kt
@@ -24,6 +24,6 @@ object Versions {
     const val compileSdk = 33
     const val targetSdk = 33
     const val minSdk = 23
-    val javaCompileVersion = JavaVersion.VERSION_17
+    val javaCompileVersion = JavaVersion.VERSION_11
     val javaLanguageVersion: JavaLanguageVersion = JavaLanguageVersion.of(11)
 }

--- a/plugins/src/main/kotlin/extension/CommonExtension.kt
+++ b/plugins/src/main/kotlin/extension/CommonExtension.kt
@@ -32,8 +32,8 @@ fun CommonExtension<*, *, *, *>.androidConfig(project: Project) {
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     testOptions {

--- a/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
+++ b/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
@@ -16,16 +16,13 @@
 
 package extension
 
+import gradle.kotlin.dsl.accessors._71f190358cebd46a469f2989484fd643.androidTestImplementation
+import gradle.kotlin.dsl.accessors._71f190358cebd46a469f2989484fd643.debugImplementation
+import gradle.kotlin.dsl.accessors._71f190358cebd46a469f2989484fd643.implementation
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.project
 import java.io.File
-
-private fun DependencyHandlerScope.implementation(dependency: Any) = dependencies.add("implementation", dependency)
-
-private fun DependencyHandlerScope.androidTestImplementation(dependency: Any) = dependencies.add("androidTestImplementation", dependency)
-
-private fun DependencyHandlerScope.debugImplementation(dependency: Any) = dependencies.add("debugImplementation", dependency)
 
 /**
  * Dependencies used by all the modules


### PR DESCRIPTION
This reverts commit a44fdd8259391fb670fe46ba9a35192a89162b8a, reversing changes made to 6592a1a2ebc3ab68bf932d23c7dbfb3e87a61ddc.

I didn't check that this made AS Electric Eel impossible to use. We'll need to bump versions again after Flamingo becomes stable.