### PR TITLE
Add Maestro tests for create & join rooms

### DIFF
--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -50,6 +50,6 @@ jobs:
             USERNAME=maestroelement
             PASSWORD=${{ secrets.MATRIX_MAESTRO_ACCOUNT_PASSWORD }}
             ROOM_NAME=MyRoom
-            INVITEE1_MXID=maestroelement2
-            INVITEE2_MXID=maestroelement3
+            INVITEE1_MXID=@maestroelement2:matrix.org
+            INVITEE2_MXID=@maestroelement3:matrix.org
             APP_ID=io.element.android.x.debug

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -50,4 +50,6 @@ jobs:
             USERNAME=maestroelement
             PASSWORD=${{ secrets.MATRIX_MAESTRO_ACCOUNT_PASSWORD }}
             ROOM_NAME=MyRoom
+            INVITEE1_MXID=maestroelement2
+            INVITEE2_MXID=maestroelement3
             APP_ID=io.element.android.x.debug

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -23,9 +23,11 @@ From root dir of the project
 ```shell
 maestro test \
     -e APP_ID=io.element.android.x.debug \
-    -e USERNAME=user \
+    -e USERNAME=user1 \
     -e PASSWORD=123 \
     -e ROOM_NAME="MyRoom" \
+    -e INVITEE1_MXID=user2 \
+    -e INVITEE2_MXID=user3 \
     .maestro/allTests.yaml
 ```
 

--- a/.maestro/tests/roomList/createAndDeleteDM.yaml
+++ b/.maestro/tests/roomList/createAndDeleteDM.yaml
@@ -1,0 +1,13 @@
+appId: ${APP_ID}
+---
+# Purpose: Test the creation and deletion of a DM room.
+- tapOn: "Create a new conversation or room"
+- tapOn: "Search for someone"
+- inputText: ${INVITEE1_MXID}
+- tapOn:
+    text: ${INVITEE1_MXID}
+    index: 1
+- takeScreenshot: build/maestro/330-createAndDeleteDM
+- tapOn: "maestroelement2"
+- tapOn: "Leave room"
+- tapOn: "Leave"

--- a/.maestro/tests/roomList/createAndDeleteRoom.yaml
+++ b/.maestro/tests/roomList/createAndDeleteRoom.yaml
@@ -1,0 +1,33 @@
+appId: ${APP_ID}
+---
+# Purpose: Test the creation and deletion of a room
+- tapOn: "Create a new conversation or room"
+- tapOn: "New room"
+- tapOn: "Search for someone"
+- inputText: ${INVITEE1_MXID}
+- tapOn:
+    text: ${INVITEE1_MXID}
+    index: 1
+- tapOn: "Next"
+- tapOn: "e.g. your project name"
+- inputText: "aRoomName"
+- tapOn: "What is this room about?"
+- inputText: "aRoomTopic"
+- tapOn: "Create"
+- takeScreenshot: build/maestro/320-createAndDeleteRoom
+- tapOn: "aRoomName"
+- tapOn: "Invite people"
+# assert there's 1 memeber and 1 invitee
+- tapOn: "Search for someone"
+- inputText: ${INVITEE2_MXID}
+- tapOn:
+    text: ${INVITEE2_MXID}
+    index: 1
+- tapOn: "Send"
+- tapOn: "Back"
+- tapOn: "aRoomName"
+- tapOn: "People"
+# assert there's 1 memeber and 2 invitees
+- tapOn: "Back"
+- tapOn: "Leave room"
+- tapOn: "Leave"

--- a/.maestro/tests/roomList/roomContextMenu.yaml
+++ b/.maestro/tests/roomList/roomContextMenu.yaml
@@ -1,0 +1,14 @@
+appId: ${APP_ID}
+---
+# Purpose: Test the context menu of a room in the room list
+- longPressOn: ${ROOM_NAME}
+- takeScreenshot: build/maestro/310-RoomList-ContextMenu
+- tapOn:
+    text: "Settings"
+    index: 0
+- tapOn: "Back"
+- longPressOn: ${ROOM_NAME}
+- tapOn:
+    text: "Leave room"
+    index: 0
+- tapOn: "Cancel"

--- a/.maestro/tests/roomList/roomList.yaml
+++ b/.maestro/tests/roomList/roomList.yaml
@@ -1,6 +1,8 @@
 appId: ${APP_ID}
 ---
-- takeScreenshot: build/maestro/300-RoomList
 - runFlow: searchRoomList.yaml
+- takeScreenshot: build/maestro/300-RoomList
 - runFlow: timeline/timeline.yaml
-
+- runFlow: roomContextMenu.yaml
+- runFlow: createAndDeleteRoom.yaml
+- runFlow: createAndDeleteDM.yaml


### PR DESCRIPTION
I created 2 additional test users to use them as MXID we lookup during room creation.

I.e. we will not login as those users, it's just 2 known MXIDs that we know exist so we can look them up.

- https://github.com/vector-im/element-x-android/issues/409