### PR TITLE
Log cleanup

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx3072m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options="-Xmx2g" -Dkotlin.incremental=false
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 2 --no-daemon
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 2 --no-daemon --warn
 
 jobs:
   check:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx3072m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.jvm.options="-Xmx2560m" -Dkotlin.incremental=false
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 4
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 4 --warn
 
 jobs:
   tests:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,7 +206,7 @@ knit {
 dependencies {
     allLibrariesImpl()
     allServicesImpl()
-    allFeaturesImpl(rootDir)
+    allFeaturesImpl(rootDir, logger)
     implementation(projects.libraries.deeplink)
     implementation(projects.tests.uitests)
     implementation(projects.anvilannotations)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -213,8 +213,7 @@ dependencies {
     implementation(projects.appnav)
     anvil(projects.anvilcodegen)
 
-    // https://developer.android.com/studio/write/java8-support#library-desugaring-versions
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+    coreLibraryDesugaring(libs.android.desugar)
     implementation(libs.appyx.core)
     implementation(libs.androidx.splash)
     implementation(libs.androidx.core)

--- a/appnav/build.gradle.kts
+++ b/appnav/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     implementation(libs.dagger)
     kapt(libs.dagger.compiler)
 
-    allFeaturesApi(rootDir)
+    allFeaturesApi(rootDir, logger)
 
     implementation(projects.libraries.core)
     implementation(projects.libraries.androidutils)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,8 @@ dependencygraph = "0.10"
 [libraries]
 # Project
 android_gradle_plugin = { module = "com.android.tools.build:gradle", version.ref = "android_gradle_plugin" }
+# https://developer.android.com/studio/write/java8-support#library-desugaring-versions
+android_desugar = "com.android.tools:desugar_jdk_libs:2.0.3"
 kotlin_gradle_plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 # https://firebase.google.com/docs/android/setup#available-libraries
 google_firebase_bom = "com.google.firebase:firebase-bom:32.0.0"

--- a/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
+++ b/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
@@ -19,6 +19,7 @@ package extension
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.project
+import org.gradle.api.logging.Logger
 import java.io.File
 
 private fun DependencyHandlerScope.implementation(dependency: Any) = dependencies.add("implementation", dependency)
@@ -53,16 +54,21 @@ fun DependencyHandlerScope.composeDependencies(libs: LibrariesForLibs) {
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
 }
 
-private fun DependencyHandlerScope.addImplementationProjects(directory: File, path: String, nameFilter: String) {
+private fun DependencyHandlerScope.addImplementationProjects(
+    directory: File,
+    path: String,
+    nameFilter: String,
+    logger: Logger,
+) {
     directory.listFiles().orEmpty().also { it.sort() }.forEach { file ->
         if (file.isDirectory) {
             val newPath = "$path:${file.name}"
             val buildFile = File(file, "build.gradle.kts")
             if (buildFile.exists() && file.name == nameFilter) {
                 implementation(project(newPath))
-                println("Added implementation(project($newPath))")
+                logger.lifecycle("Added implementation(project($newPath))")
             } else {
-                addImplementationProjects(file, newPath, nameFilter)
+                addImplementationProjects(file, newPath, nameFilter, logger)
             }
         }
     }
@@ -100,12 +106,12 @@ fun DependencyHandlerScope.allServicesImpl() {
     implementation(project(":services:toolbox:impl"))
 }
 
-fun DependencyHandlerScope.allFeaturesApi(rootDir: File) {
+fun DependencyHandlerScope.allFeaturesApi(rootDir: File, logger: Logger) {
     val featuresDir = File(rootDir, "features")
-    addImplementationProjects(featuresDir, ":features", "api")
+    addImplementationProjects(featuresDir, ":features", "api", logger)
 }
 
-fun DependencyHandlerScope.allFeaturesImpl(rootDir: File) {
+fun DependencyHandlerScope.allFeaturesImpl(rootDir: File, logger: Logger) {
     val featuresDir = File(rootDir, "features")
-    addImplementationProjects(featuresDir, ":features", "impl")
+    addImplementationProjects(featuresDir, ":features", "impl", logger)
 }

--- a/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
+++ b/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
@@ -54,7 +54,7 @@ fun DependencyHandlerScope.composeDependencies(libs: LibrariesForLibs) {
 }
 
 private fun DependencyHandlerScope.addImplementationProjects(directory: File, path: String, nameFilter: String) {
-    directory.listFiles().orEmpty().forEach { file ->
+    directory.listFiles().orEmpty().also { it.sort() }.forEach { file ->
         if (file.isDirectory) {
             val newPath = "$path:${file.name}"
             val buildFile = File(file, "build.gradle.kts")
@@ -104,6 +104,7 @@ fun DependencyHandlerScope.allFeaturesApi(rootDir: File) {
     val featuresDir = File(rootDir, "features")
     addImplementationProjects(featuresDir, ":features", "api")
 }
+
 fun DependencyHandlerScope.allFeaturesImpl(rootDir: File) {
     val featuresDir = File(rootDir, "features")
     addImplementationProjects(featuresDir, ":features", "impl")

--- a/samples/minimal/build.gradle.kts
+++ b/samples/minimal/build.gradle.kts
@@ -61,5 +61,5 @@ dependencies {
     implementation(projects.features.login.impl)
     implementation(projects.features.networkmonitor.impl)
     implementation(libs.coroutines.core)
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+    coreLibraryDesugaring(libs.android.desugar)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -62,7 +62,7 @@ fun includeProjects(directory: File, path: String, maxDepth: Int = 1) {
             val buildFile = File(file, "build.gradle.kts")
             if (buildFile.exists()) {
                 include(newPath)
-                println("Included project: $newPath")
+                logger.lifecycle("Included project: $newPath")
             } else if (maxDepth > 0) {
                 includeProjects(file, newPath, maxDepth - 1)
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,7 +56,7 @@ include(":anvilcodegen")
 include(":samples:minimal")
 
 fun includeProjects(directory: File, path: String, maxDepth: Int = 1) {
-    directory.listFiles().orEmpty().forEach { file ->
+    directory.listFiles().orEmpty().also { it.sort() }.forEach { file ->
         if (file.isDirectory) {
             val newPath = "$path:${file.name}"
             val buildFile = File(file, "build.gradle.kts")

--- a/tests/uitests/build.gradle.kts
+++ b/tests/uitests/build.gradle.kts
@@ -37,5 +37,5 @@ dependencies {
     implementation(libs.showkase)
 
     allLibrariesImpl()
-    allFeaturesImpl(rootDir)
+    allFeaturesImpl(rootDir, logger)
 }


### PR DESCRIPTION
I am tired to scroll in the logs generated on CI workflow, this PR should reduce verbosity, to see faster warnings and errors. No change on the build workflow, it's also nice to have verbose log when investigating compilation issue.

Note to @vector-im/element-x-android-developers : I have added

```yaml
org.gradle.logging.level=warn
```

to my `gradle.properties` file and it's a game changer.

More info here: https://docs.gradle.org/current/userguide/logging.html