### PR TITLE
Make danger check view changes

### DIFF
--- a/appnav/build.gradle.kts
+++ b/appnav/build.gradle.kts
@@ -69,4 +69,6 @@ dependencies {
     testImplementation(projects.services.appnavstate.test)
     testImplementation(libs.test.appyx.junit)
     testImplementation(libs.test.arch.core)
+
+    ksp(libs.showkase.processor)
 }

--- a/features/logout/api/build.gradle.kts
+++ b/features/logout/api/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 plugins {
     id("io.element.android-compose-library")
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -25,4 +26,6 @@ dependencies {
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.designsystem)
     implementation(projects.libraries.uiStrings)
+
+    ksp(libs.showkase.processor)
 }

--- a/features/networkmonitor/api/build.gradle.kts
+++ b/features/networkmonitor/api/build.gradle.kts
@@ -16,6 +16,7 @@
 
 plugins {
     id("io.element.android-compose-library")
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -26,4 +27,6 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(projects.libraries.designsystem)
     implementation(projects.libraries.uiStrings)
+
+    ksp(libs.showkase.processor)
 }

--- a/features/rageshake/api/build.gradle.kts
+++ b/features/rageshake/api/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 plugins {
     id("io.element.android-compose-library")
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -26,4 +27,6 @@ dependencies {
     implementation(projects.libraries.designsystem)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.uiStrings)
+
+    ksp(libs.showkase.processor)
 }

--- a/features/rageshake/api/src/main/kotlin/io/element/android/features/rageshake/api/crash/CrashDetectionView.kt
+++ b/features/rageshake/api/src/main/kotlin/io/element/android/features/rageshake/api/crash/CrashDetectionView.kt
@@ -80,3 +80,5 @@ private fun ContentToPreview() {
         state = aCrashDetectionState().copy(crashDetected = true)
     )
 }
+
+// This file has a @Preview but the showkase processor isn't included in the build file :(

--- a/features/rageshake/api/src/main/kotlin/io/element/android/features/rageshake/api/crash/CrashDetectionView.kt
+++ b/features/rageshake/api/src/main/kotlin/io/element/android/features/rageshake/api/crash/CrashDetectionView.kt
@@ -81,4 +81,3 @@ private fun ContentToPreview() {
     )
 }
 
-// This file has a @Preview but the showkase processor isn't included in the build file :(

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.logout.api_null_DefaultGroup_LogoutPreferenceViewDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.logout.api_null_DefaultGroup_LogoutPreferenceViewDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:169eebc0429e7a3ee2b44c39e813ebf65c9a2be819b5512cdcdb96931a1be6ee
+size 12316

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.logout.api_null_DefaultGroup_LogoutPreferenceViewLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.logout.api_null_DefaultGroup_LogoutPreferenceViewLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35bb48c9086e30e0799bd9e5fb6ccb968cbc3c9497f3591d2011a08f13b3b2ad
+size 11753

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.networkmonitor.api.ui_null_DefaultGroup_PreviewDarkConnectivityIndicatorView_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.networkmonitor.api.ui_null_DefaultGroup_PreviewDarkConnectivityIndicatorView_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86dccea33c870ec705cfb9d35482cc18bd43ba6dbc4e0307345dc78636a3c22c
+size 5509

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.networkmonitor.api.ui_null_DefaultGroup_PreviewLightConnectivityIndicatorView_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.networkmonitor.api.ui_null_DefaultGroup_PreviewLightConnectivityIndicatorView_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddc812fa59eb9062d588bd631d78a2f88a536fb3a4c433c7a1f89dad78cfd2a0
+size 5468

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.crash_null_DefaultGroup_CrashDetectionViewDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.crash_null_DefaultGroup_CrashDetectionViewDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:188e1558e25532aa4ae84b7251187d6d7b884964d208a64402bf816da4abe182
+size 97

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.crash_null_DefaultGroup_CrashDetectionViewLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.crash_null_DefaultGroup_CrashDetectionViewLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d59921a81b41ccfb1cc2c44328af28fb82624ba076e5e1081e67c85f78f26280
+size 97

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.detection_null_DefaultGroup_RageshakeDialogContentDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.detection_null_DefaultGroup_RageshakeDialogContentDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:188e1558e25532aa4ae84b7251187d6d7b884964d208a64402bf816da4abe182
+size 97

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.detection_null_DefaultGroup_RageshakeDialogContentLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.detection_null_DefaultGroup_RageshakeDialogContentLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d59921a81b41ccfb1cc2c44328af28fb82624ba076e5e1081e67c85f78f26280
+size 97

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.preferences_null_DefaultGroup_RageshakePreferencesViewDarkPreview_0_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.preferences_null_DefaultGroup_RageshakePreferencesViewDarkPreview_0_null_0,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d26696bc153ce1bdf4cde822c6b8e96f82d1920898778449ebd1b9ea4ce8c12b
+size 55419

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.preferences_null_DefaultGroup_RageshakePreferencesViewDarkPreview_0_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.preferences_null_DefaultGroup_RageshakePreferencesViewDarkPreview_0_null_1,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:808b519280fa368c0b7fe878dc1632b81730ea1a4bfd9eee5161d7cb8d067fbc
+size 48092

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.preferences_null_DefaultGroup_RageshakePreferencesViewLightPreview_0_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.preferences_null_DefaultGroup_RageshakePreferencesViewLightPreview_0_null_0,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5821d4464d86f2e57edd992d06d7eb801f055c43db24c64365bf58e31f2e1dcc
+size 54171

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.preferences_null_DefaultGroup_RageshakePreferencesViewLightPreview_0_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.rageshake.api.preferences_null_DefaultGroup_RageshakePreferencesViewLightPreview_0_null_1,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be319eb78cf8852f2ce9037d349588c2e4d08c8e2efd25cbdab8a05655125738
+size 47055

