### PR TITLE
Search for users to start a new DM.

### DIFF
--- a/changelog.d/95.feature
+++ b/changelog.d/95.feature
@@ -1,0 +1,1 @@
+[Create and join rooms] Search for users to start a DM

--- a/docs/_developer_onboarding.md
+++ b/docs/_developer_onboarding.md
@@ -426,6 +426,7 @@ Rageshake can be very useful to get logs from a release version of the applicati
 - When this is possible, prefer using `sealed interface` instead of `sealed class`;
 - When writing temporary code, using the string "DO NOT COMMIT" in a comment can help to avoid committing things by mistake. If committed and pushed, the CI
   will detect this String and will warn the user about it. (TODO Not supported yet!)
+- Very occasionally the gradle cache misbehaves and causes problems with Dagger. Try building with `--no-build-cache` if Dagger isn't behaving how you expect.
 
 ## Happy coding!
 

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/AllMatrixUsersDataSource.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/AllMatrixUsersDataSource.kt
@@ -24,16 +24,16 @@ import io.element.android.libraries.matrix.api.usersearch.MatrixUserProfile
 import io.element.android.libraries.matrix.ui.model.MatrixUser
 import javax.inject.Inject
 
-// TODO this is empty as we currently don't have an endpoint to perform user search
 class AllMatrixUsersDataSource @Inject constructor(
     private val client: MatrixClient
 ) : UserListDataSource {
     override suspend fun search(query: String): List<MatrixUser> {
-        val res = client.searchUsers(query, SEARCH_RESULTS)
+        val res = client.searchUsers(query, MAX_SEARCH_RESULTS)
         return res.getOrNull()?.results?.map(::toMatrixUser).orEmpty()
     }
 
     override suspend fun getProfile(userId: UserId): MatrixUser? {
+        // TODO: hook up to matrix client
         return null
     }
 
@@ -48,6 +48,6 @@ class AllMatrixUsersDataSource @Inject constructor(
     )
 
     companion object {
-        private const val SEARCH_RESULTS = 5L
+        private const val MAX_SEARCH_RESULTS = 5L
     }
 }

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/AllMatrixUsersDataSource.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/AllMatrixUsersDataSource.kt
@@ -33,7 +33,7 @@ class AllMatrixUsersDataSource @Inject constructor(
     }
 
     override suspend fun getProfile(userId: UserId): MatrixUser? {
-        // TODO: hook up to matrix client
+        // TODO hook up to matrix client
         return null
     }
 

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/AllMatrixUsersDataSource.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/AllMatrixUsersDataSource.kt
@@ -17,17 +17,37 @@
 package io.element.android.features.createroom.impl
 
 import io.element.android.features.userlist.api.UserListDataSource
+import io.element.android.libraries.designsystem.components.avatar.AvatarData
+import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.usersearch.MatrixUserProfile
 import io.element.android.libraries.matrix.ui.model.MatrixUser
 import javax.inject.Inject
 
 // TODO this is empty as we currently don't have an endpoint to perform user search
