### PR TITLE
Ignore `PdfViewerState` for kover merged verify

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -222,6 +222,7 @@ koverMerged {
                 excludes += "io.element.android.libraries.matrix.api.timeline.item.event.EventSendState$*"
                 excludes += "io.element.android.libraries.matrix.api.room.RoomMembershipState*"
                 excludes += "io.element.android.libraries.push.impl.notifications.NotificationState*"
+                excludes += "io.element.android.features.messages.impl.media.local.pdf.PdfViewerState"
             }
             bound {
                 minValue = 90


### PR DESCRIPTION
This was a false positive in coverage, since it's not really a presenter's state and it uses lots of Android SDK components that can't be unit tested.

Ignoring it should fix the kover verification step.