### PR TITLE
Fix flaky media tests.

### DIFF
--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.features.messages
 
+import android.net.Uri
 import app.cash.molecule.RecompositionClock
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
@@ -40,11 +41,15 @@ import io.element.android.libraries.mediapickers.test.FakePickerProvider
 import io.element.android.libraries.mediaupload.api.MediaSender
 import io.element.android.libraries.mediaupload.test.FakeMediaPreProcessor
 import io.element.android.libraries.textcomposer.MessageComposerMode
+import io.mockk.mockk
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class MessagesPresenterTest {
+
+    private val mockMediaUrl: Uri = mockk("localMediaUri")
+
     @Test
     fun `present - initial state`() = runTest {
         val presenter = createMessagePresenter()
@@ -135,7 +140,7 @@ class MessagesPresenterTest {
             room = matrixRoom,
             mediaPickerProvider = FakePickerProvider(),
             featureFlagService = FakeFeatureFlagService(),
-            localMediaFactory = FakeLocalMediaFactory(),
+            localMediaFactory = FakeLocalMediaFactory(mockMediaUrl),
             mediaSender = MediaSender(FakeMediaPreProcessor(),matrixRoom),
             snackbarDispatcher = SnackbarDispatcher(),
         )

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/attachments/AttachmentsPreviewPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/attachments/AttachmentsPreviewPresenterTest.kt
@@ -18,6 +18,7 @@
 
 package io.element.android.features.messages.attachments
 
+import android.net.Uri
 import androidx.media3.common.MimeTypes
 import app.cash.molecule.RecompositionClock
 import app.cash.molecule.moleculeFlow
@@ -35,6 +36,7 @@ import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
 import io.element.android.libraries.mediaupload.api.MediaPreProcessor
 import io.element.android.libraries.mediaupload.api.MediaSender
 import io.element.android.libraries.mediaupload.test.FakeMediaPreProcessor
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -42,6 +44,7 @@ import org.junit.Test
 class AttachmentsPreviewPresenterTest {
 
     private val mediaPreProcessor = FakeMediaPreProcessor()
+    private val mockMediaUrl: Uri = mockk("localMediaUri")
 
     @Test
     fun `present - send media success scenario`() = runTest {
@@ -87,7 +90,10 @@ class AttachmentsPreviewPresenterTest {
     }
 
     private fun anAttachmentsPreviewPresenter(
-        localMedia: LocalMedia = aLocalMedia(mimeType = MimeTypes.IMAGE_JPEG),
+        localMedia: LocalMedia = aLocalMedia(
+            uri = mockMediaUrl,
+            mimeType = MimeTypes.IMAGE_JPEG
+        ),
         room: MatrixRoom = FakeMatrixRoom()
     ): AttachmentsPreviewPresenter {
         return AttachmentsPreviewPresenter(

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/fixtures/media.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/fixtures/media.kt
@@ -23,7 +23,7 @@ import io.element.android.features.messages.impl.media.local.LocalMedia
 import io.mockk.mockk
 
 fun aLocalMedia(
-    uri: Uri = mockk("localMediaUri"),
+    uri: Uri,
     mimeType: String = MimeTypes.IMAGE_JPEG,
     name: String = "a media",
     size: Long = 1000,

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/media/FakeLocalMediaFactory.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/media/FakeLocalMediaFactory.kt
@@ -23,12 +23,12 @@ import io.element.android.features.messages.impl.media.local.LocalMediaFactory
 import io.element.android.libraries.core.mimetype.MimeTypes
 import io.element.android.libraries.matrix.api.media.MediaFile
 
-class FakeLocalMediaFactory : LocalMediaFactory {
+class FakeLocalMediaFactory(private val localMediaUri: Uri) : LocalMediaFactory {
 
     var fallbackMimeType: String = MimeTypes.OctetStream
 
     override fun createFromMediaFile(mediaFile: MediaFile, mimeType: String?): LocalMedia {
-        return aLocalMedia(mimeType = mimeType ?: fallbackMimeType)
+        return aLocalMedia(uri = localMediaUri, mimeType = mimeType ?: fallbackMimeType)
     }
 
     override fun createFromUri(uri: Uri, mimeType: String?): LocalMedia {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/media/viewer/MediaViewerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/media/viewer/MediaViewerPresenterTest.kt
@@ -18,6 +18,7 @@
 
 package io.element.android.features.messages.media.viewer
 
+import android.net.Uri
 import androidx.media3.common.MimeTypes
 import app.cash.molecule.RecompositionClock
 import app.cash.molecule.moleculeFlow
@@ -31,6 +32,7 @@ import io.element.android.libraries.architecture.Async
 import io.element.android.libraries.matrix.test.FAKE_DELAY_IN_MS
 import io.element.android.libraries.matrix.test.media.FakeMediaLoader
 import io.element.android.libraries.matrix.test.media.aMediaSource
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -40,7 +42,8 @@ private const val TESTED_MEDIA_NAME = "MediaName"
 
 class MediaViewerPresenterTest {
 
-    private val localMediaFactory = FakeLocalMediaFactory()
+    private val mockMediaUrl: Uri = mockk("localMediaUri")
+    private val localMediaFactory = FakeLocalMediaFactory(mockMediaUrl)
     private val mediaLoader = FakeMediaLoader()
 
     @Test

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/textcomposer/MessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/textcomposer/MessageComposerPresenterTest.kt
@@ -18,6 +18,7 @@
 
 package io.element.android.features.messages.textcomposer
 
+import android.net.Uri
 import app.cash.molecule.RecompositionClock
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.ReceiveTurbine
@@ -69,7 +70,8 @@ class MessageComposerPresenterTest {
     )
     private val mediaPreProcessor = FakeMediaPreProcessor()
     private val snackbarDispatcher = SnackbarDispatcher()
-    private val localMediaFactory = FakeLocalMediaFactory()
+    private val mockMediaUrl: Uri = mockk("localMediaUri")
+    private val localMediaFactory = FakeLocalMediaFactory(mockMediaUrl)
 
     @Test
     fun `present - initial state`() = runTest {


### PR DESCRIPTION
Creating a mock during the test run seems to sometimes take a large amount of time when running the tests in parallel (possibly some kind of resource contention?)

Instead, perform the mocking in the test class so it's part of the setup, not the  actual test runs.