### PR TITLE
Upgrade version of lint from 8.0.0 to 8.2.0-alpha02 (latest).

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ signing.element.nightly.keyPassword=Secret
 
 # Customise the Lint version to use a more recent version than the one bundled with AGP
 # https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
-android.experimental.lint.version=8.0.0
+android.experimental.lint.version=8.2.0-alpha02
 
 # Enable test fixture for all modules by default
 android.experimental.enableTestFixtures=true


### PR DESCRIPTION
Fix warning:
WARNING: The build will use lint version 8.0.0 which is older than the default. Recommendation: Remove or update the gradle property android.experimental.lint.version to be at least 8.0.1