### PR TITLE
Enable one last ignored test for LeaveRoomPresenterImpl

### DIFF
--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/TestCoroutineDispatchers.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/TestCoroutineDispatchers.kt
@@ -17,27 +17,33 @@
 package io.element.android.tests.testutils
 
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
+/**
+ * Create a [CoroutineDispatchers] instance for testing.
+ *
+ * @param testScheduler The [TestCoroutineScheduler] to use. If using [runTest] use the one provided by its [TestScope].
+ * If null the [TestDispatcher] logic will select one or create a new one.
+ * @param useUnconfinedTestDispatcher If true, use [UnconfinedTestDispatcher] for all dispatchers.
+ * If false, use [StandardTestDispatcher] for all dispatchers.
+ */
 fun testCoroutineDispatchers(
     testScheduler: TestCoroutineScheduler? = null,
-) = CoroutineDispatchers(
-    io = UnconfinedTestDispatcher(testScheduler),
-    computation = UnconfinedTestDispatcher(testScheduler),
-    main = UnconfinedTestDispatcher(testScheduler),
-    diffUpdateDispatcher = UnconfinedTestDispatcher(testScheduler),
-)
+    useUnconfinedTestDispatcher: Boolean = true,
+): CoroutineDispatchers = when (useUnconfinedTestDispatcher) {
+    false -> CoroutineDispatchers(
+        io = StandardTestDispatcher(testScheduler),
+        computation = StandardTestDispatcher(testScheduler),
+        main = StandardTestDispatcher(testScheduler),
+        diffUpdateDispatcher = StandardTestDispatcher(testScheduler),
+    )
 
-fun testCoroutineDispatchers(
-    io: TestDispatcher = UnconfinedTestDispatcher(),
-    computation: TestDispatcher = UnconfinedTestDispatcher(),
-    main: TestDispatcher = UnconfinedTestDispatcher(),
-    diffUpdateDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
-) = CoroutineDispatchers(
-    io = io,
-    computation = computation,
-    main = main,
-    diffUpdateDispatcher = diffUpdateDispatcher,
-)
+    true -> CoroutineDispatchers(
+        io = UnconfinedTestDispatcher(testScheduler),
+        computation = UnconfinedTestDispatcher(testScheduler),
+        main = UnconfinedTestDispatcher(testScheduler),
+        diffUpdateDispatcher = UnconfinedTestDispatcher(testScheduler),
+    )
+}


### PR DESCRIPTION
Most of the tests in `LeaveRoomPresenterImplTest.kt` where using `UnconfinedTestDispatcher` which was conflating some of the state returned by the presenter. This prevented to test one specific case which had been left with an `@Ignore` annotation.
This PR switches to `StandardTestDispatcher` so that the ignored test case can work and also fixes some other test cases whose behavior is now more correct under the `StandardTestDispatcher`.

Also updates our test factory method for `CoroutineDispatchers` to more easily obtain a `CoroutineDispatchers` which uses `StandardTestDispatcher`.