### PR TITLE
Handle navigation on notification click

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,6 +206,7 @@ dependencies {
     allLibrariesImpl()
     allServicesImpl()
     allFeaturesImpl(rootDir)
+    implementation(projects.libraries.deeplink)
     implementation(projects.tests.uitests)
     implementation(projects.anvilannotations)
     implementation(projects.appnav)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,14 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!-- Handle deep-link for notification, uncomment to be able to test deeplink with ./tools/adb/deeplink.sh -->
+            <!--intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:host="open"
+                    android:scheme="elementx" />
+            </intent-filter-->
         </activity>
 
         <provider

--- a/app/src/main/kotlin/io/element/android/x/intent/IntentProviderImpl.kt
+++ b/app/src/main/kotlin/io/element/android/x/intent/IntentProviderImpl.kt
@@ -18,7 +18,9 @@ package io.element.android.x.intent
 
 import android.content.Context
 import android.content.Intent
+import androidx.core.net.toUri
 import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.libraries.deeplink.DeepLinkCreator
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.matrix.api.core.RoomId
@@ -28,17 +30,19 @@ import io.element.android.libraries.push.impl.intent.IntentProvider
 import io.element.android.x.MainActivity
 import javax.inject.Inject
 
-// TODO EAx change to deep-link.
 @ContributesBinding(AppScope::class)
 class IntentProviderImpl @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val deepLinkCreator: DeepLinkCreator,
 ) : IntentProvider {
-    override fun getMainIntent(): Intent {
-        return Intent(context, MainActivity::class.java)
-    }
-
-    override fun getIntent(sessionId: SessionId, roomId: RoomId?, threadId: ThreadId?): Intent {
-        // TODO Handle deeplink or pass parameters
-        return Intent(context, MainActivity::class.java)
+    override fun getViewIntent(
+        sessionId: SessionId,
+        roomId: RoomId?,
+        threadId: ThreadId?,
+    ): Intent {
+        return Intent(context, MainActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            data = deepLinkCreator.create(sessionId, roomId, threadId).toUri()
+        }
     }
 }

--- a/appnav/build.gradle.kts
+++ b/appnav/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(projects.libraries.core)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.architecture)
+    implementation(projects.libraries.deeplink)
     implementation(projects.libraries.matrix.api)
     implementation(projects.libraries.push.api)
     implementation(projects.libraries.pushproviders.api)

--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -33,6 +33,7 @@ import com.bumble.appyx.core.plugin.plugins
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.navmodel.backstack.operation.replace
+import com.bumble.appyx.navmodel.backstack.operation.singleTop
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import io.element.android.anvilannotations.ContributesNode
@@ -56,10 +57,7 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.ui.di.MatrixUIBindings
 import io.element.android.services.appnavstate.api.AppNavigationStateService
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
-import kotlin.coroutines.coroutineContext
 
 @ContributesNode(AppScope::class)
 class LoggedInFlowNode @AssistedInject constructor(
@@ -214,6 +212,19 @@ class LoggedInFlowNode @AssistedInject constructor(
             NavTarget.VerifySession -> {
                 verifySessionEntryPoint.createNode(this, buildContext)
             }
+        }
+    }
+
+    suspend fun attachRoot(): Node {
+        return attachChild {
+            backstack.singleTop(NavTarget.RoomList)
+        }
+    }
+
+    suspend fun attachRoom(roomId: RoomId): RoomFlowNode {
+        return attachChild {
+            backstack.singleTop(NavTarget.RoomList)
+            backstack.push(NavTarget.Room(roomId))
         }
     }
 

--- a/appnav/src/main/kotlin/io/element/android/appnav/RoomFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RoomFlowNode.kt
@@ -18,7 +18,6 @@ package io.element.android.appnav
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import com.bumble.appyx.core.composable.Children
 import com.bumble.appyx.core.lifecycle.subscribe

--- a/libraries/deeplink/build.gradle.kts
+++ b/libraries/deeplink/build.gradle.kts
@@ -37,4 +37,5 @@ dependencies {
 
     testImplementation(libs.test.junit)
     testImplementation(libs.test.truth)
+    testImplementation(projects.libraries.matrix.test)
 }

--- a/libraries/deeplink/build.gradle.kts
+++ b/libraries/deeplink/build.gradle.kts
@@ -37,5 +37,7 @@ dependencies {
 
     testImplementation(libs.test.junit)
     testImplementation(libs.test.truth)
+    testImplementation(libs.test.robolectric)
     testImplementation(projects.libraries.matrix.test)
+    testImplementation(projects.tests.testutils)
 }

