### PR TITLE
Add gradle cache to 'record screenshots' workflow

### DIFF
--- a/.github/workflows/recordScreenshots.yml
+++ b/.github/workflows/recordScreenshots.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
+      # Add gradle cache, this should speed up the process
+      - name: Configure gradle
+        uses: gradle/gradle-build-action@v2.4.2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Record screenshots
         run: "./.github/workflows/scripts/recordScreenshots.sh"
         env:


### PR DESCRIPTION
This reduces the workflow time from [15min](https://github.com/vector-im/element-x-android/actions/runs/5174149941) to [~6:30min](https://github.com/vector-im/element-x-android/actions/runs/5174254583/jobs/9320367977).