### PR TITLE
[Message Actions] Add emoji reactions option

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -219,6 +219,8 @@ dependencies {
     implementation(libs.network.okhttp.logging)
     implementation(libs.serialization.json)
 
+    implementation(libs.vanniktech.emoji)
+
     implementation(libs.dagger)
     kapt(libs.dagger.compiler)
 

--- a/app/src/main/kotlin/io/element/android/x/ElementXApplication.kt
+++ b/app/src/main/kotlin/io/element/android/x/ElementXApplication.kt
@@ -23,6 +23,7 @@ import io.element.android.libraries.di.DaggerComponentOwner
 import io.element.android.x.di.DaggerAppComponent
 import io.element.android.x.info.logApplicationInfo
 import io.element.android.x.initializer.CrashInitializer
+import io.element.android.x.initializer.EmojiInitializer
 import io.element.android.x.initializer.MatrixInitializer
 import io.element.android.x.initializer.TimberInitializer
 
@@ -40,6 +41,7 @@ class ElementXApplication : Application(), DaggerComponentOwner {
             initializeComponent(CrashInitializer::class.java)
             initializeComponent(TimberInitializer::class.java)
             initializeComponent(MatrixInitializer::class.java)
+            initializeComponent(EmojiInitializer::class.java)
         }
         logApplicationInfo()
     }

--- a/app/src/main/kotlin/io/element/android/x/initializer/EmojiInitializer.kt
+++ b/app/src/main/kotlin/io/element/android/x/initializer/EmojiInitializer.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.x.initializer
+
+import androidx.startup.Initializer
+import com.vanniktech.emoji.EmojiManager
+import com.vanniktech.emoji.google.GoogleEmojiProvider
+
+class EmojiInitializer : Initializer<Unit> {
+    override fun create(context: android.content.Context) {
+        EmojiManager.install(GoogleEmojiProvider())
+    }
+
+    override fun dependencies(): MutableList<Class<out Initializer<*>>> = mutableListOf()
+}

--- a/changelog.d/563.feature
+++ b/changelog.d/563.feature
@@ -1,0 +1,1 @@
+Add emoji reactions to the event context menu and allow sending custom reactions.

--- a/features/messages/impl/build.gradle.kts
+++ b/features/messages/impl/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(libs.accompanist.systemui)
     implementation(libs.vanniktech.blurhash)
     implementation(libs.telephoto.zoomableimage)
+    implementation(libs.vanniktech.emoji)
 
     testImplementation(libs.test.junit)
     testImplementation(libs.coroutines.test)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesEvents.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesEvents.kt
