### PR TITLE
Fix `NotificationData?.orDefault` using an invalid UserId

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
@@ -119,7 +119,7 @@ private fun NotificationData?.orDefault(roomId: RoomId, eventId: EventId): Notif
                 isRemote = false,
                 localSendState = null,
                 reactions = emptyList(),
-                sender = UserId(""),
+                sender = UserId("@user:domain"),
                 senderProfile = ProfileTimelineDetails.Unavailable,
                 timestamp = System.currentTimeMillis(),
                 content = MessageContent(


### PR DESCRIPTION
Push notifications were broken because of this issue in develop.