### PR TITLE
[Room Details] Block & unblock user

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/RoomFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RoomFlowNode.kt
@@ -18,6 +18,7 @@ package io.element.android.appnav
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
 import com.bumble.appyx.core.composable.Children
@@ -134,8 +135,18 @@ class RoomFlowNode @AssistedInject constructor(
         object RoomDetails : NavTarget
     }
 
+    private val timeline = inputs.room.timeline()
+
     @Composable
     override fun View(modifier: Modifier) {
+
+        DisposableEffect(Unit) {
+            timeline.initialize()
+            onDispose {
+                timeline.dispose()
+            }
+        }
+
         Children(
             navModel = backstack,
             modifier = modifier,

--- a/changelog.d/339.feature
+++ b/changelog.d/339.feature
@@ -1,0 +1,1 @@
+Block & unblock users from room details screen.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -167,15 +167,12 @@ fun MessagesViewContent(
                 onMessageLongClicked = onMessageLongClicked
             )
         }
-
-        if (state.composerState.isVisible) {
-            MessageComposerView(
-                state = state.composerState,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight(Alignment.Bottom)
-            )
-        }
+        MessageComposerView(
+            state = state.composerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight(Alignment.Bottom)
+        )
     }
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -167,12 +167,15 @@ fun MessagesViewContent(
                 onMessageLongClicked = onMessageLongClicked
             )
         }
-        MessageComposerView(
-            state = state.composerState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .wrapContentHeight(Alignment.Bottom)
-        )
+
+        if (state.composerState.isVisible) {
+            MessageComposerView(
+                state = state.composerState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight(Alignment.Bottom)
+            )
+        }
     }
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerPresenter.kt
@@ -19,13 +19,10 @@ package io.element.android.features.messages.impl.textcomposer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import io.element.android.libraries.architecture.Presenter
-import io.element.android.libraries.core.bool.orTrue
 import io.element.android.libraries.core.data.StableCharSequence
 import io.element.android.libraries.core.data.toStableCharSequence
 import io.element.android.libraries.matrix.api.room.MatrixRoom
