### PR TITLE
Disable kotlin incremental compilation for now, waiting for better

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,6 +38,9 @@ android.nonTransitiveRClass=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.parallel=true
+# Check here for the reasons https://github.com/square/anvil/issues/693
+# useClasspathSnapshot=false is not enough in most cases.
+kotlin.incremental=false
 
 # Dummy values for signing secrets / nightly
 signing.element.nightly.storePassword=Secret


### PR DESCRIPTION
See [here](https://github.com/square/anvil/issues/693) for the reason.
If it ends up being too slow we might want to `-Pkotlin.incremental=false` command line argument when needed instead.