### PR TITLE
Danger: don't complain about reviewers

### DIFF
--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -171,11 +171,6 @@ if (hasPngs) {
     warn("You seem to have made changes to some images. Please consider using an vector drawable.")
 }
 
-// Check for reviewers
-if (github.requested_reviewers.users.length == 0 && !pr.draft) {
-    warn("Please add a reviewer to your PR.")
-}
-
 // Check that translations have not been modified by developers
 const translationAllowList = [
     "RiotTranslateBot",


### PR DESCRIPTION
Now we have a CODEOWNERS file a reviewer is assigned automatically, so there's no need for this.

It also misfires a bunch (maybe if there are no _pending_ reviewers because they've already reviewed?), so removing it fixes that noise.