### PR TITLE
Network library changes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -216,7 +216,8 @@ dependencies {
     implementation(libs.coil)
 
     implementation(platform(libs.network.okhttp.bom))
-    implementation("com.squareup.okhttp3:logging-interceptor")
+    implementation(libs.network.okhttp.logging)
+    implementation(libs.serialization.json)
 
     implementation(libs.dagger)
     kapt(libs.dagger.compiler)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,6 +104,8 @@ squareup_seismic = "com.squareup:seismic:1.0.3"
 
 # network
 network_okhttp_bom = "com.squareup.okhttp3:okhttp-bom:4.11.0"
+network_okhttp_logging = { module = "com.squareup.okhttp3:logging-interceptor" }
+network_okhttp = { module = "com.squareup.okhttp3:okhttp" }
 network_retrofit = "com.squareup.retrofit2:retrofit:2.9.0"
 network_retrofit_converter_serialization = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0"
 

--- a/libraries/network/build.gradle.kts
+++ b/libraries/network/build.gradle.kts
@@ -31,9 +31,8 @@ dependencies {
     implementation(projects.libraries.core)
     implementation(projects.libraries.di)
     implementation(platform(libs.network.okhttp.bom))
-    implementation("com.squareup.okhttp3:okhttp")
-    implementation("com.squareup.okhttp3:logging-interceptor")
-
+    implementation(libs.network.okhttp)
+    implementation(libs.network.okhttp.logging)
     implementation(libs.network.retrofit)
     implementation(libs.network.retrofit.converter.serialization)
     implementation(libs.serialization.json)

--- a/libraries/network/src/main/kotlin/io/element/android/libraries/network/RetrofitFactory.kt
+++ b/libraries/network/src/main/kotlin/io/element/android/libraries/network/RetrofitFactory.kt
@@ -17,23 +17,21 @@
 package io.element.android.libraries.network
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
-import dagger.Lazy
 import io.element.android.libraries.core.uri.ensureTrailingSlash
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import javax.inject.Inject
+import javax.inject.Provider
 
 class RetrofitFactory @Inject constructor(
-    private val okHttpClient: Lazy<OkHttpClient>,
+    private val okHttpClient: Provider<OkHttpClient>,
+    private val json: Provider<Json>,
 ) {
-    fun create(baseUrl: String): Retrofit {
-        val contentType = "application/json".toMediaType()
-        return Retrofit.Builder()
-            .baseUrl(baseUrl.ensureTrailingSlash())
-            .addConverterFactory(Json.asConverterFactory(contentType))
-            .callFactory { request -> okHttpClient.get().newCall(request) }
-            .build()
-    }
+    fun create(baseUrl: String): Retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl.ensureTrailingSlash())
+        .addConverterFactory(json.get().asConverterFactory("application/json".toMediaType()))
+        .callFactory(okHttpClient.get())
+        .build()
 }


### PR DESCRIPTION
- Allows for http2
- Caches a global instance of kotlinx-serialization `Json` and configures it with a bit more leniency.
- Moves okhttp's dependency strings to the .toml file
- Switches off logging for release builds