### PR TITLE
Add debounce/minimum length for add user search

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/addpeople/AddPeoplePresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/addpeople/AddPeoplePresenter.kt
@@ -35,7 +35,11 @@ class AddPeoplePresenter @Inject constructor(
 
     private val userListPresenter by lazy {
         userListPresenterFactory.create(
-            UserListPresenterArgs(selectionMode = SelectionMode.Multiple),
+            UserListPresenterArgs(
+                selectionMode = SelectionMode.Multiple,
+                minimumSearchLength = 3,
+                searchDebouncePeriodMillis = UserListPresenterArgs.DEFAULT_DEBOUNCE
+            ),
             userListDataSource,
             dataStore.selectedUserListDataStore,
         )

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootPresenter.kt
@@ -49,7 +49,7 @@ class CreateRoomRootPresenter @Inject constructor(
             UserListPresenterArgs(
                 selectionMode = SelectionMode.Single,
                 minimumSearchLength = 3,
-                searchDebouncePeriodMillis = 500,
+                searchDebouncePeriodMillis = UserListPresenterArgs.DEFAULT_DEBOUNCE,
             ),
             userListDataSource,
             userListDataStore,

--- a/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListPresenterArgs.kt
+++ b/features/userlist/api/src/main/kotlin/io/element/android/features/userlist/api/UserListPresenterArgs.kt
@@ -19,8 +19,13 @@ package io.element.android.features.userlist.api
 data class UserListPresenterArgs(
     val selectionMode: SelectionMode,
     val minimumSearchLength: Int = 1,
-    val searchDebouncePeriodMillis: Long = 0,
-)
+    val searchDebouncePeriodMillis: Long = NO_DEBOUNCE,
+) {
+    companion object {
+        const val NO_DEBOUNCE = 0L
+        const val DEFAULT_DEBOUNCE = 500L
+    }
+}
 
 enum class SelectionMode {
     Single,


### PR DESCRIPTION
This functionality was already implemented, it just didn't have the right parameters configured for the user list presenter.

Closes #109