### PR TITLE
GH Workflows: move deps check, fix nightly

### DIFF
--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -17,7 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'vector-im/element-x-android' }}
     steps:
-      - uses: actions/checkout@v3
+      - name: ⏬ Checkout with LFS
+        uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+
       - name: Use JDK 17
         uses: actions/setup-java@v3
         with:
@@ -41,3 +45,27 @@ jobs:
           ORG_GRADLE_PROJECT_SONAR_LOGIN: ${{ secrets.SONAR_TOKEN }}
         if: ${{ always() && env.SONAR_TOKEN != '' && env.ORG_GRADLE_PROJECT_SONAR_LOGIN != '' }}
         run: ./gradlew sonar $CI_GRADLE_ARG_PROPERTIES
+
+  # Gradle dependency analysis using https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin
+  dependency-analysis:
+    name: Dependency analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
+      - name: Configure gradle
+        uses: gradle/gradle-build-action@v2.4.2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
+      - name: Dependency analysis
+        run: ./gradlew dependencyCheckAnalyze $CI_GRADLE_ARG_PROPERTIES
+      - name: Upload dependency analysis
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: dependency-analysis
+          path: build/reports/dependency-check-report.html

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,35 +66,3 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
           # Fallback for forks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Gradle dependency analysis using https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin
-  dependency-analysis:
-    name: Dependency analysis
-    runs-on: ubuntu-latest
-    # Allow all jobs on main and develop. Just one per PR.
-    concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && format('dep-main-{0}', github.sha) || github.ref == 'refs/heads/develop' && format('dep-develop-{0}', github.sha) || format('dep-{0}', github.ref) }}
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # Ensure we are building the branch and not the branch after being merged on develop
-          # https://github.com/actions/checkout/issues/881
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
-      - name: Use JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
-      - name: Configure gradle
-        uses: gradle/gradle-build-action@v2.4.2
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-      - name: Dependency analysis
-        run: ./gradlew dependencyCheckAnalyze $CI_GRADLE_ARG_PROPERTIES
-      - name: Upload dependency analysis
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: dependency-analysis
-          path: build/reports/dependency-check-report.html


### PR DESCRIPTION
Move the dependency check job from the quality workflow that runs on every PR to the nightly reports workflow. This sometimes flakes as it does a _lot_ of HTTP requests. It's less intrusive if that happens outside of the PR workflow.

Also change the nightly job that runs tests to use LFS, so it actually has access to screenshots :)

The sonar task is still broken, but it seems like an upstream bug: https://community.sonarsource.com/t/sonar-plugin-4-1-0-3113-4-2-0-3129-errors/91568