@@ -18,7 +18,9 @@ package io.element.android.features.messages.impl
 
 import io.element.android.features.messages.impl.actionlist.model.TimelineItemAction
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.libraries.matrix.api.core.EventId
 
 sealed interface MessagesEvents {
     data class HandleAction(val action: TimelineItemAction, val event: TimelineItem.Event) : MessagesEvents
+    data class SendReaction(val emoji: String, val eventId: EventId) : MessagesEvents
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -45,6 +45,7 @@ import io.element.android.features.messages.impl.utils.messagesummary.MessageSum
 import io.element.android.features.networkmonitor.api.NetworkMonitor
 import io.element.android.features.networkmonitor.api.NetworkStatus
 import io.element.android.libraries.architecture.Presenter
+import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.designsystem.utils.SnackbarDispatcher
@@ -67,6 +68,7 @@ class MessagesPresenter @Inject constructor(
     private val networkMonitor: NetworkMonitor,
     private val snackbarDispatcher: SnackbarDispatcher,
     private val messageSummaryFormatter: MessageSummaryFormatter,
+    private val dispatchers: CoroutineDispatchers,
 ) : Presenter<MessagesState> {
 
     @Composable
@@ -139,7 +141,7 @@ class MessagesPresenter @Inject constructor(
     private fun CoroutineScope.sendReaction(
         emoji: String,
         eventId: EventId,
-    ) = launch {
+    ) = launch(dispatchers.io) {
         room.sendReaction(emoji, eventId)
             .onFailure { Timber.e(it) }
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -49,6 +49,7 @@ import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.designsystem.utils.SnackbarDispatcher
 import io.element.android.libraries.designsystem.utils.handleSnackbarMessage
+import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.ui.components.AttachmentThumbnailInfo
 import io.element.android.libraries.matrix.ui.components.AttachmentThumbnailType
@@ -103,6 +104,7 @@ class MessagesPresenter @Inject constructor(
         fun handleEvents(event: MessagesEvents) {
             when (event) {
                 is MessagesEvents.HandleAction -> localCoroutineScope.handleTimelineAction(event.action, event.event, composerState)
+                is MessagesEvents.SendReaction -> localCoroutineScope.sendReaction(event.emoji, event.eventId)
             }
         }
         return MessagesState(
@@ -118,7 +120,7 @@ class MessagesPresenter @Inject constructor(
         )
     }
 
-    fun CoroutineScope.handleTimelineAction(
+    private fun CoroutineScope.handleTimelineAction(
         action: TimelineItemAction,
         targetEvent: TimelineItem.Event,
         composerState: MessageComposerState,
@@ -132,6 +134,14 @@ class MessagesPresenter @Inject constructor(
             TimelineItemAction.Developer -> Unit // Handled at UI level
             TimelineItemAction.ReportContent -> notImplementedYet()
         }
+    }
+
+    private fun CoroutineScope.sendReaction(
+        emoji: String,
+        eventId: EventId,
+    ) = launch {
+        room.sendReaction(emoji, eventId)
+            .onFailure { Timber.e(it) }
     }
 
     private fun notImplementedYet() {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -131,6 +131,12 @@ fun MessagesView(
         }
     }
 
+    fun onEmojiReactionClicked(emoji: String, event: TimelineItem.Event) {
+        if (event.eventId == null) return
+        isMessageActionsBottomSheetVisible = false
+        state.eventSink(MessagesEvents.SendReaction(emoji, event.eventId))
+    }
+
     fun onDismissActionListBottomSheet() {
         isMessageActionsBottomSheetVisible = false
     }
@@ -172,7 +178,8 @@ fun MessagesView(
         state = state.actionListState,
         isVisible = isMessageActionsBottomSheetVisible,
         onDismiss = ::onDismissActionListBottomSheet,
-        onActionSelected = ::onActionSelected
+        onActionSelected = ::onActionSelected,
+        onEmojiReactionClicked = ::onEmojiReactionClicked,
     )
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
@@ -17,6 +17,7 @@
 package io.element.android.features.messages.impl.actionlist
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,6 +36,7 @@ import androidx.compose.material.ListItem
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AddReaction
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SheetState
@@ -284,6 +286,8 @@ private fun MessageSummary(event: TimelineItem.Event, modifier: Modifier = Modif
     }
 }
 
+private val emojiRippleRadius = 24.dp
+
 @Composable
 internal fun EmojiReactionsRow(
     onEmojiReactionClicked: (String) -> Unit,
@@ -294,11 +298,14 @@ internal fun EmojiReactionsRow(
         horizontalArrangement = Arrangement.SpaceBetween,
         modifier = modifier.padding(horizontal = 28.dp, vertical = 16.dp)
     ) {
-        EmojiButton("\uD83D\uDC4D", onEmojiReactionClicked)
-        EmojiButton("\uD83D\uDC4E", onEmojiReactionClicked)
-        EmojiButton("\uD83D\uDD25", onEmojiReactionClicked)
-        EmojiButton("❤\uFE0F", onEmojiReactionClicked)
-        EmojiButton("\uD83D\uDC4F", onEmojiReactionClicked)
+        // TODO use most recently used emojis here when available from the Rust SDK
+        val defaultEmojis = sequenceOf(
+            "👍", "👎", "🔥", "❤️", "👏"
+        )
+        for (emoji in defaultEmojis) {
+            EmojiButton(emoji, onEmojiReactionClicked)
+        }
+
         Icon(
             imageVector = Icons.Outlined.AddReaction,
             contentDescription = "Emojis",
@@ -306,7 +313,12 @@ internal fun EmojiReactionsRow(
             modifier = Modifier
                 .size(24.dp)
                 .align(Alignment.CenterVertically)
-                .clickable(enabled = true, onClick = onCustomReactionClicked)
+                .clickable(
+                    enabled = true,
+                    onClick = onCustomReactionClicked,
+                    indication = rememberRipple(bounded = false, radius = emojiRippleRadius),
+                    interactionSource = remember { MutableInteractionSource() }
+                )
         )
     }
 }
@@ -317,7 +329,16 @@ private fun EmojiButton(
     onClicked: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Text(emoji, fontSize = 28.dpToSp(), modifier = modifier.clickable { onClicked(emoji) })
+    Text(
+        emoji,
+        fontSize = 28.dpToSp(),
+        modifier = modifier.clickable(
+            enabled = true,
+            onClick = { onClicked(emoji) },
+            indication = rememberRipple(bounded = false, radius = emojiRippleRadius),
+            interactionSource = remember { MutableInteractionSource() }
+        )
+    )
 }
 
 @Composable

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
@@ -132,10 +132,10 @@ fun ActionListView(
 @Composable
 private fun SheetContent(
     state: ActionListState,
-    modifier: Modifier = Modifier,
     onActionClicked: (TimelineItemAction) -> Unit,
     onEmojiReactionClicked: (String) -> Unit,
     onCustomReactionClicked: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     when (val target = state.target) {
         is ActionListState.Target.Loading,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/EmojiPicker.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/EmojiPicker.kt
@@ -29,6 +29,8 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.runtime.Composable
@@ -43,12 +45,30 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.vanniktech.emoji.Emoji
 import com.vanniktech.emoji.google.GoogleEmojiProvider
 import io.element.android.libraries.designsystem.preview.ElementPreviewDark
 import io.element.android.libraries.designsystem.preview.ElementPreviewLight
 import io.element.android.libraries.designsystem.theme.components.Icon
+import io.element.android.libraries.designsystem.theme.components.ModalBottomSheet
 import io.element.android.libraries.designsystem.theme.components.Text
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomReactionBottomSheet(
+    isVisible: Boolean,
+    sheetState: SheetState,
+    onDismiss: () -> Unit,
+    onEmojiSelected: (Emoji) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (isVisible) {
+        ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState, modifier = modifier) {
+            EmojiPicker(onEmojiSelected = onEmojiSelected, modifier = Modifier.fillMaxWidth())
+        }
+    }
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -106,8 +126,10 @@ fun EmojiPicker(
                 horizontalArrangement = Arrangement.SpaceEvenly,
             ) {
                 items(currentCategory.emojis, key = { it.unicode }) { item ->
-                    Box(modifier = Modifier.size(40.dp).clickable { onEmojiSelected(item) }, contentAlignment = Alignment.Center) {
-                        Text(text = item.unicode)
+                    Box(modifier = Modifier
+                        .size(40.dp)
+                        .clickable { onEmojiSelected(item) }, contentAlignment = Alignment.Center) {
+                        Text(text = item.unicode, fontSize = 20.sp)
                     }
                 }
             }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/EmojiPicker.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/EmojiPicker.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -63,7 +64,7 @@ fun CustomReactionBottomSheet(
 ) {
     if (isVisible) {
         ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState, modifier = modifier) {
-            EmojiPicker(onEmojiSelected = onEmojiSelected, modifier = Modifier.fillMaxWidth())
+            EmojiPicker(onEmojiSelected = onEmojiSelected, modifier = Modifier.fillMaxSize())
         }
     }
 }
@@ -106,7 +107,7 @@ fun EmojiPicker(
         ) { index ->
             val category = categories[index]
             LazyVerticalGrid(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxSize(),
                 columns = GridCells.Adaptive(minSize = 40.dp),
                 contentPadding = PaddingValues(vertical = 10.dp, horizontal = 16.dp),
                 horizontalArrangement = Arrangement.SpaceEvenly,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/EmojiPicker.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/EmojiPicker.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.timeline.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vanniktech.emoji.Emoji
+import com.vanniktech.emoji.google.GoogleEmojiProvider
+import io.element.android.libraries.designsystem.preview.ElementPreviewDark
+import io.element.android.libraries.designsystem.preview.ElementPreviewLight
+import io.element.android.libraries.designsystem.theme.components.Icon
+import io.element.android.libraries.designsystem.theme.components.Text
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun EmojiPicker(
+    onEmojiSelected: (Emoji) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var selectedTabIndex by rememberSaveable {
+        mutableStateOf(0)
+    }
+
+    val emojiProvider = remember { GoogleEmojiProvider() }
+    val categories = remember { emojiProvider.categories }
+    Column (modifier) {
+        TabRow(
+            selectedTabIndex = selectedTabIndex,
+        ) {
+            categories.forEachIndexed { index, category ->
+                Tab(
+                    text = {
+                        Icon(
+                            resourceId = emojiProvider.getIcon(category),
+                            contentDescription = category.categoryNames["en"]
+                        )
+                    },
+                    selected = selectedTabIndex == index,
+                    onClick = {
+                        selectedTabIndex = index
+                    }
+                )
+            }
+        }
+        val currentCategory = remember(selectedTabIndex) { categories[selectedTabIndex] }
+        val pagerState = rememberPagerState()
+
+        LaunchedEffect(selectedTabIndex) {
+            pagerState.animateScrollToPage(selectedTabIndex)
+        }
+
+        LaunchedEffect(pagerState) {
+            snapshotFlow { pagerState.currentPage }.collect { page ->
+                selectedTabIndex = page
+            }
+        }
+
+        HorizontalPager(
+            pageCount = categories.size,
+            state = pagerState,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            LazyVerticalGrid(
+                modifier = Modifier.fillMaxWidth(),
+                columns = GridCells.Adaptive(minSize = 40.dp),
+                contentPadding = PaddingValues(vertical = 10.dp, horizontal = 16.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                items(currentCategory.emojis, key = { it.unicode }) { item ->
+                    Box(modifier = Modifier.size(40.dp).clickable { onEmojiSelected(item) }, contentAlignment = Alignment.Center) {
+                        Text(text = item.unicode)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun EmojiPickerLightPreview() {
+    ElementPreviewLight {
+        EmojiPicker(
+            onEmojiSelected = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview
+@Composable
+fun EmojiPickerDarkPreview() {
+    ElementPreviewDark {
+        EmojiPicker(
+            onEmojiSelected = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -149,6 +149,7 @@ unifiedpush = "com.github.UnifiedPush:android-connector:2.1.1"
 gujun_span = "me.gujun.android:span:1.7"
 otaliastudios_transcoder = "com.otaliastudios:transcoder:0.10.5"
 vanniktech_blurhash = "com.vanniktech:blurhash:0.1.0"
+vanniktech_emoji = "com.vanniktech:emoji-google:0.16.0"
 telephoto_zoomableimage = { module = "me.saket.telephoto:zoomable-image-coil", version.ref = "telephoto" }
 
 # Analytics

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -81,6 +81,8 @@ interface MatrixRoom : Closeable {
 
     suspend fun sendFile(file: File, fileInfo: FileInfo): Result<Unit>
 
+    suspend fun sendReaction(emoji: String, eventId: EventId): Result<Unit>
+
     suspend fun leave(): Result<Unit>
 
     suspend fun acceptInvitation(): Result<Unit>

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -259,6 +259,12 @@ class RustMatrixRoom(
         }
     }
 
+    override suspend fun sendReaction(emoji: String, eventId: EventId): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            innerRoom.sendReaction(key = emoji, eventId = eventId.value)
+        }
+    }
+
     @OptIn(ExperimentalUnsignedTypes::class)
     override suspend fun updateAvatar(mimeType: String, data: ByteArray): Result<Unit> =
         withContext(Dispatchers.IO) {

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -70,8 +70,12 @@ class FakeMatrixRoom(
     private var setTopicResult = Result.success(Unit)
     private var updateAvatarResult = Result.success(Unit)
     private var removeAvatarResult = Result.success(Unit)
+    private var sendReactionResult = Result.success(Unit)
 
     var sendMediaCount = 0
+        private set
+
+    var sendReactionCount = 0
         private set
 
     var isInviteAccepted: Boolean = false
@@ -125,8 +129,8 @@ class FakeMatrixRoom(
     }
 
     override suspend fun sendReaction(emoji: String, eventId: EventId): Result<Unit> {
-        delay(FAKE_DELAY_IN_MS)
-        return Result.success(Unit)
+        sendReactionCount++
+        return sendReactionResult
     }
 
     var editMessageParameter: String? = null
@@ -283,5 +287,9 @@ class FakeMatrixRoom(
 
     fun givenSetTopicResult(result: Result<Unit>) {
         setTopicResult = result
+    }
+
+    fun givenSendReactionResult(result: Result<Unit>) {
+        sendReactionResult = result
     }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -124,6 +124,11 @@ class FakeMatrixRoom(
         return Result.success(Unit)
     }
 
+    override suspend fun sendReaction(emoji: String, eventId: EventId): Result<Unit> {
+        delay(FAKE_DELAY_IN_MS)
+        return Result.success(Unit)
+    }
+
     var editMessageParameter: String? = null
         private set
 

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.messages.impl.timeline.components_null_DefaultGroup_EmojiPickerDarkPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.messages.impl.timeline.components_null_DefaultGroup_EmojiPickerDarkPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a70e089f9987f96a1f8bf4b690f38981d3c802f623e4a1420661e8aa10ad1566
+size 175771

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.messages.impl.timeline.components_null_DefaultGroup_EmojiPickerLightPreview_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.messages.impl.timeline.components_null_DefaultGroup_EmojiPickerLightPreview_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b0802887deebf06ca63678751c3553c7bac5765a13cbf85c45f89b76c324173
+size 175771


### PR DESCRIPTION
## Changes

- Added logic to send reactions for events.
- Added [Vanniktech's Emoji library](https://github.com/vanniktech/Emoji) for the emoji picker.
- Created component `EmojiPicker` based on that.
- Added a wrapping `CustomReactionBottomSheet` for the picker.
- Fixed `ModalBottomSheet` implementation in `MessagesView`, which broke animations.

## Why

Closes #563 .

## Screenshots

| Light mode | Dark mode |
| - | - |
|![Screenshot_1686296492](https://github.com/vector-im/element-x-android/assets/480955/8a0431f9-5075-4424-9942-95b272ed8d63)|![Screenshot_1686296521](https://github.com/vector-im/element-x-android/assets/480955/dc67b2aa-404a-4cef-be6b-3317e374b3df)|
