### PR TITLE
Fix more R8 issues

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,3 +25,10 @@
 -keepclassmembers class <1>.<2> {
   <1>.<2>$Companion Companion;
 }
+
+# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
+# Taken from https://raw.githubusercontent.com/square/okhttp/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**


### PR DESCRIPTION
These values are actually from OkHttp: https://raw.githubusercontent.com/square/okhttp/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro

The weird thing is, it [mentions here](https://square.github.io/okhttp/features/r8_proguard/) those shouldn't be needed when using R8, which we use since the upgrade to AGP 8.0 that actually broke minification.