### PR TITLE
Fix bad namespace.

### DIFF
--- a/libraries/mediaupload/test/build.gradle.kts
+++ b/libraries/mediaupload/test/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 }
 
 android {
-    namespace = "io.element.android.libraries.matrix.test"
+    namespace = "io.element.android.libraries.mediaupload.test"
 }
 
 dependencies {


### PR DESCRIPTION
There were a warning: Namespace 'io.element.android.libraries.matrix.test' used in: :libraries:matrix:test, :libraries:mediaupload:test.