### PR TITLE
Try to fix flaky test by setting a longer timeout in runTest

### DIFF
--- a/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/detection/RageshakeDetectionPresenterTest.kt
+++ b/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/detection/RageshakeDetectionPresenterTest.kt
@@ -85,7 +85,7 @@ class RageshakeDetectionPresenterTest {
     }
 
     @Test
-    fun `present - screenshot with success then dismiss`() = runTest {
+    fun `present - screenshot with success then dismiss`() = runTest(timeout = 30.seconds) {
         val screenshotHolder = FakeScreenshotHolder(screenshotUri = null)
         val rageshake = FakeRageShake(isAvailableValue = true)
         val rageshakeDataStore = FakeRageshakeDataStore(isEnabled = true)
@@ -99,7 +99,7 @@ class RageshakeDetectionPresenterTest {
         )
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()
-        }.test(timeout = 30.seconds) {
+        }.test {
             skipItems(1)
             val initialState = awaitItem()
             assertThat(initialState.isStarted).isFalse()


### PR DESCRIPTION
After upgrading Kotlin coroutines to `v1.7.x` we've seen some issues with the test `RageshakeDetectionPresenterTest: present - screenshot with success then dismiss` because it takes longer than the new timeout in `runTest` to complete (10s). 

This seems to be cause by `mockk()` taking >10s to mock a `Bitmap`, so while we find a way to void this we'll add this workaround.