### PR TITLE
Reduce time to run test from 15 minutes to about 8

### DIFF
--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -1,0 +1,43 @@
+name: Nightly reports
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every nights at 5
+    - cron: "0 5 * * *"
+
+# Enrich gradle.properties for CI/CD
+env:
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx3072m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.jvm.options="-Xmx2560m" -Dkotlin.incremental=false
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 4
+
+jobs:
+  nightlyReports:
+    name: Create kover report artifact and upload sonar result.
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'vector-im/element-x-android' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
+
+      - name: ⚙️ Run unit & screenshot tests, generate kover report
+        run: ./gradlew koverMergedReport $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+
+      - name: ✅ Upload kover report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: kover-results
+          path: |
+            **/build/reports/kover/merged
+
+      - name: 🔊 Publish results to Sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          ORG_GRADLE_PROJECT_SONAR_LOGIN: ${{ secrets.SONAR_TOKEN }}
+        if: ${{ always() && env.SONAR_TOKEN != '' && env.ORG_GRADLE_PROJECT_SONAR_LOGIN != '' }}
+        run: ./gradlew sonar $CI_GRADLE_ARG_PROPERTIES

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,13 +68,9 @@ jobs:
           path: tests/uitests/out/failures/
           retention-days: 5
 
-      - name: ✅ Upload kover report
+      - name: ✅ Upload kover report (disabled)
         if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: kover-results
-          path: |
-            **/build/reports/kover/merged
+        run: echo "This is now done only once a day, see nightlyReports.yml"
 
       - name: 🚫 Upload test results on error
         if: failure()
@@ -85,12 +81,8 @@ jobs:
             **/out/failures/
             **/build/reports/tests/*UnitTest/
 
-      - name: 🔊 Publish results to Sonar
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          ORG_GRADLE_PROJECT_SONAR_LOGIN: ${{ secrets.SONAR_TOKEN }}
-        if: ${{ always() && env.SONAR_TOKEN != '' && env.ORG_GRADLE_PROJECT_SONAR_LOGIN != '' }}
-        run: ./gradlew sonar $CI_GRADLE_ARG_PROPERTIES
+      - name: 🔊 Publish results to Sonar (disabled)
+        run: echo "This is now done only once a day, see nightlyReports.yml"
 
       # https://github.com/codecov/codecov-action
       - name: ☂️ Upload coverage reports to codecov


### PR DESCRIPTION
Motivation: test run by the CI should be as fast as possible.

Reduce time to run test from 15 minutes to about 8 by disabling creating artifact with Kover merged report (this artifact is not very useful, when we want to check the coverage, we run the task locally) and uploading to sonar (analysis on develop is enough for now).

Instead those 2 steps are now run once a day in a separate GitHub action.

See for instance the log a the Test task:

<img width="1425" alt="image" src="https://github.com/vector-im/element-x-android/assets/3940906/780df566-11d4-4e79-ac0d-c91e5ba12d5e">

The 2 removed steps should save about 8 minutes per run.