-class AllMatrixUsersDataSource @Inject constructor() : UserListDataSource {
+class AllMatrixUsersDataSource @Inject constructor(
+    private val client: MatrixClient
+) : UserListDataSource {
     override suspend fun search(query: String): List<MatrixUser> {
-        return emptyList()
+        val res = client.searchUsers(query, SEARCH_RESULTS)
+        return res.getOrNull()?.results?.map(::toMatrixUser).orEmpty()
     }
 
     override suspend fun getProfile(userId: UserId): MatrixUser? {
         return null
+    }
+
+    private fun toMatrixUser(matrixUserProfile: MatrixUserProfile) = MatrixUser(
+        id = matrixUserProfile.userId,
+        username = matrixUserProfile.displayName,
+        avatarData = AvatarData(
+            id = matrixUserProfile.userId.value,
+            name = matrixUserProfile.displayName,
+            url = matrixUserProfile.avatarUrl,
+        )
+    )
+
+    companion object {
+        private const val SEARCH_RESULTS = 5L
     }
 }

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/addpeople/AddPeopleUserListStateProvider.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/addpeople/AddPeopleUserListStateProvider.kt
@@ -19,6 +19,7 @@ package io.element.android.features.createroom.impl.addpeople
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.features.userlist.api.SelectionMode
 import io.element.android.features.userlist.api.UserListState
+import io.element.android.features.userlist.api.UserSearchResultState
 import io.element.android.features.userlist.api.aListOfSelectedUsers
 import io.element.android.features.userlist.api.aUserListState
 import io.element.android.libraries.matrix.ui.components.aMatrixUserList
@@ -29,13 +30,13 @@ open class AddPeopleUserListStateProvider : PreviewParameterProvider<UserListSta
         get() = sequenceOf(
             aUserListState(),
             aUserListState().copy(
-                searchResults = aMatrixUserList().toImmutableList(),
+                searchResults = UserSearchResultState.Results(aMatrixUserList().toImmutableList()),
                 selectedUsers = aListOfSelectedUsers(),
                 isSearchActive = false,
                 selectionMode = SelectionMode.Multiple,
             ),
             aUserListState().copy(
-                searchResults = aMatrixUserList().toImmutableList(),
+                searchResults = UserSearchResultState.Results(aMatrixUserList().toImmutableList()),
                 selectedUsers = aListOfSelectedUsers(),
                 isSearchActive = true,
                 selectionMode = SelectionMode.Multiple,

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootPresenter.kt
@@ -46,7 +46,11 @@ class CreateRoomRootPresenter @Inject constructor(
 
     private val presenter by lazy {
         presenterFactory.create(
-            UserListPresenterArgs(selectionMode = SelectionMode.Single),
+            UserListPresenterArgs(
+                selectionMode = SelectionMode.Single,
+                minimumSearchLength = 3,
+                searchDebouncePeriodMillis = 500,
+            ),
             userListDataSource,
             userListDataStore,
         )

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootStateProvider.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootStateProvider.kt
@@ -17,6 +17,7 @@
 package io.element.android.features.createroom.impl.root
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import io.element.android.features.userlist.api.UserSearchResultState
 import io.element.android.features.userlist.api.aUserListState
 import io.element.android.libraries.architecture.Async
 import io.element.android.libraries.matrix.ui.components.aMatrixUser
@@ -31,7 +32,7 @@ open class CreateRoomRootStateProvider : PreviewParameterProvider<CreateRoomRoot
                 userListState = aMatrixUser().let {
                     aUserListState().copy(
                         searchQuery = it.id.value,
-                        searchResults = persistentListOf(it),
+                        searchResults = UserSearchResultState.Results(persistentListOf(it)),
                         selectedUsers = persistentListOf(it),
                         isSearchActive = true,
                     )
@@ -42,7 +43,7 @@ open class CreateRoomRootStateProvider : PreviewParameterProvider<CreateRoomRoot
                 userListState = aMatrixUser().let {
                     aUserListState().copy(
                         searchQuery = it.id.value,
-                        searchResults = persistentListOf(it),
+                        searchResults = UserSearchResultState.Results(persistentListOf(it)),
                         selectedUsers = persistentListOf(it),
                         isSearchActive = true,
                     )

--- a/features/createroom/impl/src/test/kotlin/io/element/android/features/createroom/impl/AllMatrixUsersDataSourceTest.kt
+++ b/features/createroom/impl/src/test/kotlin/io/element/android/features/createroom/impl/AllMatrixUsersDataSourceTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.createroom.impl
+
+import com.google.common.truth.Truth
+import io.element.android.libraries.designsystem.components.avatar.AvatarData
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.usersearch.MatrixSearchUserResults
+import io.element.android.libraries.matrix.api.usersearch.MatrixUserProfile
+import io.element.android.libraries.matrix.test.AN_AVATAR_URL
+import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.A_USER_ID_2
+import io.element.android.libraries.matrix.test.A_USER_NAME
+import io.element.android.libraries.matrix.test.FakeMatrixClient
+import io.element.android.libraries.matrix.ui.model.MatrixUser
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class AllMatrixUsersDataSourceTest {
+
+    @Test
+    fun `search - returns users on success`() = runTest {
+        val matrixClient = FakeMatrixClient()
+        matrixClient.givenSearchUsersResult(
+            searchTerm = "test",
+            result = Result.success(
+                MatrixSearchUserResults(
+                    results = listOf(aMatrixUserProfile(), aMatrixUserProfile(userId = A_USER_ID_2)),
+                    limited = false
+                )
+            )
+        )
+        val dataSource = AllMatrixUsersDataSource(matrixClient)
+
+        val results = dataSource.search("test")
+        Truth.assertThat(results).containsExactly(
+            MatrixUser(
+                id = A_USER_ID,
+                username = A_USER_NAME,
+                avatarData = AvatarData(id = A_USER_ID.value, name = A_USER_NAME, url = AN_AVATAR_URL)
+            ),
+            MatrixUser(
+                id = A_USER_ID_2,
+                username = A_USER_NAME,
+                avatarData = AvatarData(id = A_USER_ID_2.value, name = A_USER_NAME, url = AN_AVATAR_URL)
+            )
+        )
+    }
+
+    @Test
+    fun `search - returns empty list on error`() = runTest {
+        val matrixClient = FakeMatrixClient()
+        matrixClient.givenSearchUsersResult(
+            searchTerm = "test",
+            result = Result.failure(Throwable("Ruhroh"))
+        )
+        val dataSource = AllMatrixUsersDataSource(matrixClient)
+
+        val results = dataSource.search("test")
+        Truth.assertThat(results).isEmpty()
+    }
+
+    private fun aMatrixUserProfile(
+        userId: UserId = A_USER_ID,
+        displayName: String = A_USER_NAME,
+        avatarUrl: String = AN_AVATAR_URL
+    ) = MatrixUserProfile(userId, displayName, avatarUrl)
+}

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListStateProvider.kt
@@ -17,6 +17,7 @@
 package io.element.android.features.roomdetails.impl.members
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import io.element.android.features.userlist.api.UserSearchResultState
 import io.element.android.features.userlist.api.aUserListState
 import io.element.android.libraries.architecture.Async
 import io.element.android.libraries.matrix.ui.components.aMatrixUser
@@ -33,7 +34,7 @@ internal class RoomMemberListStateProvider : PreviewParameterProvider<RoomMember
 }
 
 internal fun aRoomMemberListState(
-    searchResults: ImmutableList<MatrixUser> = persistentListOf(),
+    searchResults: UserSearchResultState = UserSearchResultState.NotSearching,
     allUsers: Async<ImmutableList<MatrixUser>> = Async.Uninitialized,
 ) =
     RoomMemberListState(

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/RoomMemberListPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/RoomMemberListPresenterTests.kt
@@ -26,15 +26,14 @@ import io.element.android.features.userlist.api.UserListDataSource
 import io.element.android.features.userlist.api.UserListDataStore
 import io.element.android.features.userlist.api.UserListPresenter
 import io.element.android.features.userlist.api.UserListPresenterArgs
+import io.element.android.features.userlist.api.UserSearchResultState
 import io.element.android.features.userlist.impl.DefaultUserListPresenter
 import io.element.android.features.userlist.test.FakeUserListDataSource
 import io.element.android.libraries.architecture.Async
-import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
 import io.element.android.libraries.matrix.ui.components.aMatrixUser
 import io.element.android.tests.testutils.testCoroutineDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okhttp3.internal.toImmutableList
 import org.junit.Test
@@ -72,7 +71,7 @@ class RoomMemberListPresenterTests {
             val initialState = awaitItem()
             Truth.assertThat(initialState.allUsers).isInstanceOf(Async.Loading::class.java)
             Truth.assertThat(initialState.userListState.isSearchActive).isFalse()
-            Truth.assertThat(initialState.userListState.searchResults).isEmpty()
+            Truth.assertThat(initialState.userListState.searchResults).isEqualTo(UserSearchResultState.NotSearching)
             Truth.assertThat(initialState.userListState.selectionMode).isEqualTo(SelectionMode.Single)
 
             val loadedState = awaitItem()

--- a/features/userlist/api/build.gradle.kts
+++ b/features/userlist/api/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 plugins {
     id("io.element.android-compose-library")
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -27,4 +28,5 @@ dependencies {
     implementation(projects.libraries.uiStrings)
     implementation(projects.libraries.matrix.api)
     implementation(projects.libraries.matrixui)
+    ksp(libs.showkase.processor)
 }

--- a/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListPresenterArgs.kt
+++ b/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListPresenterArgs.kt
@@ -18,6 +18,8 @@ package io.element.android.features.userlist.api
 
 data class UserListPresenterArgs(
     val selectionMode: SelectionMode,
+    val minimumSearchLength: Int = 1,
+    val searchDebouncePeriodMillis: Long = 0,
 )
 
 enum class SelectionMode {

--- a/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListState.kt
+++ b/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListState.kt
@@ -31,7 +31,12 @@ data class UserListState(
 }
 
 sealed interface UserSearchResultState {
+    /** No search results are available yet (e.g. because the user hasn't entered a (long enough) search term). */
     object NotSearching : UserSearchResultState
+
+    /** The search has completed, but no results were found. */
     object NoResults : UserSearchResultState
+
+    /** The search has completed, and some matching users were found. */
     data class Results(val results: ImmutableList<MatrixUser>) : UserSearchResultState
 }

--- a/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListState.kt
+++ b/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListState.kt
@@ -21,11 +21,17 @@ import kotlinx.collections.immutable.ImmutableList
 
 data class UserListState(
     val searchQuery: String,
-    val searchResults: ImmutableList<MatrixUser>,
+    val searchResults: UserSearchResultState,
     val selectedUsers: ImmutableList<MatrixUser>,
     val isSearchActive: Boolean,
     val selectionMode: SelectionMode,
     val eventSink: (UserListEvents) -> Unit,
 ) {
     val isMultiSelectionEnabled = selectionMode == SelectionMode.Multiple
+}
+
+sealed interface UserSearchResultState {
+    object NotSearching : UserSearchResultState
+    object NoResults : UserSearchResultState
+    data class Results(val results: ImmutableList<MatrixUser>) : UserSearchResultState
 }

--- a/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListStateProvider.kt
+++ b/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListStateProvider.kt
@@ -37,22 +37,27 @@ open class UserListStateProvider : PreviewParameterProvider<UserListState> {
                 isSearchActive = true,
                 searchQuery = "@someone:matrix.org",
                 selectedUsers = aListOfSelectedUsers(),
-                searchResults = aMatrixUserList().toImmutableList(),
+                searchResults = UserSearchResultState.Results(aMatrixUserList().toImmutableList()),
             ),
             aUserListState().copy(
                 isSearchActive = true,
                 searchQuery = "@someone:matrix.org",
                 selectionMode = SelectionMode.Multiple,
                 selectedUsers = aListOfSelectedUsers(),
-                searchResults = aMatrixUserList().toImmutableList(),
-            )
+                searchResults = UserSearchResultState.Results(aMatrixUserList().toImmutableList()),
+            ),
+            aUserListState().copy(
+                isSearchActive = true,
+                searchQuery = "something-with-no-results",
+                searchResults = UserSearchResultState.NoResults
+            ),
         )
 }
 
 fun aUserListState() = UserListState(
     isSearchActive = false,
     searchQuery = "",
-    searchResults = persistentListOf(),
+    searchResults = UserSearchResultState.NotSearching,
     selectedUsers = persistentListOf(),
     selectionMode = SelectionMode.Single,
     eventSink = {}

--- a/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/components/SearchUserBar.kt
+++ b/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/components/SearchUserBar.kt
@@ -17,14 +17,17 @@
 package io.element.android.features.userlist.api.components
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -32,7 +35,9 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.element.android.features.userlist.api.UserSearchResultState
 import io.element.android.libraries.designsystem.components.button.BackButton
 import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.IconButton
@@ -46,7 +51,7 @@ import kotlinx.collections.immutable.ImmutableList
 @Composable
 fun SearchUserBar(
     query: String,
-    results: ImmutableList<MatrixUser>,
+    state: UserSearchResultState,
     selectedUsers: ImmutableList<MatrixUser>,
     active: Boolean,
     isMultiSelectionEnabled: Boolean,
@@ -91,6 +96,7 @@ fun SearchUserBar(
                     }
                 }
             }
+
             !active -> {
                 {
                     Icon(
@@ -100,6 +106,7 @@ fun SearchUserBar(
                     )
                 }
             }
+
             else -> null
         },
         colors = if (!active) SearchBarDefaults.colors() else SearchBarDefaults.colors(containerColor = Color.Transparent),
@@ -113,31 +120,43 @@ fun SearchUserBar(
                 )
             }
 
-            LazyColumn {
-                if (isMultiSelectionEnabled) {
-                    items(results) { matrixUser ->
-                        SearchMultipleUsersResultItem(
-                            modifier = Modifier.fillMaxWidth(),
-                            matrixUser = matrixUser,
-                            isUserSelected = selectedUsers.find { it.id == matrixUser.id } != null,
-                            onCheckedChange = { checked ->
-                                if (checked) {
-                                    onUserSelected(matrixUser)
-                                } else {
-                                    onUserDeselected(matrixUser)
+
+            if (state is UserSearchResultState.Results) {
+                LazyColumn {
+                    if (isMultiSelectionEnabled) {
+                        items(state.results) { matrixUser ->
+                            SearchMultipleUsersResultItem(
+                                modifier = Modifier.fillMaxWidth(),
+                                matrixUser = matrixUser,
+                                isUserSelected = selectedUsers.find { it.id == matrixUser.id } != null,
+                                onCheckedChange = { checked ->
+                                    if (checked) {
+                                        onUserSelected(matrixUser)
+                                    } else {
+                                        onUserDeselected(matrixUser)
+                                    }
                                 }
-                            }
-                        )
-                    }
-                } else {
-                    items(results) { matrixUser ->
-                        SearchSingleUserResultItem(
-                            modifier = Modifier.fillMaxWidth(),
-                            matrixUser = matrixUser,
-                            onClick = { onUserSelected(matrixUser) }
-                        )
+                            )
+                        }
+                    } else {
+                        items(state.results) { matrixUser ->
+                            SearchSingleUserResultItem(
+                                modifier = Modifier.fillMaxWidth(),
+                                matrixUser = matrixUser,
+                                onClick = { onUserSelected(matrixUser) }
+                            )
+                        }
                     }
                 }
+            } else if (state is UserSearchResultState.NoResults) {
+                Spacer(Modifier.size(80.dp))
+
+                Text(
+                    text = stringResource(R.string.common_no_results),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
         },
     )

--- a/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/components/UserListView.kt
+++ b/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/components/UserListView.kt
@@ -44,7 +44,7 @@ fun UserListView(
         SearchUserBar(
             modifier = Modifier.fillMaxWidth(),
             query = state.searchQuery,
-            results = state.searchResults,
+            state = state.searchResults,
             selectedUsers = state.selectedUsers,
             active = state.isSearchActive,
             isMultiSelectionEnabled = state.isMultiSelectionEnabled,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -26,6 +26,7 @@ import io.element.android.libraries.matrix.api.pusher.PushersService
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.api.room.RoomSummaryDataSource
+import io.element.android.libraries.matrix.api.usersearch.MatrixSearchUserResults
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
 import java.io.Closeable
 
@@ -58,4 +59,6 @@ interface MatrixClient : Closeable {
     fun onSlidingSyncUpdate()
 
     fun roomMembershipObserver(): RoomMembershipObserver
+
+   suspend fun searchUsers(searchTerm: String, limit: Long): Result<MatrixSearchUserResults>
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/usersearch/MatrixSearchUserResults.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/usersearch/MatrixSearchUserResults.kt
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-package io.element.android.features.createroom.impl.di
+package io.element.android.libraries.matrix.api.usersearch
 
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
-import io.element.android.features.createroom.impl.AllMatrixUsersDataSource
-import io.element.android.features.userlist.api.UserListDataSource
-import io.element.android.libraries.di.SessionScope
-import javax.inject.Named
-
-@Module
-@ContributesTo(SessionScope::class)
-interface CreateRoomModule {
-
-    @Binds
-    @Named("AllUsers")
-    fun bindAllUserListDataSource(dataSource: AllMatrixUsersDataSource): UserListDataSource
-
-}
+data class MatrixSearchUserResults(
+    val results: List<MatrixUserProfile>,
+    val limited: Boolean,
+)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/usersearch/MatrixUserProfile.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/usersearch/MatrixUserProfile.kt
@@ -14,22 +14,12 @@
  * limitations under the License.
  */
 
-package io.element.android.features.createroom.impl.di
+package io.element.android.libraries.matrix.api.usersearch
 
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
-import io.element.android.features.createroom.impl.AllMatrixUsersDataSource
-import io.element.android.features.userlist.api.UserListDataSource
-import io.element.android.libraries.di.SessionScope
-import javax.inject.Named
+import io.element.android.libraries.matrix.api.core.UserId
 
-@Module
-@ContributesTo(SessionScope::class)
-interface CreateRoomModule {
-
-    @Binds
-    @Named("AllUsers")
-    fun bindAllUserListDataSource(dataSource: AllMatrixUsersDataSource): UserListDataSource
-
-}
+data class MatrixUserProfile(
+    val userId: UserId,
+    val displayName: String?,
+    val avatarUrl: String?
+)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -29,6 +29,7 @@ import io.element.android.libraries.matrix.api.pusher.PushersService
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.api.room.RoomSummaryDataSource
+import io.element.android.libraries.matrix.api.usersearch.MatrixSearchUserResults
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
 import io.element.android.libraries.matrix.impl.media.RustMediaResolver
 import io.element.android.libraries.matrix.impl.notification.RustNotificationService
@@ -36,6 +37,7 @@ import io.element.android.libraries.matrix.impl.pushers.RustPushersService
 import io.element.android.libraries.matrix.impl.room.RustMatrixRoom
 import io.element.android.libraries.matrix.impl.room.RustRoomSummaryDataSource
 import io.element.android.libraries.matrix.impl.sync.SlidingSyncObserverProxy
+import io.element.android.libraries.matrix.impl.usersearch.UserSearchResultMapper
 import io.element.android.libraries.matrix.impl.verification.RustSessionVerificationService
 import io.element.android.libraries.sessionstorage.api.SessionStore
 import kotlinx.coroutines.CoroutineScope
@@ -361,6 +363,13 @@ class RustMatrixClient constructor(
     }
 
     override fun roomMembershipObserver(): RoomMembershipObserver = roomMembershipObserver
+
+    override suspend fun searchUsers(searchTerm: String, limit: Long): Result<MatrixSearchUserResults> =
+        withContext(dispatchers.io) {
+            runCatching {
+                UserSearchResultMapper.map(client.searchUsers(searchTerm, limit.toULong()))
+            }
+        }
 
     private fun File.deleteSessionDirectory(userID: String): Boolean {
         // Rust sanitises the user ID replacing invalid characters with an _

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/usersearch/UserSearchResultMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/usersearch/UserSearchResultMapper.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.usersearch
+
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.usersearch.MatrixSearchUserResults
+import io.element.android.libraries.matrix.api.usersearch.MatrixUserProfile
+import org.matrix.rustcomponents.sdk.SearchUsersResults
+import org.matrix.rustcomponents.sdk.UserProfile
+
+object UserSearchResultMapper {
+
+    fun map(result: SearchUsersResults): MatrixSearchUserResults {
+        return MatrixSearchUserResults(
+            results = result.results.map(::mapUserProfile),
+            limited = result.limited,
+        )
+    }
+
+    private fun mapUserProfile(userProfile: UserProfile): MatrixUserProfile {
+        return MatrixUserProfile(
+            userId = UserId(userProfile.userId),
+            displayName = userProfile.displayName,
+            avatarUrl = userProfile.avatarUrl,
+        )
+    }
+}

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -27,6 +27,7 @@ import io.element.android.libraries.matrix.api.pusher.PushersService
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.api.room.RoomSummaryDataSource
+import io.element.android.libraries.matrix.api.usersearch.MatrixSearchUserResults
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
 import io.element.android.libraries.matrix.test.media.FakeMediaResolver
 import io.element.android.libraries.matrix.test.notification.FakeNotificationService
@@ -55,6 +56,7 @@ class FakeMatrixClient(
     private var findDmResult: MatrixRoom? = FakeMatrixRoom()
     private var logoutFailure: Throwable? = null
     private val getRoomResults = mutableMapOf<RoomId, MatrixRoom>()
+    private val searchUserResults = mutableMapOf<String, Result<MatrixSearchUserResults>>()
 
     override fun getRoom(roomId: RoomId): MatrixRoom? {
         return getRoomResults[roomId]
@@ -126,6 +128,10 @@ class FakeMatrixClient(
         return RoomMembershipObserver()
     }
 
+    override suspend fun searchUsers(searchTerm: String, limit: Long): Result<MatrixSearchUserResults> {
+        return searchUserResults[searchTerm] ?: Result.failure(IllegalStateException("No response defined for $searchTerm"))
+    }
+
     // Mocks
 
     fun givenLogoutError(failure: Throwable?) {
@@ -158,5 +164,9 @@ class FakeMatrixClient(
 
     fun givenGetRoomResult(roomId: RoomId, result: MatrixRoom) {
         getRoomResults[roomId] = result
+    }
+
+    fun givenSearchUsersResult(searchTerm: String, result: Result<MatrixSearchUserResults>) {
+        searchUserResults[searchTerm] = result
     }
 }

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl.components_null_DefaultGroup_SearchRoomListTopBarDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl.components_null_DefaultGroup_SearchRoomListTopBarDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:90e726f5086c32da2a9bf2887e5295a761748ba991cd541a4e119f14bc57b0e8
-size 7159

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl.components_null_DefaultGroup_SearchRoomListTopBarLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomlist.impl.components_null_DefaultGroup_SearchRoomListTopBarLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:007fd7051cb4b8059dc33ff1cd2b4be4cffaa5e1c129adb61dd4d9e8a561953f
-size 7096

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SearchMultipleUsersResultItemDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SearchMultipleUsersResultItemDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bd925ebe0257b400ed0b1cb956848622d1b42d8afcc71f915522c4878aaf94b
+size 23447

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SearchMultipleUsersResultItemLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SearchMultipleUsersResultItemLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12b569ad80bb4a4df89d70d9ae4a92da0d9e96deb477e1e437efbef5ec4a1fdd
+size 22302

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SearchSingleUserResultItemDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SearchSingleUserResultItemDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91de9d54216aac2bf2c4721e5e8ff5e74be43105846bdac16230cb7bea7427af
+size 13777

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SearchSingleUserResultItemLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SearchSingleUserResultItemLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38fbef57e6fb2860d05ab2b864bab16a30ebc98199eb18b19e422f946c52e163
+size 13096

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SelectedUserDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SelectedUserDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b357bc650466f045ff7a3d601b0a716f81af9fc55cd4f082a231747905e6860
+size 13146

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SelectedUserLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SelectedUserLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de04bcf3f3d053024f7f5e9e11da95b7d609cf3c1982db70d1ef734b0f21d729
+size 12577

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SelectedUsersListDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SelectedUsersListDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffcc7edc0898f3afccf77679a477e76f9f9aef5c4f0309518b3025ed6ce17f96
+size 32696

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SelectedUsersListLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_SelectedUsersListLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc5d0c10593401fbb674c2a27333e546db9b0c11aca9ae280a721aa0e2d16765
+size 31793

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_0,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02d8edfee13ad4ca97dde238939b6166cccc28550d77c7b924c6aebd6e8d6a07
+size 9916

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_1,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a212fb83b307da9ebd0681492286d7f19520c8140629f0a21bad0c43e3954d6
+size 36910

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_2,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89ea65099fb4981bbeb24e49afb7400b0e8da79e3b783e198519ba1e970404a8
+size 8317

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_3,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a8ba207cf61c56b64c6855d04c8a30def0b3daf325adf57edd45b40981ed745
+size 7733

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_4,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a8ba207cf61c56b64c6855d04c8a30def0b3daf325adf57edd45b40981ed745
+size 7733

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_5,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a57daa1da9d07e6c7d497c63eb0c9fda36f48ea28f4592eef62774034b86b5e3
+size 87856

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_6,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0071d13454a9e8d75fc693d2f13a65c4d61910425217757804d92c086d56792f
+size 102885

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_7,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewDarkPreview_0_null_7,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5b879b74654fdad0638f432a71adfc9186fbe00dafd5d963a3affb33ec8c5c8
+size 12841

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_0,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fbafefd9aa66ac411836715ef57f39e05e4eeeb0f4601b8a1706d9a3a487527
+size 9692

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_1,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18d25ee10a5deb2e7a81aadd65dad542ed1a40889d77e375412c66c30a834492
+size 34260

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_2,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8de2f28cf9918a7eddcc1311c34ba0376242a4708724b57689df000b7480524
+size 8197

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_3,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:687133e4729ea42382ac0b76af6ceaf8b20cbc65923412fb97b077d2475c70f7
+size 7514

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_4,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:687133e4729ea42382ac0b76af6ceaf8b20cbc65923412fb97b077d2475c70f7
+size 7514

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_5,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a708d195ffce2d542c494c6949456a1d341dff5c51f742e04212b72863c91988
+size 84136

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_6,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff83f67a9fbcc5066547224c2f26d94c33bd0b60563acc062fde399ef9d681e1
+size 97631

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_7,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.userlist.api.components_null_DefaultGroup_UserListViewLightPreview_0_null_7,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:534cba0c13aa52b3557ab8df854c521dd13b82e5a1550d73abcef12925e389da
+size 11878


### PR DESCRIPTION
Hooks up the create room UI to the matrix client to get search results. Searches are debounced for 500ms and only executed when 3 or more characters are entered.

Wrap the result state so we can distinguish between "no results because we haven't searched yet" and
"no results because the API returned nothing", and add a "No results found" message in the UI for the latter case.

Closes #95

[usersearch.webm](https://user-images.githubusercontent.com/189133/235708313-f3bf2f93-53df-4484-880e-02f78b81050c.webm)
