### PR TITLE
[Room list] Search & menu improvements

### DIFF
--- a/changelog.d/354.feature
+++ b/changelog.d/354.feature
@@ -1,0 +1,1 @@
+Improve room list search and general UI

--- a/features/networkmonitor/impl/src/main/kotlin/io/element/android/features/networkmonitor/impl/NetworkMonitorImpl.kt
+++ b/features/networkmonitor/impl/src/main/kotlin/io/element/android/features/networkmonitor/impl/NetworkMonitorImpl.kt
@@ -71,8 +71,8 @@ class NetworkMonitorImpl @Inject constructor(
 
     private fun listenToConnectionChanges() {
         val request = NetworkRequest.Builder()
-            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-            .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+//            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+//            .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
             .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
             .build()
         connectivityManager.registerNetworkCallback(request, callback)

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListEvents.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListEvents.kt
@@ -20,4 +20,5 @@ sealed interface RoomListEvents {
     data class UpdateFilter(val newFilter: String) : RoomListEvents
     data class UpdateVisibleRange(val range: IntRange) : RoomListEvents
     object DismissRequestVerificationPrompt : RoomListEvents
+    object ToggleSearchResults : RoomListEvents
 }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -101,11 +101,14 @@ class RoomListPresenter @Inject constructor(
             derivedStateOf { sessionVerifiedStatus == SessionVerifiedStatus.NotVerified && !verificationPromptDismissed }
         }
 
+        var displaySearchResults by rememberSaveable { mutableStateOf(false) }
+
         fun handleEvents(event: RoomListEvents) {
             when (event) {
                 is RoomListEvents.UpdateFilter -> filter = event.newFilter
                 is RoomListEvents.UpdateVisibleRange -> updateVisibleRange(event.range)
                 RoomListEvents.DismissRequestVerificationPrompt -> verificationPromptDismissed = true
+                RoomListEvents.ToggleSearchResults -> displaySearchResults =! displaySearchResults
             }
         }
 
@@ -123,6 +126,7 @@ class RoomListPresenter @Inject constructor(
             snackbarMessage = snackbarMessage,
             hasNetworkConnection = networkConnectionStatus == NetworkStatus.Online,
             displayInvites = invites.isNotEmpty(),
+            displaySearchResults = displaySearchResults,
             eventSink = ::handleEvents
         )
     }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
@@ -26,7 +26,8 @@ import kotlinx.collections.immutable.ImmutableList
 data class RoomListState(
     val matrixUser: MatrixUser?,
     val roomList: ImmutableList<RoomListRoomSummary>,
-    val filter: String,
+    val filter: String?,
+    val filteredRoomList: ImmutableList<RoomListRoomSummary>,
     val displayVerificationPrompt: Boolean,
     val hasNetworkConnection: Boolean,
     val snackbarMessage: SnackbarMessage?,

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
@@ -31,5 +31,6 @@ data class RoomListState(
     val hasNetworkConnection: Boolean,
     val snackbarMessage: SnackbarMessage?,
     val displayInvites: Boolean,
+    val displaySearchResults: Boolean,
     val eventSink: (RoomListEvents) -> Unit
 )

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
@@ -36,6 +36,7 @@ open class RoomListStateProvider : PreviewParameterProvider<RoomListState> {
             aRoomListState().copy(snackbarMessage = SnackbarMessage(StringR.string.common_verification_complete)),
             aRoomListState().copy(hasNetworkConnection = false),
             aRoomListState().copy(displayInvites = true),
+            aRoomListState().copy(displaySearchResults = true, filter = "", filteredRoomList = persistentListOf()),
             aRoomListState().copy(displaySearchResults = true),
         )
 }
@@ -44,6 +45,7 @@ internal fun aRoomListState() = RoomListState(
     matrixUser = MatrixUser(id = UserId("@id:domain"), username = "User#1", avatarData = AvatarData("@id:domain", "U")),
     roomList = aRoomListRoomSummaryList(),
     filter = "filter",
+    filteredRoomList = aRoomListRoomSummaryList(),
     hasNetworkConnection = true,
     snackbarMessage = null,
     displayVerificationPrompt = false,

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
@@ -36,6 +36,7 @@ open class RoomListStateProvider : PreviewParameterProvider<RoomListState> {
             aRoomListState().copy(snackbarMessage = SnackbarMessage(StringR.string.common_verification_complete)),
             aRoomListState().copy(hasNetworkConnection = false),
             aRoomListState().copy(displayInvites = true),
+            aRoomListState().copy(displaySearchResults = true),
         )
 }
 
@@ -47,6 +48,7 @@ internal fun aRoomListState() = RoomListState(
     snackbarMessage = null,
     displayVerificationPrompt = false,
     displayInvites = false,
+    displaySearchResults = false,
     eventSink = {}
 )
 

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
@@ -16,10 +16,6 @@
 
 package io.element.android.features.roomlist.impl
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -46,31 +42,19 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -80,20 +64,18 @@ import io.element.android.features.networkmonitor.api.ui.ConnectivityIndicatorVi
 import io.element.android.features.roomlist.impl.components.RoomListTopBar
 import io.element.android.features.roomlist.impl.components.RoomSummaryRow
 import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
+import io.element.android.features.roomlist.impl.search.RoomListSearchResultContent
+import io.element.android.features.roomlist.impl.search.RoomListSearchResultView
 import io.element.android.libraries.designsystem.ElementTextStyles
-import io.element.android.libraries.designsystem.components.button.BackButton
-import io.element.android.libraries.designsystem.modifiers.applyIf
 import io.element.android.libraries.designsystem.preview.ElementPreviewDark
 import io.element.android.libraries.designsystem.preview.ElementPreviewLight
 import io.element.android.libraries.designsystem.theme.components.Button
 import io.element.android.libraries.designsystem.theme.components.FloatingActionButton
 import io.element.android.libraries.designsystem.theme.components.Icon
-import io.element.android.libraries.designsystem.theme.components.IconButton
 import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.theme.components.Surface
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.theme.components.TextButton
-import io.element.android.libraries.designsystem.theme.components.TopAppBar
 import io.element.android.libraries.designsystem.theme.roomListUnreadIndicator
 import io.element.android.libraries.designsystem.utils.LogCompositions
 import io.element.android.libraries.matrix.api.core.RoomId
@@ -101,7 +83,6 @@ import kotlinx.coroutines.launch
 import io.element.android.libraries.designsystem.R as DrawableR
 import io.element.android.libraries.ui.strings.R as StringR
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RoomListView(
     state: RoomListState,
@@ -124,94 +105,11 @@ fun RoomListView(
         // This overlaid view will only be visible when state.displaySearchResults is true
         RoomListSearchResultView(
             state = state,
-            onBackButtonPressed = { TODO() },
+            onRoomClicked = onRoomClicked,
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
         )
-    }
-}
-
-@Composable
-internal fun RoomListSearchResultView(
-    state: RoomListState,
-    onBackButtonPressed: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    AnimatedVisibility(
-        visible = state.displaySearchResults,
-        enter = fadeIn(),
-        exit = fadeOut(),
-    ) {
-        Column(
-            modifier = modifier
-                .applyIf(state.displaySearchResults, ifTrue = {
-                    // Disable input interaction to underlying views
-                    pointerInput(Unit) {}
-                })
-        ) {
-            if (state.displaySearchResults) {
-                RoomListSearchResultContent(state = state, onBackButtonPressed = onBackButtonPressed)
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-internal fun RoomListSearchResultContent(
-    state: RoomListState,
-    onBackButtonPressed: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val borderColor = MaterialTheme.colorScheme.tertiary
-    val strokeWidth = 1.dp
-    Scaffold (
-        topBar = {
-            TopAppBar(
-                modifier = Modifier.drawBehind {
-                    drawLine(
-                        color = borderColor,
-                        start = Offset(0f, size.height),
-                        end = Offset(size.width, size.height),
-                        strokeWidth = strokeWidth.value
-                    )
-                },
-                navigationIcon = { BackButton(onClick = onBackButtonPressed) },
-
-                title = {
-                    var value by remember { mutableStateOf(TextFieldValue()) }
-                    val focusRequester = FocusRequester()
-                    TextField(
-                        modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
-                        value = value,
-                        onValueChange = { value = it },
-                        colors = TextFieldDefaults.textFieldColors(
-                            containerColor = Color.Transparent,
-                            focusedIndicatorColor = Color.Transparent,
-                            unfocusedIndicatorColor = Color.Transparent,
-                            errorIndicatorColor = Color.Transparent,
-                            disabledIndicatorColor = Color.Transparent
-                        ),
-                        trailingIcon = {
-                            if (value.text.isNotEmpty()) {
-                                IconButton(onClick = { /*TODO*/ }) {
-                                    Icon(imageVector = Icons.Default.Close, contentDescription = stringResource(StringR.string.action_cancel))
-                                }
-                            }
-                        }
-                    )
-
-                    LaunchedEffect(state.displaySearchResults) {
-                        if (state.displaySearchResults) {
-                            focusRequester.requestFocus()
-                        }
-                    }
-                }
-            )
-        }
-    ) {
-
     }
 }
 
@@ -420,7 +318,7 @@ internal fun PreviewRequestVerificationHeaderDark() {
     }
 }
 
-private fun RoomListRoomSummary.contentType() = isPlaceholder
+internal fun RoomListRoomSummary.contentType() = isPlaceholder
 
 @Preview
 @Composable
@@ -441,6 +339,6 @@ private fun ContentToPreview(state: RoomListState) {
 @Composable
 internal fun RoomListSearchResultContentPreview() {
     ElementPreviewLight {
-        RoomListSearchResultContent(state = aRoomListState(), onBackButtonPressed = {})
+        RoomListSearchResultContent(state = aRoomListState(), onRoomClicked = {})
     }
 }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
@@ -16,6 +16,10 @@
 
 package io.element.android.features.roomlist.impl
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -42,19 +46,31 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -65,15 +81,19 @@ import io.element.android.features.roomlist.impl.components.RoomListTopBar
 import io.element.android.features.roomlist.impl.components.RoomSummaryRow
 import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
 import io.element.android.libraries.designsystem.ElementTextStyles
+import io.element.android.libraries.designsystem.components.button.BackButton
+import io.element.android.libraries.designsystem.modifiers.applyIf
 import io.element.android.libraries.designsystem.preview.ElementPreviewDark
 import io.element.android.libraries.designsystem.preview.ElementPreviewLight
 import io.element.android.libraries.designsystem.theme.components.Button
 import io.element.android.libraries.designsystem.theme.components.FloatingActionButton
 import io.element.android.libraries.designsystem.theme.components.Icon
+import io.element.android.libraries.designsystem.theme.components.IconButton
 import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.theme.components.Surface
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.theme.components.TextButton
+import io.element.android.libraries.designsystem.theme.components.TopAppBar
 import io.element.android.libraries.designsystem.theme.roomListUnreadIndicator
 import io.element.android.libraries.designsystem.utils.LogCompositions
 import io.element.android.libraries.matrix.api.core.RoomId
@@ -81,6 +101,7 @@ import kotlinx.coroutines.launch
 import io.element.android.libraries.designsystem.R as DrawableR
 import io.element.android.libraries.ui.strings.R as StringR
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RoomListView(
     state: RoomListState,
@@ -91,15 +112,107 @@ fun RoomListView(
     onCreateRoomClicked: () -> Unit = {},
     onInvitesClicked: () -> Unit = {},
 ) {
-    RoomListContent(
-        state = state,
-        modifier = modifier,
-        onRoomClicked = onRoomClicked,
-        onOpenSettings = onOpenSettings,
-        onVerifyClicked = onVerifyClicked,
-        onCreateRoomClicked = onCreateRoomClicked,
-        onInvitesClicked = onInvitesClicked,
-    )
+    Box(modifier = modifier) {
+        RoomListContent(
+            state = state,
+            onRoomClicked = onRoomClicked,
+            onOpenSettings = onOpenSettings,
+            onVerifyClicked = onVerifyClicked,
+            onCreateRoomClicked = onCreateRoomClicked,
+            onInvitesClicked = onInvitesClicked,
+        )
+        // This overlaid view will only be visible when state.displaySearchResults is true
+        RoomListSearchResultView(
+            state = state,
+            onBackButtonPressed = { TODO() },
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+        )
+    }
+}
+
+@Composable
+internal fun RoomListSearchResultView(
+    state: RoomListState,
+    onBackButtonPressed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = state.displaySearchResults,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        Column(
+            modifier = modifier
+                .applyIf(state.displaySearchResults, ifTrue = {
+                    // Disable input interaction to underlying views
+                    pointerInput(Unit) {}
+                })
+        ) {
+            if (state.displaySearchResults) {
+                RoomListSearchResultContent(state = state, onBackButtonPressed = onBackButtonPressed)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun RoomListSearchResultContent(
+    state: RoomListState,
+    onBackButtonPressed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val borderColor = MaterialTheme.colorScheme.tertiary
+    val strokeWidth = 1.dp
+    Scaffold (
+        topBar = {
+            TopAppBar(
+                modifier = Modifier.drawBehind {
+                    drawLine(
+                        color = borderColor,
+                        start = Offset(0f, size.height),
+                        end = Offset(size.width, size.height),
+                        strokeWidth = strokeWidth.value
+                    )
+                },
+                navigationIcon = { BackButton(onClick = onBackButtonPressed) },
+
+                title = {
+                    var value by remember { mutableStateOf(TextFieldValue()) }
+                    val focusRequester = FocusRequester()
+                    TextField(
+                        modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+                        value = value,
+                        onValueChange = { value = it },
+                        colors = TextFieldDefaults.textFieldColors(
+                            containerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            errorIndicatorColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent
+                        ),
+                        trailingIcon = {
+                            if (value.text.isNotEmpty()) {
+                                IconButton(onClick = { /*TODO*/ }) {
+                                    Icon(imageVector = Icons.Default.Close, contentDescription = stringResource(StringR.string.action_cancel))
+                                }
+                            }
+                        }
+                    )
+
+                    LaunchedEffect(state.displaySearchResults) {
+                        if (state.displaySearchResults) {
+                            focusRequester.requestFocus()
+                        }
+                    }
+                }
+            )
+        }
+    ) {
+
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -167,8 +280,9 @@ fun RoomListContent(
                 ConnectivityIndicatorView(isOnline = state.hasNetworkConnection)
                 RoomListTopBar(
                     matrixUser = state.matrixUser,
-                    filter = state.filter,
+                    areSearchResultsDisplayed = state.displaySearchResults,
                     onFilterChanged = { state.eventSink(RoomListEvents.UpdateFilter(it)) },
+                    onToggleSearch = { state.eventSink(RoomListEvents.ToggleSearchResults) },
                     onOpenSettings = onOpenSettings,
                     scrollBehavior = scrollBehavior,
                 )
@@ -321,4 +435,12 @@ internal fun RoomListViewDarkPreview(@PreviewParameter(RoomListStateProvider::cl
 @Composable
 private fun ContentToPreview(state: RoomListState) {
     RoomListView(state)
+}
+
+@Preview
+@Composable
+internal fun RoomListSearchResultContentPreview() {
+    ElementPreviewLight {
+        RoomListSearchResultContent(state = aRoomListState(), onBackButtonPressed = {})
+    }
 }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
@@ -93,23 +93,26 @@ fun RoomListView(
     onCreateRoomClicked: () -> Unit = {},
     onInvitesClicked: () -> Unit = {},
 ) {
-    Box(modifier = modifier) {
-        RoomListContent(
-            state = state,
-            onRoomClicked = onRoomClicked,
-            onOpenSettings = onOpenSettings,
-            onVerifyClicked = onVerifyClicked,
-            onCreateRoomClicked = onCreateRoomClicked,
-            onInvitesClicked = onInvitesClicked,
-        )
-        // This overlaid view will only be visible when state.displaySearchResults is true
-        RoomListSearchResultView(
-            state = state,
-            onRoomClicked = onRoomClicked,
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-        )
+    Column(modifier = modifier) {
+        ConnectivityIndicatorView(isOnline = state.hasNetworkConnection)
+        Box {
+            RoomListContent(
+                state = state,
+                onRoomClicked = onRoomClicked,
+                onOpenSettings = onOpenSettings,
+                onVerifyClicked = onVerifyClicked,
+                onCreateRoomClicked = onCreateRoomClicked,
+                onInvitesClicked = onInvitesClicked,
+            )
+            // This overlaid view will only be visible when state.displaySearchResults is true
+            RoomListSearchResultView(
+                state = state,
+                onRoomClicked = onRoomClicked,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+            )
+        }
     }
 }
 
@@ -174,17 +177,14 @@ fun RoomListContent(
     Scaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            Column {
-                ConnectivityIndicatorView(isOnline = state.hasNetworkConnection)
-                RoomListTopBar(
-                    matrixUser = state.matrixUser,
-                    areSearchResultsDisplayed = state.displaySearchResults,
-                    onFilterChanged = { state.eventSink(RoomListEvents.UpdateFilter(it)) },
-                    onToggleSearch = { state.eventSink(RoomListEvents.ToggleSearchResults) },
-                    onOpenSettings = onOpenSettings,
-                    scrollBehavior = scrollBehavior,
-                )
-            }
+            RoomListTopBar(
+                matrixUser = state.matrixUser,
+                areSearchResultsDisplayed = state.displaySearchResults,
+                onFilterChanged = { state.eventSink(RoomListEvents.UpdateFilter(it)) },
+                onToggleSearch = { state.eventSink(RoomListEvents.ToggleSearchResults) },
+                onOpenSettings = onOpenSettings,
+                scrollBehavior = scrollBehavior,
+            )
         },
         content = { padding ->
             Column(

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
@@ -35,9 +34,7 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -66,11 +63,13 @@ import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.ui.model.MatrixUser
 import io.element.android.libraries.ui.strings.R as StringR
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RoomListTopBar(
     matrixUser: MatrixUser?,
-    filter: String,
+    areSearchResultsDisplayed: Boolean,
     onFilterChanged: (String) -> Unit,
+    onToggleSearch: () -> Unit,
     onOpenSettings: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
     modifier: Modifier = Modifier,
@@ -79,36 +78,23 @@ fun RoomListTopBar(
         tag = "RoomListScreen",
         msg = "TopBar"
     )
-    var searchWidgetStateIsOpened by rememberSaveable { mutableStateOf(false) }
 
     fun closeFilter() {
         onFilterChanged("")
-        searchWidgetStateIsOpened = false
     }
 
-    BackHandler(enabled = searchWidgetStateIsOpened) {
+    BackHandler(enabled = areSearchResultsDisplayed) {
         closeFilter()
+        onToggleSearch()
     }
 
-    if (searchWidgetStateIsOpened) {
-        SearchRoomListTopBar(
-            text = filter,
-            onFilterChanged = onFilterChanged,
-            onCloseClicked = ::closeFilter,
-            scrollBehavior = scrollBehavior,
-            modifier = modifier,
-        )
-    } else {
-        DefaultRoomListTopBar(
-            matrixUser = matrixUser,
-            onOpenSettings = onOpenSettings,
-            onSearchClicked = {
-                searchWidgetStateIsOpened = true
-            },
-            scrollBehavior = scrollBehavior,
-            modifier = modifier,
-        )
-    }
+    DefaultRoomListTopBar(
+        matrixUser = matrixUser,
+        onOpenSettings = onOpenSettings,
+        onSearchClicked = onToggleSearch,
+        scrollBehavior = scrollBehavior,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -216,7 +202,7 @@ private fun DefaultRoomListTopBar(
         },
         navigationIcon = {
             if (matrixUser != null) {
-                IconButton(onClick = {}) {
+                IconButton(onClick = onOpenSettings) {
                     Avatar(matrixUser.avatarData)
                 }
             }
@@ -226,11 +212,6 @@ private fun DefaultRoomListTopBar(
                 onClick = onSearchClicked
             ) {
                 Icon(Icons.Default.Search, contentDescription = "search")
-            }
-            IconButton(
-                onClick = onOpenSettings
-            ) {
-                Icon(Icons.Default.Settings, contentDescription = "Settings")
             }
         },
         scrollBehavior = scrollBehavior,

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
@@ -20,44 +20,28 @@ package io.element.android.features.roomlist.impl.components
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.ContentAlpha
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.element.android.features.roomlist.impl.R
 import io.element.android.libraries.designsystem.components.avatar.Avatar
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
-import io.element.android.libraries.designsystem.components.form.textFieldState
 import io.element.android.libraries.designsystem.preview.ElementPreviewDark
 import io.element.android.libraries.designsystem.preview.ElementPreviewLight
 import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.IconButton
 import io.element.android.libraries.designsystem.theme.components.MediumTopAppBar
 import io.element.android.libraries.designsystem.theme.components.Text
-import io.element.android.libraries.designsystem.theme.components.TextField
-import io.element.android.libraries.designsystem.theme.components.TopAppBar
 import io.element.android.libraries.designsystem.utils.LogCompositions
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.ui.model.MatrixUser
@@ -97,92 +81,7 @@ fun RoomListTopBar(
     )
 }
 
-@Composable
-fun SearchRoomListTopBar(
-    text: String,
-    scrollBehavior: TopAppBarScrollBehavior,
-    modifier: Modifier = Modifier,
-    onFilterChanged: (String) -> Unit = {},
-    onCloseClicked: () -> Unit = {},
-) {
-    var filterState by textFieldState(stateValue = text)
-    val focusRequester = remember { FocusRequester() }
-    TopAppBar(
-        modifier = modifier
-            .nestedScroll(scrollBehavior.nestedScrollConnection),
-        title = {
-            TextField(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(focusRequester),
-                value = filterState,
-                textStyle = TextStyle(
-                    fontSize = 17.sp
-                ),
-                onValueChange = {
-                    filterState = it
-                    onFilterChanged(it)
-                },
-                placeholder = {
-                    Text(
-                        text = stringResource(id = StringR.string.action_search),
-                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = ContentAlpha.medium)
-                    )
-                },
-                singleLine = true,
-                trailingIcon = {
-                    if (text.isNotEmpty()) {
-                        IconButton(
-                            onClick = {
-                                onFilterChanged("")
-                            }
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Close,
-                                contentDescription = "clear",
-                                tint = MaterialTheme.colorScheme.onBackground
-                            )
-                        }
-                    }
-                },
-            )
-        },
-        navigationIcon = {
-            IconButton(
-                onClick = {
-                    onCloseClicked()
-                }
-            ) {
-                Icon(
-                    imageVector = Icons.Default.ArrowBack,
-                    contentDescription = "close",
-                    tint = MaterialTheme.colorScheme.onBackground
-                )
-            }
-        },
-        windowInsets = WindowInsets(0.dp)
-    )
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
-}
-
-@Preview
-@Composable
-internal fun SearchRoomListTopBarLightPreview() = ElementPreviewLight { SearchRoomListTopBarPreview() }
-
-@Preview
-@Composable
-internal fun SearchRoomListTopBarDarkPreview() = ElementPreviewDark { SearchRoomListTopBarPreview() }
-
-@Composable
-private fun SearchRoomListTopBarPreview() {
-    SearchRoomListTopBar(
-        text = "Hello",
-        scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState()),
-    )
-}
-
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DefaultRoomListTopBar(
     matrixUser: MatrixUser?,
@@ -203,7 +102,7 @@ private fun DefaultRoomListTopBar(
         navigationIcon = {
             if (matrixUser != null) {
                 IconButton(onClick = onOpenSettings) {
-                    Avatar(matrixUser.avatarData)
+                    Avatar(matrixUser.avatarData, contentDescription = stringResource(StringR.string.common_settings))
                 }
             }
         },
@@ -211,7 +110,7 @@ private fun DefaultRoomListTopBar(
             IconButton(
                 onClick = onSearchClicked
             ) {
-                Icon(Icons.Default.Search, contentDescription = "search")
+                Icon(Icons.Default.Search, contentDescription = stringResource(StringR.string.action_search))
             }
         },
         scrollBehavior = scrollBehavior,
@@ -227,6 +126,7 @@ internal fun DefaultRoomListTopBarLightPreview() = ElementPreviewLight { Default
 @Composable
 internal fun DefaultRoomListTopBarDarkPreview() = ElementPreviewDark { DefaultRoomListTopBarPreview() }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DefaultRoomListTopBarPreview() {
     DefaultRoomListTopBar(

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearch.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearch.kt
@@ -20,6 +20,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -31,6 +32,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -59,6 +61,7 @@ import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.IconButton
 import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.theme.components.TopAppBar
+import io.element.android.libraries.designsystem.utils.copy
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.ui.strings.R
 
@@ -120,7 +123,9 @@ internal fun RoomListSearchResultContent(
                     val filter = state.filter.orEmpty()
                     val focusRequester = FocusRequester()
                     TextField(
-                        modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester),
                         value = filter,
                         onValueChange = { state.eventSink(RoomListEvents.UpdateFilter(it)) },
                         colors = TextFieldDefaults.textFieldColors(
@@ -149,7 +154,8 @@ internal fun RoomListSearchResultContent(
                             focusRequester.requestFocus()
                         }
                     }
-                }
+                },
+                windowInsets = TopAppBarDefaults.windowInsets.copy(top = 0)
             )
         }
     ) { padding ->
@@ -178,7 +184,9 @@ internal fun RoomListSearchResultContent(
                 .padding(padding)
         ) {
             LazyColumn(
-                modifier = Modifier.weight(1f).nestedScroll(nestedScrollConnection),
+                modifier = Modifier
+                    .weight(1f)
+                    .nestedScroll(nestedScrollConnection),
                 state = lazyListState,
             ) {
                 items(

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearch.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearch.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.roomlist.impl.search
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.dp
+import io.element.android.features.roomlist.impl.RoomListEvents
+import io.element.android.features.roomlist.impl.RoomListState
+import io.element.android.features.roomlist.impl.components.RoomSummaryRow
+import io.element.android.features.roomlist.impl.contentType
+import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
+import io.element.android.libraries.designsystem.components.button.BackButton
+import io.element.android.libraries.designsystem.modifiers.applyIf
+import io.element.android.libraries.designsystem.theme.components.Icon
+import io.element.android.libraries.designsystem.theme.components.IconButton
+import io.element.android.libraries.designsystem.theme.components.Scaffold
+import io.element.android.libraries.designsystem.theme.components.TopAppBar
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.ui.strings.R
+
+@Composable
+internal fun RoomListSearchResultView(
+    state: RoomListState,
+    onRoomClicked: (RoomId) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = state.displaySearchResults,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        Column(
+            modifier = modifier
+                .applyIf(state.displaySearchResults, ifTrue = {
+                    // Disable input interaction to underlying views
+                    pointerInput(Unit) {}
+                })
+        ) {
+            if (state.displaySearchResults) {
+                RoomListSearchResultContent(state = state, onRoomClicked = onRoomClicked)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun RoomListSearchResultContent(
+    state: RoomListState,
+    onRoomClicked: (RoomId) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val borderColor = MaterialTheme.colorScheme.tertiary
+    val strokeWidth = 1.dp
+    fun onBackButtonPressed() {
+        state.eventSink(RoomListEvents.ToggleSearchResults)
+    }
+    fun onRoomClicked(room: RoomListRoomSummary) {
+        if (room.roomId == null) return
+        onRoomClicked(room.roomId)
+    }
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                modifier = Modifier.drawBehind {
+                    drawLine(
+                        color = borderColor,
+                        start = Offset(0f, size.height),
+                        end = Offset(size.width, size.height),
+                        strokeWidth = strokeWidth.value
+                    )
+                },
+                navigationIcon = { BackButton(onClick = ::onBackButtonPressed) },
+                title = {
+                    val filter = state.filter.orEmpty()
+                    val focusRequester = FocusRequester()
+                    TextField(
+                        modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+                        value = filter,
+                        onValueChange = { state.eventSink(RoomListEvents.UpdateFilter(it)) },
+                        colors = TextFieldDefaults.textFieldColors(
+                            containerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            errorIndicatorColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent
+                        ),
+                        trailingIcon = {
+                            if (filter.isNotEmpty()) {
+                                IconButton(onClick = {
+                                    state.eventSink(RoomListEvents.UpdateFilter(""))
+                                }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Close,
+                                        contentDescription = stringResource(R.string.action_cancel)
+                                    )
+                                }
+                            }
+                        }
+                    )
+
+                    LaunchedEffect(state.displaySearchResults) {
+                        if (state.displaySearchResults) {
+                            focusRequester.requestFocus()
+                        }
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        val lazyListState = rememberLazyListState()
+        val visibleRange by remember {
+            derivedStateOf {
+                val layoutInfo = lazyListState.layoutInfo
+                val firstItemIndex = layoutInfo.visibleItemsInfo.firstOrNull()?.index ?: 0
+                val size = layoutInfo.visibleItemsInfo.size
+                firstItemIndex until firstItemIndex + size
+            }
+        }
+        val nestedScrollConnection = remember {
+            object : NestedScrollConnection {
+                override suspend fun onPostFling(
+                    consumed: Velocity,
+                    available: Velocity
+                ): Velocity {
+                    state.eventSink(RoomListEvents.UpdateVisibleRange(visibleRange))
+                    return super.onPostFling(consumed, available)
+                }
+            }
+        }
+        Column(
+            modifier = Modifier
+                .padding(padding)
+        ) {
+            LazyColumn(
+                modifier = Modifier.weight(1f).nestedScroll(nestedScrollConnection),
+                state = lazyListState,
+            ) {
+                items(
+                    items = state.filteredRoomList,
+                    contentType = { room -> room.contentType() },
+                ) { room ->
+                    RoomSummaryRow(room = room, onClick = ::onRoomClicked)
+                }
+            }
+        }
+    }
+}

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTests.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTests.kt
@@ -112,6 +112,8 @@ class RoomListPresenterTests {
             withUserState.eventSink.invoke(RoomListEvents.UpdateFilter("t"))
             val withFilterState = awaitItem()
             Truth.assertThat(withFilterState.filter).isEqualTo("t")
+
+            cancelAndIgnoreRemainingEvents()
         }
     }
 
@@ -168,17 +170,18 @@ class RoomListPresenterTests {
             val loadedState = awaitItem()
             // Test filtering with result
             loadedState.eventSink.invoke(RoomListEvents.UpdateFilter(A_ROOM_NAME.substring(0, 3)))
+            skipItems(1) // Filter update
             val withNotFilteredRoomState = awaitItem()
             Truth.assertThat(withNotFilteredRoomState.filter).isEqualTo(A_ROOM_NAME.substring(0, 3))
-            Truth.assertThat(withNotFilteredRoomState.roomList.size).isEqualTo(1)
-            Truth.assertThat(withNotFilteredRoomState.roomList.first())
+            Truth.assertThat(withNotFilteredRoomState.filteredRoomList.size).isEqualTo(1)
+            Truth.assertThat(withNotFilteredRoomState.filteredRoomList.first())
                 .isEqualTo(aRoomListRoomSummary)
             // Test filtering without result
             withNotFilteredRoomState.eventSink.invoke(RoomListEvents.UpdateFilter("tada"))
             skipItems(1) // Filter update
             val withFilteredRoomState = awaitItem()
             Truth.assertThat(withFilteredRoomState.filter).isEqualTo("tada")
-            Truth.assertThat(withFilteredRoomState.roomList).isEmpty()
+            Truth.assertThat(withFilteredRoomState.filteredRoomList).isEmpty()
         }
     }
 

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/Avatar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/Avatar.kt
@@ -41,7 +41,11 @@ import io.element.android.libraries.designsystem.theme.components.Text
 import timber.log.Timber
 
 @Composable
-fun Avatar(avatarData: AvatarData, modifier: Modifier = Modifier) {
+fun Avatar(
+    avatarData: AvatarData,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
     val commonModifier = modifier
         .size(avatarData.size.dp)
         .clip(CircleShape)
@@ -54,6 +58,7 @@ fun Avatar(avatarData: AvatarData, modifier: Modifier = Modifier) {
         ImageAvatar(
             avatarData = avatarData,
             modifier = commonModifier,
+            contentDescription = contentDescription,
         )
     }
 }
@@ -62,13 +67,14 @@ fun Avatar(avatarData: AvatarData, modifier: Modifier = Modifier) {
 private fun ImageAvatar(
     avatarData: AvatarData,
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
 ) {
     AsyncImage(
         model = avatarData,
         onError = {
             Timber.e("TAG", "Error $it\n${it.result}", it.result.throwable)
         },
-        contentDescription = null,
+        contentDescription = contentDescription,
         contentScale = ContentScale.Crop,
         placeholder = debugPlaceholderAvatar(),
         modifier = modifier
@@ -89,7 +95,7 @@ private fun InitialsAvatar(
         end = Offset(100f, 0f)
     )
     Box(
-        modifier.background(brush = initialsGradient)
+        modifier.background(brush = initialsGradient),
     ) {
         Text(
             modifier = Modifier.align(Alignment.Center),

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/ApplyIf.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/ApplyIf.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.designsystem.modifiers
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+
+/**
+ * Applies the [ifTrue] modifier when the [condition] is true, [ifFalse] otherwise.
+ */
+fun Modifier.applyIf(
+    condition: Boolean,
+    ifTrue: @Composable Modifier.() -> Modifier,
+    ifFalse: @Composable (Modifier.() -> Modifier)? = null
+): Modifier =
+    composed {
+        when {
+            condition -> then(ifTrue(Modifier))
+            ifFalse != null -> then(ifFalse(Modifier))
+            else -> this
+        }
+    }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/ApplyIf.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/ApplyIf.kt
@@ -16,19 +16,27 @@
 
 package io.element.android.libraries.designsystem.modifiers
 
+import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.platform.debugInspectorInfo
 
 /**
  * Applies the [ifTrue] modifier when the [condition] is true, [ifFalse] otherwise.
  */
+@SuppressLint("UnnecessaryComposedModifier") // It's actually necessary due to the `@Composable` lambdas
 fun Modifier.applyIf(
     condition: Boolean,
     ifTrue: @Composable Modifier.() -> Modifier,
     ifFalse: @Composable (Modifier.() -> Modifier)? = null
 ): Modifier =
-    composed {
+    composed(
+        inspectorInfo = debugInspectorInfo {
+            name = "applyIf"
+            value = condition
+        }
+    ) {
         when {
             condition -> then(ifTrue(Modifier))
             ifFalse != null -> then(ifFalse(Modifier))

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/CircularReveal.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/CircularReveal.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.designsystem.modifiers
+
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.platform.debugInspectorInfo
+import kotlin.math.sqrt
+
+// Note: these modifiers come from https://gist.github.com/darvld/eb3844474baf2f3fc6d3ab44a4b4b5f8
+
+/**
+ *  A modifier that clips the composable content using an animated circle. The circle will
+ *  expand/shrink with an animation whenever [visible] changes.
+ *
+ *  For more fine-grained control over the transition, see this method's overload, which allows passing
+ *  a [State] object to control the progress of the reveal animation.
+ *
+ *  By default, the circle is centered in the content, but custom positions may be specified using
+ *  [revealFrom]. Specified offsets should be between 0 (left/top) and 1 (right/bottom).*/
+fun Modifier.circularReveal(
+    visible: Boolean,
+    showScrim: Boolean = false,
+    revealFrom: Offset = Offset(0.5f, 0.5f),
+): Modifier = composed(
+    factory = {
+        val factor = updateTransition(visible, label = "Visibility")
+            .animateFloat(label = "revealFactor") { if (it) 1f else 0f }
+
+        circularReveal(factor, showScrim, revealFrom)
+    },
+    inspectorInfo = debugInspectorInfo {
+        name = "circularReveal"
+        properties["visible"] = visible
+        properties["revealFrom"] = revealFrom
+    }
+)
+
+/**
+ * A modifier that clips the composable content using a circular shape. The radius of the circle
+ * will be determined by the [transitionProgress].
+ *
+ * The values of the progress should be between 0 and 1.
+ *
+ * By default, the circle is centered in the content, but custom positions may be specified using
+ *  [revealFrom]. Specified offsets should be between 0 (left/top) and 1 (right/bottom).
+ *  */
+fun Modifier.circularReveal(
+    transitionProgress: State<Float>,
+    showScrim: Boolean = false,
+    revealFrom: Offset = Offset(0.5f, 0.5f)
+): Modifier {
+    return drawWithCache {
+        val path = Path()
+        val center = revealFrom.mapTo(size)
+        val radius = calculateRadius(revealFrom, size)
+        val scrimColor = if (showScrim)
+            Color.Gray
+        else
+            Color.Transparent
+
+        path.addOval(Rect(center, radius * transitionProgress.value))
+
+        onDrawWithContent {
+            if (showScrim) {
+                drawRect(scrimColor, alpha = transitionProgress.value * 0.75f)
+            }
+            clipPath(path) { this@onDrawWithContent.drawContent() }
+        }
+    }
+}
+
+private fun Offset.mapTo(size: Size): Offset {
+    return Offset(x * size.width, y * size.height)
+}
+
+private fun calculateRadius(normalizedOrigin: Offset, size: Size) = with(normalizedOrigin) {
+    val x = (if (x > 0.5f) x else 1 - x) * size.width
+    val y = (if (y > 0.5f) y else 1 - y) * size.height
+
+    sqrt(x * x + y * y)
+}

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/WindowInsetsExtension.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/WindowInsetsExtension.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.designsystem.utils
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+
+@Composable
+fun WindowInsets.copy(
+    top: Int? = null,
+    right: Int? = null,
+    bottom: Int? = null,
+    left: Int? = null
+): WindowInsets {
+    val density = LocalDensity.current
+    val direction = LocalLayoutDirection.current
+    return WindowInsets(
+        top = top ?: this.getTop(density),
+        right = right ?: this.getRight(density, direction),
+        bottom = bottom ?: this.getBottom(density),
+        left = left ?: this.getLeft(density, direction)
+    )
+}

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl.components_null_DefaultGroup_DefaultRoomListTopBarDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl.components_null_DefaultGroup_DefaultRoomListTopBarDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bca09418758a20493dae2e73a747449af8a448ad3a3cc4c5aae2e08a425f3fb
-size 13464
+oid sha256:b5f2b24a19ca49b3e6e34ccd65d2bdba72d0384104931bda92e191959d58c5c3
+size 12697

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl.components_null_DefaultGroup_DefaultRoomListTopBarLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl.components_null_DefaultGroup_DefaultRoomListTopBarLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e50325c75193e47958862ea9cb515d7c84d2c47a00b01256fc244319780c107f
-size 12425
+oid sha256:c4fa32eb24a0cc51b9b19c6f24a7d3d59aae65f1f30a43b1a6d70b3ed3e2154d
+size 11716

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListSearchResultContentPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListSearchResultContentPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97b11203623c0c98da88dfedf85cb80d1f35cc55da570e12061b1385691bf1f0
+size 27758

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_0,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0fc272268179409483fc5fad89aa00714a6811c63e478b5c696d4ab0338ce6bf
-size 37781
+oid sha256:3cdb131c68de1fce5a3319151e39148e9f3a71c7bc3984e89ec0a80abf0f7288
+size 37044

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_1,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d729c75d73d1837b365c8332b6e4203cb2492f6c5c4af06741a4bd2e818daebb
-size 60667
+oid sha256:8b265978c4db7b266fd07d56364eccafba1cd765ed9bf6d5a03b1584e173ba6a
+size 59936

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_2,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0fc272268179409483fc5fad89aa00714a6811c63e478b5c696d4ab0338ce6bf
-size 37781
+oid sha256:3cdb131c68de1fce5a3319151e39148e9f3a71c7bc3984e89ec0a80abf0f7288
+size 37044

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_3,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56a253a7981823ca0fc7b653f9e83d29d1f259fea43ca4cee5760fa863306f2c
-size 39847
+oid sha256:ccf989dac7fad3cc70443d96e1ebd519463a6559ed0795ae2a1ffbaf91bdfe7c
+size 39092

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_4,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b1222e1ef2d0739caa410540bf74fea681ef2e05bb04b976e50f1fe5256d613
-size 39762
+oid sha256:c2a23141c6cc8aa6e7e5f0757bda4d1117bf7f752412ccc4649ea560113b3e3f
+size 39030

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_5,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9095546c30bb5bc9800c852456fa9cd82d14e873a5e1488d29496af088e951da
+size 4882

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewDarkPreview_0_null_6,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cfe321535e1ce223a0460435123dc59e74c436bdd8696cf4bdb2169f511832b
+size 28541

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_0,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43b69859fa3ee38d2b7f7415b87738db65dc6dac3d2fabddc1f1346b0b64932b
-size 37329
+oid sha256:a2a261b30866af95b856ee1e7d6ac2cbe2d638cf80277645f361b043d2f94e60
+size 36658

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_1,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f61d4fc4d5af166e1761f004e7d80934eef24a582c96c590c769ed1fb13041a4
-size 59489
+oid sha256:0cdd1fad4b3db78fb8599785334366e3bfbaf5dead7990f396f8752862ab9e98
+size 58987

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_2,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43b69859fa3ee38d2b7f7415b87738db65dc6dac3d2fabddc1f1346b0b64932b
-size 37329
+oid sha256:a2a261b30866af95b856ee1e7d6ac2cbe2d638cf80277645f361b043d2f94e60
+size 36658

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_3,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1bf9529823b4e04261b1528b2309c549f1d3aad80c542059f11c1b26a2979b04
-size 39359
+oid sha256:1ba3d8a5cfbd102dc6df8f511eb14663170a6d550ee5e65702bc1f3fce3efd14
+size 38657

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_4,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ebb15a58e5d3497b2819f5a6b6fde88962f01cc2ae02d4b8cda0e45e1dde677f
-size 39314
+oid sha256:d427b479f9eb6227bb92aecd997bab97a735ef85dd279a575d777e754effd258
+size 38639

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_5,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d463ab6d045cc310973c5ff900cf4d9ae04e93cb1c7eac3f9b2aa0ea9b827cee
+size 4815

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl_null_DefaultGroup_RoomListViewLightPreview_0_null_6,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97b11203623c0c98da88dfedf85cb80d1f35cc55da570e12061b1385691bf1f0
+size 27758


### PR DESCRIPTION
## Changes

* The settings screen can be opened by tapping on the user avatar now, the 'settings' menu item has been removed.
* The search UI inside the room list has been extracted to a new component that is overlayed on top of the screen, similar to how `SearchView` works, although I couldn't use SearchView because we're entering the search UI from a menu item.

## Why

Implements #354 .

## Tests

1. Open settings from your user's avatar in the room list.
2. Use the search feature in the room list.