--- a/libraries/deeplink/build.gradle.kts
+++ b/libraries/deeplink/build.gradle.kts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO: Remove once https://youtrack.jetbrains.com/issue/KTIJ-19369 is fixed
+@Suppress("DSL_SCOPE_VIOLATION")
+plugins {
+    id("io.element.android-library")
+    alias(libs.plugins.anvil)
+}
+
+android {
+    namespace = "io.element.android.libraries.deeplink"
+}
+
+anvil {
+    generateDaggerFactories.set(true)
+}
+
+dependencies {
+    implementation(projects.libraries.di)
+    implementation(libs.dagger)
+    implementation(libs.androidx.corektx)
+    implementation(projects.libraries.matrix.api)
+
+    testImplementation(libs.test.junit)
+    testImplementation(libs.test.truth)
+}

--- a/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/Constants.kt
+++ b/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/Constants.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.deeplink
+
+internal const val SCHEME = "elementx"
+internal const val HOST = "open"

--- a/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeepLinkCreator.kt
+++ b/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeepLinkCreator.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 class DeepLinkCreator @Inject constructor() {
     fun create(sessionId: SessionId, roomId: RoomId?, threadId: ThreadId?): String {
         return buildString {
-            append("elementx://open/")
+            append("$SCHEME://$HOST/")
             append(sessionId.value)
             if (roomId != null) {
                 append("/")

--- a/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeepLinkCreator.kt
+++ b/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeepLinkCreator.kt
@@ -14,20 +14,26 @@
  * limitations under the License.
  */
 
-package io.element.android.libraries.push.impl.intent
+package io.element.android.libraries.deeplink
 
-import android.content.Intent
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.core.ThreadId
+import javax.inject.Inject
 
-interface IntentProvider {
-    /**
-     * Provide an intent to start the application.
-     */
-    fun getViewIntent(
-        sessionId: SessionId,
-        roomId: RoomId?,
-        threadId: ThreadId?,
-    ): Intent
+class DeepLinkCreator @Inject constructor() {
+    fun create(sessionId: SessionId, roomId: RoomId?, threadId: ThreadId?): String {
+        return buildString {
+            append("elementx://open/")
+            append(sessionId.value)
+            if (roomId != null) {
+                append("/")
+                append(roomId.value)
+                if (threadId != null) {
+                    append("/")
+                    append(threadId.value)
+                }
+            }
+        }
+    }
 }

--- a/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeeplinkData.kt
+++ b/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeeplinkData.kt
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-package io.element.android.libraries.push.impl.intent
+package io.element.android.libraries.deeplink
 
-import android.content.Intent
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.core.ThreadId
 
-interface IntentProvider {
-    /**
-     * Provide an intent to start the application.
-     */
-    fun getViewIntent(
-        sessionId: SessionId,
-        roomId: RoomId?,
-        threadId: ThreadId?,
-    ): Intent
-}
+data class DeeplinkData(
+    val sessionId: SessionId,
+    val roomId: RoomId? = null,
+    val threadId: ThreadId? = null,
+)

--- a/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeeplinkParser.kt
+++ b/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeeplinkParser.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.deeplink
+
+import android.content.Intent
+import android.net.Uri
+import io.element.android.libraries.matrix.api.core.asRoomId
+import io.element.android.libraries.matrix.api.core.asSessionId
+import io.element.android.libraries.matrix.api.core.asThreadId
+import javax.inject.Inject
+
+class DeeplinkParser @Inject constructor() {
+    fun getFromIntent(intent: Intent): DeeplinkData? {
+        return intent
+            .takeIf { it.action == Intent.ACTION_VIEW }
+            ?.data
+            ?.toDeeplinkData()
+    }
+
+    private fun Uri.toDeeplinkData(): DeeplinkData? {
+        if (scheme != "elementx") return null
+        if (host != "open") return null
+        val pathBits = path.orEmpty().split("/").drop(1)
+        val sessionId = pathBits.elementAtOrNull(0)?.asSessionId() ?: return null
+        val roomId = pathBits.elementAtOrNull(1)?.asRoomId()
+        val threadId = pathBits.elementAtOrNull(2)?.asThreadId()
+        return DeeplinkData(
+            sessionId = sessionId,
+            roomId = roomId,
+            threadId = threadId,
+        )
+    }
+}

--- a/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeeplinkParser.kt
+++ b/libraries/deeplink/src/main/kotlin/io/element/android/libraries/deeplink/DeeplinkParser.kt
@@ -32,8 +32,8 @@ class DeeplinkParser @Inject constructor() {
     }
 
     private fun Uri.toDeeplinkData(): DeeplinkData? {
-        if (scheme != "elementx") return null
-        if (host != "open") return null
+        if (scheme != SCHEME) return null
+        if (host != HOST) return null
         val pathBits = path.orEmpty().split("/").drop(1)
         val sessionId = pathBits.elementAtOrNull(0)?.asSessionId() ?: return null
         val roomId = pathBits.elementAtOrNull(1)?.asRoomId()

--- a/libraries/deeplink/src/test/kotlin/io/element/android/libraries/deeplink/DeepLinkCreatorTest.kt
+++ b/libraries/deeplink/src/test/kotlin/io/element/android/libraries/deeplink/DeepLinkCreatorTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.deeplink
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_SESSION_ID
+import io.element.android.libraries.matrix.test.A_THREAD_ID
+import org.junit.Test
+
+class DeepLinkCreatorTest {
+
+    @Test
+    fun create() {
+        val sut = DeepLinkCreator()
+        assertThat(sut.create(A_SESSION_ID, null, null))
+            .isEqualTo("elementx://open/@alice:server.org")
+        assertThat(sut.create(A_SESSION_ID, A_ROOM_ID, null))
+            .isEqualTo("elementx://open/@alice:server.org/!aRoomId:domain")
+        assertThat(sut.create(A_SESSION_ID, A_ROOM_ID, A_THREAD_ID))
+            .isEqualTo("elementx://open/@alice:server.org/!aRoomId:domain/\$aThreadId")
+    }
+}

--- a/libraries/deeplink/src/test/kotlin/io/element/android/libraries/deeplink/DeeplinkParserTest.kt
+++ b/libraries/deeplink/src/test/kotlin/io/element/android/libraries/deeplink/DeeplinkParserTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.deeplink
+
+import android.content.Intent
+import androidx.core.net.toUri
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_SESSION_ID
+import io.element.android.libraries.matrix.test.A_THREAD_ID
+import io.element.android.tests.testutils.assertNullOrThrow
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DeeplinkParserTest {
+    companion object {
+        const val A_URI =
+            "elementx://open/@alice:server.org"
+        const val A_URI_WITH_ROOM =
+            "elementx://open/@alice:server.org/!aRoomId:domain"
+        const val A_URI_WITH_ROOM_WITH_THREAD =
+            "elementx://open/@alice:server.org/!aRoomId:domain/\$aThreadId"
+    }
+
+    private val sut = DeeplinkParser()
+
+    @Test
+    fun `nominal cases`() {
+        assertThat(sut.getFromIntent(createIntent(A_URI)))
+            .isEqualTo(DeeplinkData(A_SESSION_ID, null, null))
+        assertThat(sut.getFromIntent(createIntent(A_URI_WITH_ROOM)))
+            .isEqualTo(DeeplinkData(A_SESSION_ID, A_ROOM_ID, null))
+        assertThat(sut.getFromIntent(createIntent(A_URI_WITH_ROOM_WITH_THREAD)))
+            .isEqualTo(DeeplinkData(A_SESSION_ID, A_ROOM_ID, A_THREAD_ID))
+    }
+
+    @Test
+    fun `error cases`() {
+        val sut = DeeplinkParser()
+        // Bad scheme
+        assertThat(sut.getFromIntent(createIntent("x://open/@alice:server.org"))).isNull()
+        // Bad host
+        assertThat(sut.getFromIntent(createIntent("elementx://close/@alice:server.org"))).isNull()
+        // No session Id
+        assertThat(sut.getFromIntent(createIntent("elementx://open"))).isNull()
+        // Invalid sessionId
+        assertNullOrThrow {
+            sut.getFromIntent(createIntent("elementx://open/alice:server.org"))
+        }
+        // Empty sessionId
+        assertNullOrThrow {
+            sut.getFromIntent(createIntent("elementx://open//"))
+        }
+    }
+
+    private fun createIntent(uri: String): Intent {
+        return Intent().apply {
+            action = Intent.ACTION_VIEW
+            data = uri.toUri()
+        }
+    }
+}

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationActionIds.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationActionIds.kt
@@ -34,7 +34,6 @@ data class NotificationActionIds @Inject constructor(
     val smartReply = "${buildMeta.applicationId}.NotificationActions.SMART_REPLY_ACTION"
     val dismissSummary = "${buildMeta.applicationId}.NotificationActions.DISMISS_SUMMARY_ACTION"
     val dismissRoom = "${buildMeta.applicationId}.NotificationActions.DISMISS_ROOM_NOTIF_ACTION"
-    val tapToView = "${buildMeta.applicationId}.NotificationActions.TAP_TO_VIEW_ACTION"
     val diagnostic = "${buildMeta.applicationId}.NotificationActions.DIAGNOSTIC"
     val push = "${buildMeta.applicationId}.PUSH"
 }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationUtils.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationUtils.kt
@@ -482,15 +482,11 @@ class NotificationUtils @Inject constructor(
     }
 
     private fun buildOpenRoomIntent(sessionId: SessionId, roomId: RoomId): PendingIntent? {
-        val roomIntent = intentProvider.getIntent(sessionId = sessionId, roomId = roomId, threadId = null)
-        roomIntent.action = actionIds.tapToView
-        // pending intent get reused by system, this will mess up the extra params, so put unique info to avoid that
-        roomIntent.data = createIgnoredUri("openRoom?$sessionId&$roomId")
-
+        val intent = intentProvider.getViewIntent(sessionId = sessionId, roomId = roomId, threadId = null)
         return PendingIntent.getActivity(
             context,
             clock.epochMillis().toInt(),
-            roomIntent,
+            intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
     }
@@ -498,22 +494,17 @@ class NotificationUtils @Inject constructor(
     private fun buildOpenThreadIntent(roomInfo: RoomEventGroupInfo, threadId: ThreadId?): PendingIntent? {
         val sessionId = roomInfo.sessionId
         val roomId = roomInfo.roomId
-        val threadIntentTap = intentProvider.getIntent(sessionId = sessionId, roomId = roomId, threadId = threadId)
-        threadIntentTap.action = actionIds.tapToView
-        // pending intent get reused by system, this will mess up the extra params, so put unique info to avoid that
-        threadIntentTap.data = createIgnoredUri("openThread?$sessionId&$roomId&$threadId")
-
+        val intent = intentProvider.getViewIntent(sessionId = sessionId, roomId = roomId, threadId = threadId)
         return PendingIntent.getActivity(
             context,
             clock.epochMillis().toInt(),
-            threadIntentTap,
+            intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
     }
 
     private fun buildOpenHomePendingIntentForSummary(sessionId: SessionId): PendingIntent {
-        val intent = intentProvider.getIntent(sessionId = sessionId, roomId = null, threadId = null)
-        intent.data = createIgnoredUri("tapSummary?$sessionId")
+        val intent = intentProvider.getViewIntent(sessionId = sessionId, roomId = null, threadId = null)
         return PendingIntent.getActivity(
             context,
             clock.epochMillis().toInt(),

--- a/tools/adb/deeplink.sh
+++ b/tools/adb/deeplink.sh
@@ -18,7 +18,7 @@
 # Format is:
 # elementx://open/{sessionId} to open a session
 # elementx://open/{sessionId}/{roomId} to open a room
-# elementx://open/{sessionId}/{roomId}/{eventId} to open an event
+# elementx://open/{sessionId}/{roomId}/{eventId} to open a thread
 
 # Open a session
 # adb shell am start -a android.intent.action.VIEW -d elementx://open/@benoit10518:matrix.org

--- a/tools/adb/deeplink.sh
+++ b/tools/adb/deeplink.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+#
+# Copyright (c) 2023 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Format is:
+# elementx://open/{sessionId} to open a session
+# elementx://open/{sessionId}/{roomId} to open a room
+# elementx://open/{sessionId}/{roomId}/{eventId} to open an event
+
+# Open a session
+# adb shell am start -a android.intent.action.VIEW -d elementx://open/@benoit10518:matrix.org
+# Open a room
+adb shell am start -a android.intent.action.VIEW -d elementx://open/@benoit10518:matrix.org/!dehdDVSkabQLZFYrgo:matrix.org
+# Open a thread
+# adb shell am start -a android.intent.action.VIEW -d elementx://open/@benoit10518:matrix.org/!dehdDVSkabQLZFYrgo:matrix.org/\\\$threadId


### PR DESCRIPTION
This PR add deep navigation to the application when clicking on notification.

It has same result if the app was launch or not. If the app was launched, the app is resume and is navigating to the desired target. Previous navigation is lost.

- navigate to the room list when the group notification is clicked (i.e. there are 2 notifications for 2 different rooms and there are collapsed)
- navigate to a room  (i.e. handle click on a room notification), with backstack to the room list.
- navigation to thread is not supported yet (there is a TODO in the code)

Not handled yet: for now the last session is restored, i.e. if a notification for another session is clicked, I am not sure about the effect. Some change will have to be done. We will handle that when we will think about multi-session.

Tested on API 33 emulator OK.