@@ -36,7 +33,7 @@ import javax.inject.Inject
 
 class MessageComposerPresenter @Inject constructor(
     private val appCoroutineScope: CoroutineScope,
-    private val room: MatrixRoom,
+    private val room: MatrixRoom
 ) : Presenter<MessageComposerState> {
 
     @Composable
@@ -50,11 +47,6 @@ class MessageComposerPresenter @Inject constructor(
         val composerMode: MutableState<MessageComposerMode> = rememberSaveable {
             mutableStateOf(MessageComposerMode.Normal(""))
         }
-
-        val dmMember by room.getDmMember().collectAsState(initial = null)
-
-        // Hide the composer if it's a DM and the other user is ignored
-        val isVisible = (dmMember?.isIgnored?.not()).orTrue()
 
         LaunchedEffect(composerMode.value) {
             when (val modeValue = composerMode.value) {
@@ -80,7 +72,6 @@ class MessageComposerPresenter @Inject constructor(
             text = text.value,
             isFullScreen = isFullScreen.value,
             mode = composerMode.value,
-            isVisible = isVisible,
             eventSink = ::handleEvents
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerState.kt
@@ -25,7 +25,6 @@ data class MessageComposerState(
     val text: StableCharSequence?,
     val isFullScreen: Boolean,
     val mode: MessageComposerMode,
-    val isVisible: Boolean,
     val eventSink: (MessageComposerEvents) -> Unit
 ) {
     val isSendButtonVisible: Boolean = text?.charSequence.isNullOrEmpty().not()

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerState.kt
@@ -25,6 +25,7 @@ data class MessageComposerState(
     val text: StableCharSequence?,
     val isFullScreen: Boolean,
     val mode: MessageComposerMode,
+    val isVisible: Boolean,
     val eventSink: (MessageComposerEvents) -> Unit
 ) {
     val isSendButtonVisible: Boolean = text?.charSequence.isNullOrEmpty().not()

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerStateProvider.kt
@@ -31,6 +31,5 @@ fun aMessageComposerState() = MessageComposerState(
     text = StableCharSequence(""),
     isFullScreen = false,
     mode = MessageComposerMode.Normal(content = ""),
-    isVisible = true,
     eventSink = {}
 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerStateProvider.kt
@@ -31,5 +31,6 @@ fun aMessageComposerState() = MessageComposerState(
     text = StableCharSequence(""),
     isFullScreen = false,
     mode = MessageComposerMode.Normal(content = ""),
+    isVisible = true,
     eventSink = {}
 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -80,13 +80,6 @@ class TimelinePresenter @Inject constructor(
                 .launchIn(this)
         }
 
-        DisposableEffect(Unit) {
-            timeline.initialize()
-            onDispose {
-                timeline.dispose()
-            }
-        }
-
         return TimelineState(
             highlightedEventId = highlightedEventId.value,
             paginationState = paginationState.value,

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/timeline/TimelinePresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/timeline/TimelinePresenterTest.kt
@@ -50,23 +50,6 @@ class TimelinePresenterTest {
     }
 
     @Test
-    fun `present - makes sure timeline is initialized and disposed`() = runTest {
-        val fakeTimeline = FakeMatrixTimeline()
-        val presenter = TimelinePresenter(
-            timelineItemsFactory = aTimelineItemsFactory(),
-            room = FakeMatrixRoom(matrixTimeline = fakeTimeline),
-        )
-        assertThat(fakeTimeline.isInitialized).isFalse()
-        moleculeFlow(RecompositionClock.Immediate) {
-            presenter.present()
-        }.test {
-            skipItems(2)
-            assertThat(fakeTimeline.isInitialized).isTrue()
-        }
-        assertThat(fakeTimeline.isInitialized).isFalse()
-    }
-
-    @Test
     fun `present - load more`() = runTest {
         val presenter = TimelinePresenter(
             timelineItemsFactory = aTimelineItemsFactory(),

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/blockuser/BlockUserSection.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/blockuser/BlockUserSection.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.roomdetails.blockuser
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Block
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsEvents
+import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsState
+import io.element.android.features.roomdetails.impl.R
+import io.element.android.libraries.designsystem.components.dialogs.ConfirmationDialog
+import io.element.android.libraries.designsystem.components.preferences.PreferenceCategory
+import io.element.android.libraries.designsystem.components.preferences.PreferenceText
+import io.element.android.libraries.designsystem.theme.LocalColors
+
+@Composable
+internal fun BlockUserSection(state: RoomMemberDetailsState, modifier: Modifier = Modifier) {
+    PreferenceCategory(showDivider = false, modifier = modifier) {
+        if (state.isBlocked) {
+            PreferenceText(
+                title = stringResource(R.string.screen_dm_details_unblock_user),
+                icon = Icons.Outlined.Block,
+                onClick = { state.eventSink(RoomMemberDetailsEvents.UnblockUser(needsConfirmation = true)) },
+            )
+        } else {
+            PreferenceText(
+                title = stringResource(R.string.screen_dm_details_block_user),
+                icon = Icons.Outlined.Block,
+                tintColor = LocalColors.current.textActionCritical,
+                onClick = { state.eventSink(RoomMemberDetailsEvents.BlockUser(needsConfirmation = true)) },
+            )
+        }
+    }
+}
+
+@Composable
+internal fun BlockUserDialogs(state: RoomMemberDetailsState) {
+    when (state.displayConfirmationDialog) {
+        null -> Unit
+        RoomMemberDetailsState.ConfirmationDialog.Block -> {
+            BlockConfirmationDialog(
+                onBlockAction = { state.eventSink(RoomMemberDetailsEvents.BlockUser(needsConfirmation = false)) },
+                onDismiss = { state.eventSink(RoomMemberDetailsEvents.ClearConfirmationDialog) }
+            )
+        }
+        RoomMemberDetailsState.ConfirmationDialog.Unblock -> {
+            UnblockConfirmationDialog(
+                onUnblockAction = { state.eventSink(RoomMemberDetailsEvents.UnblockUser(needsConfirmation = false)) },
+                onDismiss = { state.eventSink(RoomMemberDetailsEvents.ClearConfirmationDialog) }
+            )
+        }
+    }
+}
+
+@Composable
+internal fun BlockConfirmationDialog(onBlockAction: () -> Unit, onDismiss: () -> Unit) {
+    ConfirmationDialog(
+        content = stringResource(R.string.screen_dm_details_block_alert_description),
+        submitText = stringResource(R.string.screen_dm_details_block_alert_action),
+        onSubmitClicked = onBlockAction,
+        onDismiss = onDismiss
+    )
+}
+
+@Composable
+internal fun UnblockConfirmationDialog(onUnblockAction: () -> Unit, onDismiss: () -> Unit) {
+    ConfirmationDialog(
+        content = stringResource(R.string.screen_dm_details_unblock_alert_description),
+        submitText = stringResource(R.string.screen_dm_details_unblock_alert_action),
+        onSubmitClicked = onUnblockAction,
+        onDismiss = onDismiss
+    )
+}

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsNode.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsNode.kt
@@ -63,7 +63,10 @@ class RoomDetailsNode @AssistedInject constructor(
                 activityResultLauncher = null,
                 chooserTitle = context.getString(R.string.screen_room_details_share_room_title),
                 text = permalink,
+                noActivityFoundMessage = context.getString(AndroidUtilsR.string.error_no_compatible_app_found)
             )
+        }.onFailure {
+            Timber.e(it)
         }
     }
 
@@ -86,12 +89,21 @@ class RoomDetailsNode @AssistedInject constructor(
     override fun View(modifier: Modifier) {
         val context = LocalContext.current
         val state = presenter.present()
+
+        fun onShareRoom() {
+            this.onShareRoom(context)
+        }
+
+        fun onShareMember(roomMember: RoomMember) {
+            this.onShareMember(context, roomMember)
+        }
+
         RoomDetailsView(
             state = state,
             modifier = modifier,
-            goBack = { navigateUp() },
-            onShareRoom = { onShareRoom(context) },
-            onShareMember = { onShareMember(context, it) },
+            goBack = this::navigateUp,
+            onShareRoom = ::onShareRoom,
+            onShareMember = ::onShareMember,
             openRoomMemberList = ::openRoomMemberList,
         )
     }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsState.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsState.kt
@@ -16,10 +16,8 @@
 
 package io.element.android.features.roomdetails.impl
 
+import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsState
 import io.element.android.libraries.architecture.Async
-import io.element.android.libraries.architecture.isLoading
-
-import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMember
 
 data class RoomDetailsState(
@@ -33,6 +31,7 @@ data class RoomDetailsState(
     val displayLeaveRoomWarning: LeaveRoomWarning?,
     val error: RoomDetailsError?,
     val roomType: RoomDetailsType,
+    val roomMemberDetailsState: RoomMemberDetailsState?,
     val eventSink: (RoomDetailsEvent) -> Unit
 )
 

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsStateProvider.kt
@@ -71,5 +71,6 @@ fun aRoomDetailsState() = RoomDetailsState(
     displayLeaveRoomWarning = null,
     error = null,
     roomType = RoomDetailsType.Room,
+    roomMemberDetailsState = null,
     eventSink = {}
 )

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
@@ -42,7 +42,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import io.element.android.features.roomdetails.impl.members.details.BlockSection
+import io.element.android.features.roomdetails.blockuser.BlockUserDialogs
+import io.element.android.features.roomdetails.blockuser.BlockUserSection
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberHeaderSection
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberShareSection
 import io.element.android.libraries.architecture.Async
@@ -135,10 +136,11 @@ fun RoomDetailsView(
                     })
                 }
                 is RoomDetailsType.Dm -> {
-                    BlockSection(
-                        isBlocked = state.roomType.roomMember.isIgnored,
-                        onToggleBlock = { /*TODO*/ }
-                    )
+                    if (state.roomMemberDetailsState != null) {
+                        val roomMemberState = state.roomMemberDetailsState
+                        BlockUserSection(roomMemberState)
+                        BlockUserDialogs(roomMemberState)
+                    }
                 }
             }
 

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/di/RoomMemberModules.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/di/RoomMemberModules.kt
@@ -20,7 +20,6 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import io.element.android.features.roomdetails.impl.RoomDetailsPresenter
 import io.element.android.features.roomdetails.impl.members.RoomUserListDataSource
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsPresenter
 import io.element.android.features.userlist.api.UserListDataSource
@@ -28,7 +27,6 @@ import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMember
-import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import javax.inject.Named
 
 @Module
@@ -45,21 +43,13 @@ interface RoomMemberBindsModule {
 object RoomMemberProvidesModule {
 
     @Provides
-    fun provideRoomDetailsPresenter(
-        matrixClient: MatrixClient,
-        room: MatrixRoom,
-        roomMembershipObserver: RoomMembershipObserver,
-    ): RoomDetailsPresenter {
-        return RoomDetailsPresenter(matrixClient.sessionId, room, roomMembershipObserver)
-    }
-
-    @Provides
     fun provideRoomMemberDetailsPresenterFactory(
+        matrixClient: MatrixClient,
         room: MatrixRoom,
     ): RoomMemberDetailsPresenter.Factory {
         return object : RoomMemberDetailsPresenter.Factory {
             override fun create(roomMember: RoomMember): RoomMemberDetailsPresenter {
-                return RoomMemberDetailsPresenter(room, roomMember)
+                return RoomMemberDetailsPresenter(matrixClient.sessionId, room, roomMember)
             }
         }
     }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListNode.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListNode.kt
@@ -29,6 +29,9 @@ import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.ui.model.MatrixUser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @ContributesNode(RoomScope::class)
@@ -37,6 +40,7 @@ class RoomMemberListNode @AssistedInject constructor(
     @Assisted plugins: List<Plugin>,
     private val room: MatrixRoom,
     private val presenter: RoomMemberListPresenter,
+    private val coroutineScope: CoroutineScope,
 ) : Node(buildContext, plugins = plugins) {
 
     interface Callback : Plugin {
@@ -45,8 +49,8 @@ class RoomMemberListNode @AssistedInject constructor(
 
     private val callbacks = plugins<Callback>()
 
-    private fun onUserSelected(matrixUser: MatrixUser) {
-        val member = room.getMember(matrixUser.id)
+    private fun onUserSelected(matrixUser: MatrixUser) = coroutineScope.launch {
+        val member = room.getMember(matrixUser.id).firstOrNull()
         if (member != null) {
             callbacks.forEach { it.openRoomMemberDetails(member) }
         } else {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomUserListDataSource.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomUserListDataSource.kt
@@ -23,6 +23,7 @@ import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.ui.model.MatrixUser
+import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 
 class RoomUserListDataSource @Inject constructor(
@@ -30,7 +31,7 @@ class RoomUserListDataSource @Inject constructor(
 ) : UserListDataSource {
 
     override suspend fun search(query: String): List<MatrixUser> {
-        return room.members().filter { member ->
+        return room.members().firstOrNull().orEmpty().filter { member ->
             if (query.isBlank()) {
                 true
             } else {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsEvents.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsEvents.kt
@@ -16,4 +16,8 @@
 
 package io.element.android.features.roomdetails.impl.members.details
 
-sealed interface RoomMemberDetailsEvents
+sealed interface RoomMemberDetailsEvents {
+    data class BlockUser(val needsConfirmation: Boolean = false) : RoomMemberDetailsEvents
+    data class UnblockUser(val needsConfirmation: Boolean = false) : RoomMemberDetailsEvents
+    object ClearConfirmationDialog : RoomMemberDetailsEvents
+}

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsNode.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsNode.kt
@@ -30,7 +30,6 @@ import io.element.android.libraries.androidutils.system.startSharePlainTextInten
 import io.element.android.libraries.architecture.NodeInputs
 import io.element.android.libraries.architecture.inputs
 import io.element.android.libraries.di.RoomScope
-import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.permalink.PermalinkBuilder
 import io.element.android.libraries.matrix.api.room.RoomMember
 import timber.log.Timber
@@ -52,7 +51,6 @@ class RoomMemberDetailsNode @AssistedInject constructor(
 
     @Composable
     override fun View(modifier: Modifier) {
-
         val context = LocalContext.current
 
         fun onShareUser() {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsStateProvider.kt
@@ -24,6 +24,8 @@ open class RoomMemberDetailsStateProvider : PreviewParameterProvider<RoomMemberD
             aRoomMemberDetailsState(),
             aRoomMemberDetailsState().copy(userName = null),
             aRoomMemberDetailsState().copy(isBlocked = true),
+            aRoomMemberDetailsState().copy(displayConfirmationDialog = RoomMemberDetailsState.ConfirmationDialog.Block),
+            aRoomMemberDetailsState().copy(displayConfirmationDialog = RoomMemberDetailsState.ConfirmationDialog.Unblock),
             // Add other states here
         )
 }
@@ -33,5 +35,6 @@ fun aRoomMemberDetailsState() = RoomMemberDetailsState(
     userName = "Daniel",
     avatarUrl = null,
     isBlocked = false,
-//    eventSink = {},
+    isCurrentUser = false,
+    eventSink = {},
 )

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsView.kt
@@ -39,12 +39,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import io.element.android.features.roomdetails.blockuser.BlockUserDialogs
+import io.element.android.features.roomdetails.blockuser.BlockUserSection
 import io.element.android.features.roomdetails.impl.R
 import io.element.android.libraries.designsystem.ElementTextStyles
 import io.element.android.libraries.designsystem.components.avatar.Avatar
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.designsystem.components.button.BackButton
+import io.element.android.libraries.designsystem.components.dialogs.ConfirmationDialog
 import io.element.android.libraries.designsystem.components.preferences.PreferenceCategory
 import io.element.android.libraries.designsystem.components.preferences.PreferenceText
 import io.element.android.libraries.designsystem.preview.ElementPreviewDark
@@ -86,9 +89,10 @@ fun RoomMemberDetailsView(
                 // TODO implement send DM
             })
 
-            BlockSection(isBlocked = state.isBlocked, onToggleBlock = {
-                // TODO implement block & unblock
-            })
+            if (!state.isCurrentUser) {
+                BlockUserSection(state)
+                BlockUserDialogs(state)
+            }
         }
     }
 }
@@ -136,24 +140,6 @@ internal fun SendMessageSection(onSendMessage: () -> Unit, modifier: Modifier = 
             icon = Icons.Outlined.ChatBubbleOutline,
             onClick = onSendMessage,
         )
-    }
-}
-
-@Composable
-internal fun BlockSection(isBlocked: Boolean, onToggleBlock: () -> Unit, modifier: Modifier = Modifier) {
-    PreferenceCategory(showDivider = false, modifier = modifier) {
-        if (isBlocked) {
-            PreferenceText(
-                title = stringResource(R.string.screen_dm_details_unblock_user),
-                icon = Icons.Outlined.Block,
-            )
-        } else {
-            PreferenceText(
-                title = stringResource(R.string.screen_dm_details_block_user),
-                icon = Icons.Outlined.Block,
-                tintColor = LocalColors.current.textActionCritical,
-            )
-        }
     }
 }
 

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
@@ -34,6 +34,7 @@ import io.element.android.libraries.matrix.api.timeline.item.event.MembershipCha
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_NAME
 import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
@@ -50,7 +51,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - initial state is created from room info`() = runTest {
         val room = aMatrixRoom()
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -69,7 +70,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - room member count is calculated asynchronously`() = runTest {
         val room = aMatrixRoom()
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -84,7 +85,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - initial state with no room name`() = runTest {
         val room = aMatrixRoom(name = null)
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -100,7 +101,7 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom(name = null).apply {
             givenDmMember(aRoomMember())
         }
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -121,7 +122,7 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom(name = null).apply {
             givenFetchMemberResult(Result.failure(Throwable()))
         }
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -135,7 +136,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - Leave with confirmation on private room shows a specific warning`() = runTest {
         val room = aMatrixRoom(isPublic = false)
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -152,7 +153,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - Leave with confirmation on empty room shows a specific warning`() = runTest {
         val room = aMatrixRoom(members = listOf(aRoomMember()))
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -169,7 +170,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - Leave with confirmation shows a generic warning`() = runTest {
         val room = aMatrixRoom()
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -186,7 +187,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - Leave without confirmation leaves the room`() = runTest {
         val room = aMatrixRoom()
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -210,7 +211,7 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom().apply {
             givenLeaveRoomError(Throwable())
         }
-        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(FakeMatrixClient(), room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
@@ -23,6 +23,7 @@ import com.google.common.truth.Truth
 import io.element.android.features.roomdetails.impl.LeaveRoomWarning
 import io.element.android.features.roomdetails.impl.RoomDetailsEvent
 import io.element.android.features.roomdetails.impl.RoomDetailsPresenter
+import io.element.android.features.roomdetails.impl.RoomDetailsType
 import io.element.android.libraries.architecture.Async
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.UserId
@@ -32,7 +33,6 @@ import io.element.android.libraries.matrix.api.room.RoomMembershipState
 import io.element.android.libraries.matrix.api.timeline.item.event.MembershipChange
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_NAME
-import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -50,7 +50,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - initial state is created from room info`() = runTest {
         val room = aMatrixRoom()
-        val presenter = RoomDetailsPresenter(A_SESSION_ID, room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -69,7 +69,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - room member count is calculated asynchronously`() = runTest {
         val room = aMatrixRoom()
-        val presenter = RoomDetailsPresenter(A_SESSION_ID, room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -84,7 +84,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - initial state with no room name`() = runTest {
         val room = aMatrixRoom(name = null)
-        val presenter = RoomDetailsPresenter(A_SESSION_ID, room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -96,11 +96,32 @@ class RoomDetailsPresenterTests {
     }
 
     @Test
+    fun `present - initial state with DM member sets custom DM roomType`() = runTest {
+        val room = aMatrixRoom(name = null).apply {
+            givenDmMember(aRoomMember())
+        }
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            // It's not configured yet in the first iteration
+            Truth.assertThat(initialState.roomType).isEqualTo(RoomDetailsType.Room)
+
+            // Once updated, the RoomDetailsType becomes 'Dm'
+            val updatedState = awaitItem()
+            Truth.assertThat(updatedState.roomType).isEqualTo(RoomDetailsType.Dm(aRoomMember()))
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `present - can handle error while fetching member count`() = runTest {
         val room = aMatrixRoom(name = null).apply {
             givenFetchMemberResult(Result.failure(Throwable()))
         }
-        val presenter = RoomDetailsPresenter(A_SESSION_ID, room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -114,7 +135,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - Leave with confirmation on private room shows a specific warning`() = runTest {
         val room = aMatrixRoom(isPublic = false)
-        val presenter = RoomDetailsPresenter(A_SESSION_ID, room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -131,7 +152,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - Leave with confirmation on empty room shows a specific warning`() = runTest {
         val room = aMatrixRoom(members = listOf(aRoomMember()))
-        val presenter = RoomDetailsPresenter(A_SESSION_ID, room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -148,7 +169,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - Leave with confirmation shows a generic warning`() = runTest {
         val room = aMatrixRoom()
-        val presenter = RoomDetailsPresenter(A_SESSION_ID, room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -165,7 +186,7 @@ class RoomDetailsPresenterTests {
     @Test
     fun `present - Leave without confirmation leaves the room`() = runTest {
         val room = aMatrixRoom()
-        val presenter = RoomDetailsPresenter(A_SESSION_ID, room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -189,7 +210,7 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom().apply {
             givenLeaveRoomError(Throwable())
         }
-        val presenter = RoomDetailsPresenter(A_SESSION_ID, room, roomMembershipObserver)
+        val presenter = RoomDetailsPresenter(room, roomMembershipObserver)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/details/RoomMemberDetailsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/details/RoomMemberDetailsPresenterTests.kt
@@ -25,6 +25,7 @@ import io.element.android.features.roomdetails.aRoomMember
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsEvents
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsPresenter
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsState
+import io.element.android.libraries.matrix.test.A_SESSION_ID
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -39,7 +40,7 @@ class RoomMemberDetailsPresenterTests {
             givenUserAvatarUrlResult(Result.success("A custom avatar"))
         }
         val roomMember = aRoomMember(displayName = "Alice")
-        val presenter = RoomMemberDetailsPresenter(room, roomMember)
+        val presenter = RoomMemberDetailsPresenter(A_SESSION_ID, room, roomMember)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -62,7 +63,7 @@ class RoomMemberDetailsPresenterTests {
             givenUserAvatarUrlResult(Result.failure(Throwable()))
         }
         val roomMember = aRoomMember(displayName = "Alice")
-        val presenter = RoomMemberDetailsPresenter(room, roomMember)
+        val presenter = RoomMemberDetailsPresenter(A_SESSION_ID, room, roomMember)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -81,7 +82,7 @@ class RoomMemberDetailsPresenterTests {
             givenUserAvatarUrlResult(Result.success(null))
         }
         val roomMember = aRoomMember(displayName = "Alice")
-        val presenter = RoomMemberDetailsPresenter(room, roomMember)
+        val presenter = RoomMemberDetailsPresenter(A_SESSION_ID, room, roomMember)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -97,7 +98,7 @@ class RoomMemberDetailsPresenterTests {
     fun `present - BlockUser needing confirmation displays confirmation dialog`() = runTest {
         val room = aMatrixRoom()
         val roomMember = aRoomMember()
-        val presenter = RoomMemberDetailsPresenter(room, roomMember)
+        val presenter = RoomMemberDetailsPresenter(A_SESSION_ID, room, roomMember)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -118,7 +119,7 @@ class RoomMemberDetailsPresenterTests {
     fun `present - BlockUser and UnblockUser without confirmation change the 'blocked' state`() = runTest {
         val room = aMatrixRoom()
         val roomMember = aRoomMember()
-        val presenter = RoomMemberDetailsPresenter(room, roomMember)
+        val presenter = RoomMemberDetailsPresenter(A_SESSION_ID, room, roomMember)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {
@@ -135,7 +136,7 @@ class RoomMemberDetailsPresenterTests {
     fun `present - UnblockUser needing confirmation displays confirmation dialog`() = runTest {
         val room = aMatrixRoom()
         val roomMember = aRoomMember()
-        val presenter = RoomMemberDetailsPresenter(room, roomMember)
+        val presenter = RoomMemberDetailsPresenter(A_SESSION_ID, room, roomMember)
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
         }.test {

--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/ErrorFlow.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/ErrorFlow.kt
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
-package io.element.android.features.roomdetails.impl.members.details
+package io.element.android.libraries.core.coroutine
 
-data class RoomMemberDetailsState(
-    val userId: String,
-    val userName: String?,
-    val avatarUrl: String?,
-    val isBlocked: Boolean,
-    val displayConfirmationDialog: ConfirmationDialog? = null,
-    val isCurrentUser: Boolean,
-    val eventSink: (RoomMemberDetailsEvents) -> Unit
-) {
-    enum class ConfirmationDialog {
-        Block, Unblock
-    }
-}
+import kotlinx.coroutines.flow.flow
+
+/** Create a Flow emitting a single error event. It should be useful for tests. */
+fun <T> errorFlow(throwable: Throwable) = flow<T> { throw throwable }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -36,13 +36,13 @@ interface MatrixRoom: Closeable {
     val isDirect: Boolean
     val isPublic: Boolean
 
-    suspend fun members() : List<RoomMember>
+    fun members() : Flow<List<RoomMember>>
 
-    suspend fun memberCount(): Int
+    fun updateMembers()
 
-    fun getMember(userId: UserId): RoomMember?
+    fun getMember(userId: UserId): Flow<RoomMember?>
 
-    fun getDmMember(): RoomMember?
+    fun getDmMember(): Flow<RoomMember?>
 
     fun syncUpdateFlow(): Flow<Long>
 
@@ -61,6 +61,10 @@ interface MatrixRoom: Closeable {
     suspend fun replyMessage(eventId: EventId, message: String): Result<Unit>
 
     suspend fun redactEvent(eventId: EventId, reason: String? = null): Result<Unit>
+
+    suspend fun ignoreUser(userId: UserId): Result<Unit>
+
+    suspend fun unignoreUser(userId: UserId): Result<Unit>
 
     suspend fun leave(): Result<Unit>
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -27,10 +27,17 @@ import io.element.android.libraries.matrix.api.timeline.MatrixTimeline
 import io.element.android.libraries.matrix.impl.timeline.RustMatrixTimeline
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.flow.singleOrNull
+import kotlinx.coroutines.flow.skip
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.Room
@@ -38,6 +45,8 @@ import org.matrix.rustcomponents.sdk.SlidingSyncRoom
 import org.matrix.rustcomponents.sdk.UpdateSummary
 import org.matrix.rustcomponents.sdk.genTransactionId
 import org.matrix.rustcomponents.sdk.messageEventContentFromMarkdown
+import java.lang.IllegalStateException
+import org.matrix.rustcomponents.sdk.RoomMember as RustRoomMember
 
 class RustMatrixRoom(
     private val currentUserId: UserId,
@@ -48,37 +57,40 @@ class RustMatrixRoom(
     private val coroutineDispatchers: CoroutineDispatchers,
 ) : MatrixRoom {
 
-    private var loadMembersJob: Job? = null
-    private var cachedMembers: List<RoomMember> = emptyList()
+    private val timeline by lazy {
+        RustMatrixTimeline(
+            matrixRoom = this,
+            innerRoom = innerRoom,
+            slidingSyncRoom = slidingSyncRoom,
+            coroutineScope = coroutineScope,
+            coroutineDispatchers = coroutineDispatchers
+        )
+    }
 
-    override suspend fun members(): List<RoomMember> {
-        return cachedMembers.ifEmpty {
-            if (loadMembersJob == null) {
-                loadMembersJob = coroutineScope.launch(coroutineDispatchers.io) {
-                    cachedMembers = tryOrNull {
-                        innerRoom.members().map(RoomMemberMapper::map)
-                    } ?: emptyList()
-                }
+    private var membersFlow = MutableStateFlow<List<RoomMember>>(emptyList())
+
+    override fun members(): Flow<List<RoomMember>> {
+        return membersFlow.onSubscription { updateMembers() }
+    }
+
+    override fun updateMembers() {
+        val updatedMembers = tryOrNull {
+            innerRoom.members().map(RoomMemberMapper::map)
+        } ?: emptyList()
+        membersFlow.tryEmit(updatedMembers)
+    }
+
+    override fun getMember(userId: UserId): Flow<RoomMember?> {
+        return membersFlow.map { members -> members.find { it.userId == userId } }
+    }
+
+    override fun getDmMember(): Flow<RoomMember?> {
+        return membersFlow.map { members ->
+            if (members.size == 2 && isDirect && isEncrypted) {
+                members.find { it.userId != currentUserId }
+            } else {
+                null
             }
-            loadMembersJob?.join()
-            loadMembersJob = null
-            cachedMembers
-        }
-    }
-
-    override suspend fun memberCount(): Int {
-        return members().size
-    }
-
-    override fun getMember(userId: UserId): RoomMember? {
-        return cachedMembers.find { it.userId == userId }
-    }
-
-    override fun getDmMember(): RoomMember? {
-        return if (cachedMembers.size == 2 && isDirect && isEncrypted) {
-            cachedMembers.find { it.userId != currentUserId }
-        } else {
-            null
         }
     }
 
@@ -94,13 +106,7 @@ class RustMatrixRoom(
     }
 
     override fun timeline(): MatrixTimeline {
-        return RustMatrixTimeline(
-            matrixRoom = this,
-            innerRoom = innerRoom,
-            slidingSyncRoom = slidingSyncRoom,
-            coroutineScope = coroutineScope,
-            coroutineDispatchers = coroutineDispatchers
-        )
+        return timeline
     }
 
     override fun close() {
@@ -205,5 +211,21 @@ class RustMatrixRoom(
         runCatching {
             innerRoom.leave()
         }
+    }
+
+    override suspend fun ignoreUser(userId: UserId): Result<Unit> {
+        return runCatching {
+            getRustMember(userId)?.ignore() ?: error("No member with userId $userId exists in room $roomId")
+        }
+    }
+
+    override suspend fun unignoreUser(userId: UserId): Result<Unit> {
+        return runCatching {
+            getRustMember(userId)?.unignore() ?: error("No member with userId $userId exists in room $roomId")
+        }
+    }
+
+    private fun getRustMember(userId: UserId): RustRoomMember? {
+        return innerRoom.members().find { it.userId() == userId.value }
     }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -85,7 +85,7 @@ class RustMatrixRoom(
     }
 
     override fun getDmMember(): Flow<RoomMember?> {
-        return members().map { members ->
+        return membersFlow.map { members ->
             if (members.size == 2 && isDirect && isEncrypted) {
                 members.find { it.userId != currentUserId }
             } else {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -85,7 +85,7 @@ class RustMatrixRoom(
     }
 
     override fun getDmMember(): Flow<RoomMember?> {
-        return membersFlow.map { members ->
+        return members().map { members ->
             if (members.size == 2 && isDirect && isEncrypted) {
                 members.find { it.userId != currentUserId }
             } else {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
@@ -139,7 +139,14 @@ class RustMatrixTimeline(
 
     private suspend fun addListener(timelineListener: TimelineListener): Result<List<TimelineItem>> = withContext(coroutineDispatchers.io) {
         runCatching {
-            val settings = RoomSubscription(requiredState = listOf(RequiredState(key = "m.room.canonical_alias", value = "")), timelineLimit = null)
+            val settings = RoomSubscription(
+                requiredState = listOf(
+                    RequiredState(key = "m.room.topic", value = ""),
+                    RequiredState(key = "m.room.canonical_alias", value = ""),
+                    RequiredState(key = "m.room.join_rules", value = ""),
+                ),
+                timelineLimit = null
+            )
             val result = slidingSyncRoom.subscribeAndAddTimelineListener(timelineListener, settings)
             listenerTokens += result.taskHandle
             result.items

--- a/libraries/matrix/test/build.gradle.kts
+++ b/libraries/matrix/test/build.gradle.kts
@@ -23,6 +23,7 @@ android {
 }
 
 dependencies {
+    api(projects.libraries.core)
     api(projects.libraries.matrix.api)
     api(libs.coroutines.core)
 }

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewDarkPreview_0_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewDarkPreview_0_null_3,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8c78efed997712873719636ff1f8479d38d317e443c5d4340346d4328de9c0d
+size 28744

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewDarkPreview_0_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewDarkPreview_0_null_4,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8c78efed997712873719636ff1f8479d38d317e443c5d4340346d4328de9c0d
+size 28744

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewLightPreview_0_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewLightPreview_0_null_3,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f62537b4aa79f501908d1fff9d269139e88db5f6dbaedcf63670a4f71b47bff
+size 28303

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewLightPreview_0_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewLightPreview_0_null_4,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f62537b4aa79f501908d1fff9d269139e88db5f6dbaedcf63670a4f71b47bff
+size 28303

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl_null_DefaultGroup_RoomDetailsDarkPreview_0_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl_null_DefaultGroup_RoomDetailsDarkPreview_0_null_5,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:354452861d1e006a8bfa744251ffdaf15088e0bb181a53043f121e606233d648
-size 67340
+oid sha256:a8a9186d741d251dc8bdf6bcf71d395e8c057c310585aeb8911609eaaacce842
+size 64550

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl_null_DefaultGroup_RoomDetailsDarkPreview_0_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl_null_DefaultGroup_RoomDetailsDarkPreview_0_null_6,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1cb6bac9e72b956d0cffde807340e36a7a4d6873d4d7337995b53e82769c4f9
-size 68135
+oid sha256:a8a9186d741d251dc8bdf6bcf71d395e8c057c310585aeb8911609eaaacce842
+size 64550

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl_null_DefaultGroup_RoomDetailsLightPreview_0_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl_null_DefaultGroup_RoomDetailsLightPreview_0_null_5,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc56e29c26250c6fef312ec4c5fdfaa2f63159fd0565bd37522b46c7ff67906a
-size 61924
+oid sha256:94a589b556a750485fd61af6446457c98c5f112d0d013cd78016b88a8829e6a8
+size 58643

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl_null_DefaultGroup_RoomDetailsLightPreview_0_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl_null_DefaultGroup_RoomDetailsLightPreview_0_null_6,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6faff25a1c187dee59d0dcf0affd5029251512efb6eff7fc2d41d34bace2061
-size 62356
+oid sha256:94a589b556a750485fd61af6446457c98c5f112d0d013cd78016b88a8829e6a8
+size 58643


### PR DESCRIPTION
## What

Adds shared UI and logic code to block and unblock users from both room details screen and member details screen.

## Why

Implements #339 .

## Tests

You'll need to test this both in a DM room and a regular room.

1. Select a user you want to ignore.
2. Open the DM or regular room. Make sure it contains messages from that user (other events, including undecrypted, ones don't count).
3. Go to the room details. If you're on a regular room navigate to the member details screen for the user you chose before.
4. Block the user, come back to the timeline.
5. Their messages should have disappeared from the timeline. In the DM screen the composer shouldn't be present either.
6. Go again to the user's details, unblock them.
7. The messages should be back in the timeline, the composer should be visible again.

## Video

[block_unblock.webm](https://user-images.githubusercontent.com/480955/233005413-d19f70db-5237-4f2f-81ed-3b465d83c418.webm)
