### PR TITLE
Fix: Maestro tests fail when using settings

### DIFF
--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -16,7 +16,7 @@ jobs:
   maestro-cloud:
     name: Maestro test suite
     runs-on: ubuntu-latest
-    if: github.event.review.state == 'approved'
+    if: github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
     # Allow one per PR.

--- a/.maestro/tests/settings/settings.yaml
+++ b/.maestro/tests/settings/settings.yaml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 ---
-- tapOn: "Settings"
+- tapOn:
+    id: "home_screen-settings"
 - assertVisible: "Rageshake to report bug"
 - takeScreenshot: build/maestro/600-Settings
 - tapOn:

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
@@ -45,6 +45,8 @@ import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.utils.LogCompositions
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.ui.model.MatrixUser
+import io.element.android.libraries.testtags.TestTags
+import io.element.android.libraries.testtags.testTag
 import io.element.android.libraries.ui.strings.R as StringR
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -101,14 +103,17 @@ private fun DefaultRoomListTopBar(
         },
         navigationIcon = {
             if (matrixUser != null) {
-                IconButton(onClick = onOpenSettings) {
+                IconButton(
+                    modifier = Modifier.testTag(TestTags.homeScreenSettings),
+                    onClick = onOpenSettings
+                ) {
                     Avatar(matrixUser.avatarData, contentDescription = stringResource(StringR.string.common_settings))
                 }
             }
         },
         actions = {
             IconButton(
-                onClick = onSearchClicked
+                onClick = onSearchClicked,
             ) {
                 Icon(Icons.Default.Search, contentDescription = stringResource(StringR.string.action_search))
             }

--- a/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
+++ b/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
@@ -38,6 +38,11 @@ object TestTags {
      */
     val changeServerServer = TestTag("change_server-server")
     val changeServerContinue = TestTag("change_server-continue")
+
+    /**
+     * Room list / Home screen.
+     */
+    val homeScreenSettings = TestTag("home_screen-settings")
 }
 
 


### PR DESCRIPTION
For some reason, just asking Maestro to open 'Settings' based on the icon's content description seemed to work locally for me, but it's not working in the CI.

I also added some code that should allow us to trigger Maestro runs manually to debug issues like this more easily.