### PR TITLE
Feature/fga/fix crash on restore

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/MainNode.kt
+++ b/app/src/main/kotlin/io/element/android/x/MainNode.kt
@@ -68,13 +68,13 @@ class MainNode(
     }
 
     private val roomFlowNodeCallback = object : RoomFlowNode.LifecycleCallback {
-        override fun onFlowCreated(room: MatrixRoom) {
+        override fun onFlowCreated(owner: String, room: MatrixRoom) {
             val component = bindings<RoomComponent.ParentBindings>().roomComponentBuilder().room(room).build()
-            mainDaggerComponentOwner.addComponent(room.roomId.value, component)
+            mainDaggerComponentOwner.addComponent(owner, component)
         }
 
-        override fun onFlowReleased(room: MatrixRoom) {
-            mainDaggerComponentOwner.removeComponent(room.roomId.value)
+        override fun onFlowReleased(owner: String, room: MatrixRoom) {
+            mainDaggerComponentOwner.removeComponent(owner)
         }
     }
 

--- a/app/src/main/kotlin/io/element/android/x/MainNode.kt
+++ b/app/src/main/kotlin/io/element/android/x/MainNode.kt
@@ -57,24 +57,24 @@ class MainNode(
     DaggerComponentOwner by mainDaggerComponentOwner {
 
     private val loggedInFlowNodeCallback = object : LoggedInFlowNode.LifecycleCallback {
-        override fun onFlowCreated(client: MatrixClient) {
+        override fun onFlowCreated(identifier: String, client: MatrixClient) {
             val component = bindings<SessionComponent.ParentBindings>().sessionComponentBuilder().client(client).build()
-            mainDaggerComponentOwner.addComponent(client.sessionId.value, component)
+            mainDaggerComponentOwner.addComponent(identifier, component)
         }
 
-        override fun onFlowReleased(client: MatrixClient) {
-            mainDaggerComponentOwner.removeComponent(client.sessionId.value)
+        override fun onFlowReleased(identifier: String, client: MatrixClient) {
+            mainDaggerComponentOwner.removeComponent(identifier)
         }
     }
 
     private val roomFlowNodeCallback = object : RoomFlowNode.LifecycleCallback {
-        override fun onFlowCreated(owner: String, room: MatrixRoom) {
+        override fun onFlowCreated(identifier: String, room: MatrixRoom) {
             val component = bindings<RoomComponent.ParentBindings>().roomComponentBuilder().room(room).build()
-            mainDaggerComponentOwner.addComponent(owner, component)
+            mainDaggerComponentOwner.addComponent(identifier, component)
         }
 
-        override fun onFlowReleased(owner: String, room: MatrixRoom) {
-            mainDaggerComponentOwner.removeComponent(owner)
+        override fun onFlowReleased(identifier: String, room: MatrixRoom) {
+            mainDaggerComponentOwner.removeComponent(identifier)
         }
     }
 

--- a/app/src/main/kotlin/io/element/android/x/di/MainDaggerComponentsOwner.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/MainDaggerComponentsOwner.kt
@@ -38,6 +38,10 @@ class MainDaggerComponentsOwner @Inject constructor(@ApplicationContext context:
         daggerComponents.remove(identifier)
     }
 
+    /**
+     * We expose the dagger components in the opposite order they arrived.
+     * So we pick the most recent component when searching with the [io.element.android.libraries.architecture.bindings] methods.
+     */
     override val daggerComponent: Any
         get() = daggerComponents.values.reversed()
 }

--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -64,7 +64,6 @@ import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.appnavstate.api.AppNavigationStateService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.parcelize.Parcelize
@@ -118,9 +117,9 @@ class LoggedInFlowNode @AssistedInject constructor(
     }
 
     interface LifecycleCallback : NodeLifecycleCallback {
-        fun onFlowCreated(client: MatrixClient) = Unit
+        fun onFlowCreated(identifier: String, client: MatrixClient) = Unit
 
-        fun onFlowReleased(client: MatrixClient) = Unit
+        fun onFlowReleased(identifier: String, client: MatrixClient) = Unit
     }
 
     data class Inputs(
@@ -139,7 +138,7 @@ class LoggedInFlowNode @AssistedInject constructor(
         observeAnalyticsState()
         lifecycle.subscribe(
             onCreate = {
-                plugins<LifecycleCallback>().forEach { it.onFlowCreated(inputs.matrixClient) }
+                plugins<LifecycleCallback>().forEach { it.onFlowCreated(id, inputs.matrixClient) }
                 val imageLoaderFactory = bindings<MatrixUIBindings>().loggedInImageLoaderFactory()
                 Coil.setImageLoader(imageLoaderFactory)
                 inputs.matrixClient.startSync()
@@ -151,7 +150,7 @@ class LoggedInFlowNode @AssistedInject constructor(
             onDestroy = {
                 val imageLoaderFactory = bindings<MatrixUIBindings>().notLoggedInImageLoaderFactory()
                 Coil.setImageLoader(imageLoaderFactory)
-                plugins<LifecycleCallback>().forEach { it.onFlowReleased(inputs.matrixClient) }
+                plugins<LifecycleCallback>().forEach { it.onFlowReleased(id, inputs.matrixClient) }
                 appNavigationStateService.onLeavingSpace(id)
                 appNavigationStateService.onLeavingSession(id)
                 loggedInFlowProcessor.stopObserving()

--- a/appnav/src/main/kotlin/io/element/android/appnav/RoomFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RoomFlowNode.kt
@@ -68,8 +68,8 @@ class RoomFlowNode @AssistedInject constructor(
 ) {
 
     interface LifecycleCallback : NodeLifecycleCallback {
-        fun onFlowCreated(room: MatrixRoom) = Unit
-        fun onFlowReleased(room: MatrixRoom) = Unit
+        fun onFlowCreated(owner: String, room: MatrixRoom) = Unit
+        fun onFlowReleased(owner: String, room: MatrixRoom) = Unit
     }
 
     data class Inputs(
@@ -83,14 +83,14 @@ class RoomFlowNode @AssistedInject constructor(
         lifecycle.subscribe(
             onCreate = {
                 Timber.v("OnCreate")
-                plugins<LifecycleCallback>().forEach { it.onFlowCreated(inputs.room) }
+                plugins<LifecycleCallback>().forEach { it.onFlowCreated(id, inputs.room) }
                 appNavigationStateService.onNavigateToRoom(id, inputs.room.roomId)
                 fetchRoomMembers()
             },
             onDestroy = {
                 Timber.v("OnDestroy")
                 inputs.room.close()
-                plugins<LifecycleCallback>().forEach { it.onFlowReleased(inputs.room) }
+                plugins<LifecycleCallback>().forEach { it.onFlowReleased(id, inputs.room) }
                 appNavigationStateService.onLeavingRoom(id)
             }
         )

--- a/appnav/src/main/kotlin/io/element/android/appnav/RoomFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RoomFlowNode.kt
@@ -68,8 +68,8 @@ class RoomFlowNode @AssistedInject constructor(
 ) {
 
     interface LifecycleCallback : NodeLifecycleCallback {
-        fun onFlowCreated(owner: String, room: MatrixRoom) = Unit
-        fun onFlowReleased(owner: String, room: MatrixRoom) = Unit
+        fun onFlowCreated(identifier: String, room: MatrixRoom) = Unit
+        fun onFlowReleased(identifier: String, room: MatrixRoom) = Unit
     }
 
     data class Inputs(


### PR DESCRIPTION
This PR handles 2 cases : 
- Crash when the activity is restored (activity lifecycle issue)
- Crash when same room is close and open quickly (dagger components issue)

Closes #413 