### PR TITLE
Sliding sync cleanup

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/EventType.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/EventType.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.api.timeline.item.event
+
+/**
+ * Constants defining known event types from Matrix specifications.
+ */
+object EventType {
+    const val PRESENCE = "m.presence"
+    const val MESSAGE = "m.room.message"
+    const val STICKER = "m.sticker"
+    const val ENCRYPTED = "m.room.encrypted"
+    const val FEEDBACK = "m.room.message.feedback"
+    const val TYPING = "m.typing"
+    const val REDACTION = "m.room.redaction"
+    const val RECEIPT = "m.receipt"
+    const val ROOM_KEY = "m.room_key"
+    const val PLUMBING = "m.room.plumbing"
+    const val BOT_OPTIONS = "m.room.bot.options"
+    const val PREVIEW_URLS = "org.matrix.room.preview_urls"
+
+    // State Events
+
+    const val STATE_ROOM_WIDGET_LEGACY = "im.vector.modular.widgets"
+    const val STATE_ROOM_WIDGET = "m.widget"
+    const val STATE_ROOM_NAME = "m.room.name"
+    const val STATE_ROOM_TOPIC = "m.room.topic"
+    const val STATE_ROOM_AVATAR = "m.room.avatar"
+    const val STATE_ROOM_MEMBER = "m.room.member"
+    const val STATE_ROOM_THIRD_PARTY_INVITE = "m.room.third_party_invite"
+    const val STATE_ROOM_CREATE = "m.room.create"
+    const val STATE_ROOM_JOIN_RULES = "m.room.join_rules"
+    const val STATE_ROOM_GUEST_ACCESS = "m.room.guest_access"
+    const val STATE_ROOM_POWER_LEVELS = "m.room.power_levels"
+
+    const val STATE_SPACE_CHILD = "m.space.child"
+    const val STATE_SPACE_PARENT = "m.space.parent"
+
+    /**
+     * Note that this Event has been deprecated, see
+     * - https://matrix.org/docs/spec/client_server/r0.6.1#historical-events
+     * - https://github.com/matrix-org/matrix-doc/pull/2432
+     */
+    const val STATE_ROOM_ALIASES = "m.room.aliases"
+    const val STATE_ROOM_TOMBSTONE = "m.room.tombstone"
+    const val STATE_ROOM_CANONICAL_ALIAS = "m.room.canonical_alias"
+    const val STATE_ROOM_HISTORY_VISIBILITY = "m.room.history_visibility"
+    const val STATE_ROOM_RELATED_GROUPS = "m.room.related_groups"
+    const val STATE_ROOM_PINNED_EVENT = "m.room.pinned_events"
+    const val STATE_ROOM_ENCRYPTION = "m.room.encryption"
+    const val STATE_ROOM_SERVER_ACL = "m.room.server_acl"
+
+    // Call Events
+    const val CALL_INVITE = "m.call.invite"
+    const val CALL_CANDIDATES = "m.call.candidates"
+    const val CALL_ANSWER = "m.call.answer"
+    const val CALL_SELECT_ANSWER = "m.call.select_answer"
+    const val CALL_NEGOTIATE = "m.call.negotiate"
+    const val CALL_REJECT = "m.call.reject"
+    const val CALL_HANGUP = "m.call.hangup"
+
+    // This type is not processed by the client, just sent to the server
+    const val CALL_REPLACES = "m.call.replaces"
+
+    // Key share events
+    const val ROOM_KEY_REQUEST = "m.room_key_request"
+    const val FORWARDED_ROOM_KEY = "m.forwarded_room_key"
+
+    const val REQUEST_SECRET = "m.secret.request"
+    const val SEND_SECRET = "m.secret.send"
+
+    // Relation Events
+    const val REACTION = "m.reaction"
+
+    fun isCallEvent(type: String): Boolean {
+        return type == CALL_INVITE ||
+                type == CALL_CANDIDATES ||
+                type == CALL_ANSWER ||
+                type == CALL_HANGUP ||
+                type == CALL_SELECT_ANSWER ||
+                type == CALL_NEGOTIATE ||
+                type == CALL_REJECT ||
+                type == CALL_REPLACES
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.matrix.api.pusher.PushersService
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.api.room.RoomSummaryDataSource
+import io.element.android.libraries.matrix.api.timeline.item.event.EventType
 import io.element.android.libraries.matrix.api.user.MatrixSearchUserResults
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
@@ -114,9 +115,9 @@ class RustMatrixClient constructor(
         .timelineLimit(limit = 1u)
         .requiredState(
             requiredState = listOf(
-                RequiredState(key = "m.room.avatar", value = ""),
-                RequiredState(key = "m.room.encryption", value = ""),
-                RequiredState(key = "m.room.join_rules", value = ""),
+                RequiredState(key = EventType.STATE_ROOM_AVATAR, value = ""),
+                RequiredState(key = EventType.STATE_ROOM_ENCRYPTION, value = ""),
+                RequiredState(key = EventType.STATE_ROOM_JOIN_RULES, value = ""),
             )
         )
         .filters(visibleRoomsSlidingSyncFilters)
@@ -136,9 +137,9 @@ class RustMatrixClient constructor(
         .timelineLimit(limit = 1u)
         .requiredState(
             requiredState = listOf(
-                RequiredState(key = "m.room.avatar", value = ""),
-                RequiredState(key = "m.room.encryption", value = ""),
-                RequiredState(key = "m.room.canonical_alias", value = ""),
+                RequiredState(key = EventType.STATE_ROOM_AVATAR, value = ""),
+                RequiredState(key = EventType.STATE_ROOM_ENCRYPTION, value = ""),
+                RequiredState(key = EventType.STATE_ROOM_CANONICAL_ALIAS, value = ""),
             )
         )
         .filters(invitesSlidingSyncFilters)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -153,7 +153,7 @@ class RustMatrixClient constructor(
 
     private val slidingSync = client
         .slidingSync()
-        .homeserver("https://slidingsync.lab.matrix.org")
+        // .homeserver("https://slidingsync.lab.matrix.org")
         .withCommonExtensions()
         .storageKey("ElementX")
         .addList(visibleRoomsSlidingSyncListBuilder)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.timeline.MatrixTimeline
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
+import io.element.android.libraries.matrix.api.timeline.item.event.EventType
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventMessageMapper
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventTimelineItemMapper
 import io.element.android.libraries.matrix.impl.timeline.item.event.TimelineEventContentMapper
@@ -149,10 +150,10 @@ class RustMatrixTimeline(
         runCatching {
             val settings = RoomSubscription(
                 requiredState = listOf(
-                    RequiredState(key = "m.room.canonical_alias", value = ""),
-                    RequiredState(key = "m.room.topic", value = ""),
-                    RequiredState(key = "m.room.join_rules", value = ""),
-                    RequiredState(key = "m.room.power_levels", value = ""),
+                    RequiredState(key = EventType.STATE_ROOM_CANONICAL_ALIAS, value = ""),
+                    RequiredState(key = EventType.STATE_ROOM_TOPIC, value = ""),
+                    RequiredState(key = EventType.STATE_ROOM_JOIN_RULES, value = ""),
+                    RequiredState(key = EventType.STATE_ROOM_POWER_LEVELS, value = ""),
                 ),
                 timelineLimit = null
             )

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventProcessor.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventProcessor.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.libraries.push.impl.notifications
 
+import io.element.android.libraries.matrix.api.timeline.item.event.EventType
 import io.element.android.libraries.push.impl.notifications.model.InviteNotifiableEvent
 import io.element.android.libraries.push.impl.notifications.model.NotifiableEvent
 import io.element.android.libraries.push.impl.notifications.model.NotifiableMessageEvent
@@ -49,7 +50,7 @@ class NotifiableEventProcessor @Inject constructor(
                     else -> ProcessedEvent.Type.KEEP
                 }
                 is SimpleNotifiableEvent -> when (it.type) {
-                    /*EventType.REDACTION*/ "m.room.redaction" -> ProcessedEvent.Type.REMOVE
+                    EventType.REDACTION -> ProcessedEvent.Type.REMOVE
                     else -> ProcessedEvent.Type.KEEP
                 }
             }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/model/NotifiableMessageEvent.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/model/NotifiableMessageEvent.kt
@@ -20,6 +20,7 @@ import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.core.ThreadId
+import io.element.android.libraries.matrix.api.timeline.item.event.EventType
 import io.element.android.services.appnavstate.api.AppNavigationState
 import io.element.android.services.appnavstate.api.currentRoomId
 import io.element.android.services.appnavstate.api.currentSessionId
@@ -52,7 +53,7 @@ data class NotifiableMessageEvent(
     override val isUpdated: Boolean = false
 ) : NotifiableEvent {
 
-    val type: String = /* EventType.MESSAGE */ "m.room.message"
+    val type: String = EventType.MESSAGE
     val description: String = body ?: ""
     val title: String = senderName ?: ""
 

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventProcessorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventProcessorTest.kt
@@ -17,6 +17,7 @@
 package io.element.android.libraries.push.impl.notifications
 
 import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.timeline.item.event.EventType
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.AN_EVENT_ID_2
 import io.element.android.libraries.matrix.test.A_ROOM_ID
@@ -60,7 +61,7 @@ class NotifiableEventProcessorTest {
 
     @Test
     fun `given redacted simple event when processing then remove redaction event`() {
-        val events = listOf(aSimpleNotifiableEvent(eventId = AN_EVENT_ID, type = "m.room.redaction"))
+        val events = listOf(aSimpleNotifiableEvent(eventId = AN_EVENT_ID, type = EventType.REDACTION))
 
         val result = eventProcessor.process(events, appNavigationState = NOT_VIEWING_A_ROOM, renderedEvents = emptyList())
 


### PR DESCRIPTION
- Remove hard-coded sliding sync proxy `https://slidingsync.lab.matrix.org`. Login still OK on some matrix.org accounts, very slow on some other, this is strange. Fixes #473
- Import `EventType` from the previous SDK.
