### PR TITLE
Lazy use the OkHttpClient.

### DIFF
--- a/libraries/network/src/main/kotlin/io/element/android/libraries/network/RetrofitFactory.kt
+++ b/libraries/network/src/main/kotlin/io/element/android/libraries/network/RetrofitFactory.kt
@@ -32,6 +32,6 @@ class RetrofitFactory @Inject constructor(
     fun create(baseUrl: String): Retrofit = Retrofit.Builder()
         .baseUrl(baseUrl.ensureTrailingSlash())
         .addConverterFactory(json.get().asConverterFactory("application/json".toMediaType()))
-        .callFactory(okHttpClient.get())
+        .callFactory { request -> okHttpClient.get().newCall(request) }
         .build()
 }


### PR DESCRIPTION
I missed that change when reviewing #542.
I think it's better to lazy load the OkHttpClient.