--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -152,7 +152,7 @@ const buildFilesWithMissingProcessor = filesWithPreviews.map(file => {
 })
 
 if (buildFilesWithMissingProcessor.length > 0) {
-    fail("Please make sure modules with @Preview functions use the showkase processor. Missing processor in: " + buildFilesWithMissingProcessor.join(", "))
+    warn("You have made changes to a file containing a `@Preview` annotated function but its module doesn't include the showkase processor. Missing processor in: " + buildFilesWithMissingProcessor.join(", "))
 }
 
 // Check for screenshots on view changes

--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -1,4 +1,6 @@
 const {danger, warn} = require('danger')
+const fs = require('fs')
+const path = require('path')
 
 /**
  * Note: if you update the checks in this file, please also update the file ./docs/danger.md
@@ -128,9 +130,33 @@ if (allowList.includes(user)) {
     })
 }
 
+const previewAnnotations = [
+    'androidx.compose.ui.tooling.preview.Preview',
+    'io.element.android.libraries.designsystem.preview.LargeHeightPreview'
+]
+
+const filesWithPreviews = editedFiles.filter(file => file.endsWith(".kt")).filter(file => {
+    const content = fs.readFileSync(file);
+    return previewAnnotations.some((ann) => content.includes(ann));
+})
+
+const buildFilesWithMissingProcessor = filesWithPreviews.map(file => {
+    let parent = path.dirname(file);
+    while (fs.statSync(path.join(parent, 'build.gradle.kts'), {throwIfNoEntry: false}) === undefined) {
+        parent = path.dirname(parent);
+    }
+    return path.join(parent, 'build.gradle.kts');
+}).filter((value, index, array) => array.indexOf(value) === index).filter(buildFile => {
+    const content = fs.readFileSync(buildFile);
+    return !content.includes('ksp(libs.showkase.processor)');
+})
+
+if (buildFilesWithMissingProcessor.length > 0) {
+    fail("Please make sure modules with @Preview functions use the showkase processor. Missing processor in: " + buildFilesWithMissingProcessor.join(", "))
+}
 
 // Check for screenshots on view changes
-const hasChangedViews = editedFiles.filter(file => file.includes("/layout")).length > 0
+const hasChangedViews = filesWithPreviews.length > 0
 if (hasChangedViews) {
     if (!pr.body.includes("user-images")) {
         warn("You seem to have made changes to views. Please consider adding screenshots.")


### PR DESCRIPTION
Add a check that if a file with @Preview or @LargeHeightPreview in it is changed, then the corresponding build file includes the showkase processor.

Also change the check that prompts about screenshots to use the same @Preview logic instead of checking for "/layout" in the path which doesn't work with compose.