### PR TITLE
[Message Actions] Retry sending failed messages

### DIFF
--- a/changelog.d/487.feature
+++ b/changelog.d/487.feature
@@ -1,0 +1,1 @@
+Add menu to retry sending failed messages or delete their local echoes.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -32,6 +32,7 @@ import io.element.android.features.messages.impl.messagecomposer.MessageComposer
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerState
 import io.element.android.features.messages.impl.timeline.TimelineEvents
 import io.element.android.features.messages.impl.timeline.TimelinePresenter
+import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMenuPresenter
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemEncryptedContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemFileContent
@@ -65,6 +66,7 @@ class MessagesPresenter @Inject constructor(
     private val composerPresenter: MessageComposerPresenter,
     private val timelinePresenter: TimelinePresenter,
     private val actionListPresenter: ActionListPresenter,
+    private val retrySendMenuPresenter: RetrySendMenuPresenter,
     private val networkMonitor: NetworkMonitor,
     private val snackbarDispatcher: SnackbarDispatcher,
     private val messageSummaryFormatter: MessageSummaryFormatter,
@@ -77,6 +79,7 @@ class MessagesPresenter @Inject constructor(
         val composerState = composerPresenter.present()
         val timelineState = timelinePresenter.present()
         val actionListState = actionListPresenter.present()
+        val retryState = retrySendMenuPresenter.present()
 
         val syncUpdateFlow = room.syncUpdateFlow().collectAsState(0L)
         val roomName: MutableState<String?> = rememberSaveable {
@@ -116,6 +119,7 @@ class MessagesPresenter @Inject constructor(
             composerState = composerState,
             timelineState = timelineState,
             actionListState = actionListState,
+            retrySendMenuState = retryState,
             hasNetworkConnection = networkConnectionStatus == NetworkStatus.Online,
             snackbarMessage = snackbarMessage,
             eventSink = ::handleEvents

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Immutable
 import io.element.android.features.messages.impl.actionlist.ActionListState
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerState
 import io.element.android.features.messages.impl.timeline.TimelineState
+import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMenuState
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.utils.SnackbarMessage
 import io.element.android.libraries.matrix.api.core.RoomId
@@ -32,6 +33,7 @@ data class MessagesState(
     val composerState: MessageComposerState,
     val timelineState: TimelineState,
     val actionListState: ActionListState,
+    val retrySendMenuState: RetrySendMenuState,
     val hasNetworkConnection: Boolean,
     val snackbarMessage: SnackbarMessage?,
     val eventSink: (MessagesEvents) -> Unit

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
@@ -21,6 +21,7 @@ import io.element.android.features.messages.impl.actionlist.anActionListState
 import io.element.android.features.messages.impl.messagecomposer.aMessageComposerState
 import io.element.android.features.messages.impl.timeline.aTimelineItemList
 import io.element.android.features.messages.impl.timeline.aTimelineState
+import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMenuState
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemTextContent
 import io.element.android.libraries.core.data.StableCharSequence
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
@@ -47,6 +48,10 @@ fun aMessagesState() = MessagesState(
     ),
     timelineState = aTimelineState().copy(
         timelineItems = aTimelineItemList(aTimelineItemTextContent()),
+    ),
+    retrySendMenuState = RetrySendMenuState(
+        selectedEvent = null,
+        eventSink = {},
     ),
     actionListState = anActionListState(),
     hasNetworkConnection = true,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -34,14 +34,10 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetState
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -59,7 +55,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.element.android.features.messages.impl.actionlist.ActionListEvents
-import io.element.android.features.messages.impl.actionlist.ActionListState
 import io.element.android.features.messages.impl.actionlist.ActionListView
 import io.element.android.features.messages.impl.actionlist.model.TimelineItemAction
 import io.element.android.features.messages.impl.attachments.Attachment
@@ -67,6 +62,8 @@ import io.element.android.features.messages.impl.messagecomposer.AttachmentsStat
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerView
 import io.element.android.features.messages.impl.timeline.TimelineView
 import io.element.android.features.messages.impl.timeline.components.CustomReactionBottomSheet
+import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMenuEvents
+import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMessageMenu
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.networkmonitor.api.ui.ConnectivityIndicatorView
 import io.element.android.libraries.androidutils.ui.hideKeyboard
@@ -85,6 +82,7 @@ import io.element.android.libraries.designsystem.utils.rememberSnackbarHostState
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.timeline.item.TimelineItemDebugInfo
+import io.element.android.libraries.matrix.api.timeline.item.event.EventSendState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -176,6 +174,11 @@ fun MessagesView(
                 onMessageClicked = ::onMessageClicked,
                 onMessageLongClicked = ::onMessageLongClicked,
                 onUserDataClicked = onUserDataClicked,
+                onTimestampClicked = { event ->
+                    if (event.sendState is EventSendState.SendingFailed) {
+                        state.retrySendMenuState.eventSink(RetrySendMenuEvents.EventSelected(event))
+                    }
+                }
             )
         },
         snackbarHost = {
@@ -225,6 +228,10 @@ fun MessagesView(
             }
         }
     )
+
+    RetrySendMessageMenu(
+        state = state.retrySendMenuState
+    )
 }
 
 @Composable
@@ -245,9 +252,10 @@ private fun AttachmentStateView(
 fun MessagesViewContent(
     state: MessagesState,
     modifier: Modifier = Modifier,
-    onMessageClicked: (TimelineItem.Event) -> Unit = {},
-    onUserDataClicked: (UserId) -> Unit = {},
-    onMessageLongClicked: (TimelineItem.Event) -> Unit = {},
+    onMessageClicked: (TimelineItem.Event) -> Unit,
+    onUserDataClicked: (UserId) -> Unit,
+    onMessageLongClicked: (TimelineItem.Event) -> Unit,
+    onTimestampClicked: (TimelineItem.Event) -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -263,6 +271,7 @@ fun MessagesViewContent(
                 onMessageClicked = onMessageClicked,
                 onMessageLongClicked = onMessageLongClicked,
                 onUserDataClicked = onUserDataClicked,
+                onTimestampClicked = onTimestampClicked,
             )
         }
         MessageComposerView(

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineStateProvider.kt
@@ -94,6 +94,7 @@ internal fun aTimelineItemList(content: TimelineItemEventContent): ImmutableList
 
 internal fun aTimelineItemEvent(
     eventId: EventId = EventId("\$" + Random.nextInt().toString()),
+    transactionId: String? = null,
     isMine: Boolean = false,
     content: TimelineItemEventContent = aTimelineItemTextContent(),
     groupPosition: TimelineItemGroupPosition = TimelineItemGroupPosition.None,
@@ -104,6 +105,7 @@ internal fun aTimelineItemEvent(
     return TimelineItem.Event(
         id = eventId.value,
         eventId = eventId,
+        transactionId = transactionId,
         senderId = UserId("@senderId:domain"),
         senderAvatar = AvatarData("@senderId:domain", "sender"),
         content = content,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -69,9 +69,10 @@ import kotlinx.coroutines.launch
 fun TimelineView(
     state: TimelineState,
     modifier: Modifier = Modifier,
-    onUserDataClicked: (UserId) -> Unit = {},
-    onMessageClicked: (TimelineItem.Event) -> Unit = {},
-    onMessageLongClicked: (TimelineItem.Event) -> Unit = {},
+    onUserDataClicked: (UserId) -> Unit,
+    onMessageClicked: (TimelineItem.Event) -> Unit,
+    onMessageLongClicked: (TimelineItem.Event) -> Unit,
+    onTimestampClicked: (TimelineItem.Event) -> Unit,
 ) {
     fun onReachedLoadMore() {
         state.eventSink(TimelineEvents.LoadMore)
@@ -102,6 +103,7 @@ fun TimelineView(
                     onLongClick = onMessageLongClicked,
                     onUserDataClick = onUserDataClicked,
                     inReplyToClick = ::inReplyToClicked,
+                    onTimestampClicked = onTimestampClicked,
                 )
                 if (index == state.timelineItems.lastIndex) {
                     onReachedLoadMore()
@@ -125,6 +127,7 @@ fun TimelineItemRow(
     onClick: (TimelineItem.Event) -> Unit,
     onLongClick: (TimelineItem.Event) -> Unit,
     inReplyToClick: (EventId) -> Unit,
+    onTimestampClicked: (TimelineItem.Event) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (timelineItem) {
@@ -159,6 +162,7 @@ fun TimelineItemRow(
                     onLongClick = ::onLongClick,
                     onUserDataClick = onUserDataClick,
                     inReplyToClick = inReplyToClick,
+                    onTimestampClicked = onTimestampClicked,
                     modifier = modifier,
                 )
             }
@@ -191,6 +195,7 @@ fun TimelineItemRow(
                                 onLongClick = onLongClick,
                                 inReplyToClick = inReplyToClick,
                                 onUserDataClick = onUserDataClick,
+                                onTimestampClicked = onTimestampClicked,
                             )
                         }
                     }
@@ -276,6 +281,10 @@ fun TimelineViewDarkPreview(
 private fun ContentToPreview(content: TimelineItemEventContent) {
     val timelineItems = aTimelineItemList(content)
     TimelineView(
-        state = aTimelineState(timelineItems)
+        state = aTimelineState(timelineItems),
+        onMessageClicked = {},
+        onTimestampClicked = {},
+        onUserDataClicked = {},
+        onMessageLongClicked = {},
     )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineEventTimestampView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineEventTimestampView.kt
@@ -17,12 +17,15 @@
 package io.element.android.features.messages.impl.timeline.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -54,7 +57,15 @@ fun TimelineEventTimestampView(
     val isMessageEdited = (event.content as? TimelineItemTextBasedContent)?.isEdited.orFalse()
     val tint = if (hasMessageSendingFailed) ElementTheme.colors.textActionCritical else null
     Row(
-        modifier = modifier.clickable(onClick = onClick),
+        modifier = Modifier
+            .clickable(
+                onClick = onClick,
+                enabled = true,
+                indication = rememberRipple(bounded = false),
+                interactionSource = MutableInteractionSource()
+            )
+            .padding(start = 16.dp) // Add extra padding for touch target size
+            .then(modifier),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (isMessageEdited) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -84,13 +84,9 @@ fun TimelineItemEventRow(
         onUserDataClick(event.senderId)
     }
 
-    fun inReplayToClicked() {
+    fun inReplyToClicked() {
         val inReplyToEventId = (event.inReplyTo as? InReplyTo.Ready)?.eventId ?: return
         inReplyToClick(inReplyToEventId)
-    }
-
-    fun onTimestampClicked() {
-        onTimestampClicked(event)
     }
 
     val (parentAlignment, contentAlignment) = if (event.isMine) {
@@ -136,8 +132,10 @@ fun TimelineItemEventRow(
                         interactionSource = interactionSource,
                         onMessageClick = onClick,
                         onMessageLongClick = onLongClick,
-                        inReplyToClick = ::inReplayToClicked,
-                        onTimestampClicked = ::onTimestampClicked,
+                        inReplyToClick = ::inReplyToClicked,
+                        onTimestampClicked = {
+                            onTimestampClicked(event)
+                        }
                     )
                 }
                 TimelineItemReactionsView(

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -75,6 +75,7 @@ fun TimelineItemEventRow(
     onLongClick: () -> Unit,
     onUserDataClick: (UserId) -> Unit,
     inReplyToClick: (EventId) -> Unit,
+    onTimestampClicked: (TimelineItem.Event) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -86,6 +87,10 @@ fun TimelineItemEventRow(
     fun inReplayToClicked() {
         val inReplyToEventId = (event.inReplyTo as? InReplyTo.Ready)?.eventId ?: return
         inReplyToClick(inReplyToEventId)
+    }
+
+    fun onTimestampClicked() {
+        onTimestampClicked(event)
     }
 
     val (parentAlignment, contentAlignment) = if (event.isMine) {
@@ -132,6 +137,7 @@ fun TimelineItemEventRow(
                         onMessageClick = onClick,
                         onMessageLongClick = onLongClick,
                         inReplyToClick = ::inReplayToClicked,
+                        onTimestampClicked = ::onTimestampClicked,
                     )
                 }
                 TimelineItemReactionsView(
@@ -177,6 +183,7 @@ private fun MessageEventBubbleContent(
     onMessageClick: () -> Unit,
     onMessageLongClick: () -> Unit,
     inReplyToClick: () -> Unit,
+    onTimestampClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val isMediaItem = event.content is TimelineItemImageContent || event.content is TimelineItemVideoContent
@@ -207,7 +214,7 @@ private fun MessageEventBubbleContent(
                 ContentView(modifier = contentModifier)
                 TimelineEventTimestampView(
                     event = event,
-                    onClick = onMessageClick,
+                    onClick = onTimestampClicked,
                     modifier = timestampModifier
                         .padding(horizontal = 4.dp, vertical = 4.dp) // Outer padding
                         .background(LocalColors.current.gray300, RoundedCornerShape(10.0.dp))
@@ -220,7 +227,7 @@ private fun MessageEventBubbleContent(
                 ContentView(modifier = contentModifier.padding(start = 12.dp, end = 12.dp, top = 8.dp))
                 TimelineEventTimestampView(
                     event = event,
-                    onClick = onMessageClick,
+                    onClick = onTimestampClicked,
                     modifier = timestampModifier
                         .align(Alignment.End)
                         .padding(horizontal = 8.dp, vertical = 2.dp)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuEvents.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuEvents.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.timeline.components.retrysendmenu
+
+import io.element.android.features.messages.impl.timeline.model.TimelineItem
+
+sealed interface RetrySendMenuEvents {
+    data class EventSelected(val event: TimelineItem.Event) : RetrySendMenuEvents
+    object RetrySend : RetrySendMenuEvents
+    object RemoveFailed : RetrySendMenuEvents
+    object Dismiss: RetrySendMenuEvents
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuPresenter.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.timeline.components.retrysendmenu
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.libraries.matrix.api.room.MatrixRoom
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class RetrySendMenuPresenter @Inject constructor(
+    private val room: MatrixRoom,
+) {
+
+    @Composable
+    fun present(): RetrySendMenuState {
+        val coroutineScope = rememberCoroutineScope()
+        var selectedEvent: TimelineItem.Event? by remember { mutableStateOf(null) }
+
+        fun handleEvents(event: RetrySendMenuEvents) {
+            when (event) {
+                is RetrySendMenuEvents.EventSelected -> {
+                    selectedEvent = event.event
+                }
+                RetrySendMenuEvents.RetrySend -> {
+                    coroutineScope.launch {
+                        selectedEvent?.transactionId?.let { transactionId ->
+                            room.retrySendMessage(transactionId)
+                        }
+                        selectedEvent = null
+                    }
+                }
+                RetrySendMenuEvents.RemoveFailed -> {
+                    coroutineScope.launch {
+                        selectedEvent?.transactionId?.let { transactionId ->
+                            room.cancelSend(transactionId)
+                        }
+                        selectedEvent = null
+                    }
+                }
+                RetrySendMenuEvents.Dismiss -> {
+                    selectedEvent = null
+                }
+            }
+        }
+
+        return RetrySendMenuState(
+            selectedEvent = selectedEvent,
+            eventSink = ::handleEvents,
+        )
+    }
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuPresenter.kt
@@ -23,20 +23,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class RetrySendMenuPresenter @Inject constructor(
     private val room: MatrixRoom,
-) {
+) : Presenter<RetrySendMenuState> {
 
     @Composable
-    fun present(): RetrySendMenuState {
+    override fun present(): RetrySendMenuState {
         val coroutineScope = rememberCoroutineScope()
         var selectedEvent: TimelineItem.Event? by remember { mutableStateOf(null) }
 
-        fun handleEvents(event: RetrySendMenuEvents) {
+        fun handleEvent(event: RetrySendMenuEvents) {
             when (event) {
                 is RetrySendMenuEvents.EventSelected -> {
                     selectedEvent = event.event
@@ -65,7 +66,7 @@ class RetrySendMenuPresenter @Inject constructor(
 
         return RetrySendMenuState(
             selectedEvent = selectedEvent,
-            eventSink = ::handleEvents,
+            eventSink = ::handleEvent,
         )
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuState.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.timeline.components.retrysendmenu
+
+import io.element.android.features.messages.impl.timeline.model.TimelineItem
+
+data class RetrySendMenuState(
+    val selectedEvent: TimelineItem.Event?,
+    val eventSink: (RetrySendMenuEvents) -> Unit,
+)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMenuState.kt
@@ -16,8 +16,10 @@
 
 package io.element.android.features.messages.impl.timeline.components.retrysendmenu
 
+import androidx.compose.runtime.Immutable
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 
+@Immutable
 data class RetrySendMenuState(
     val selectedEvent: TimelineItem.Event?,
     val eventSink: (RetrySendMenuEvents) -> Unit,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMessageMenu.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/retrysendmenu/RetrySendMessageMenu.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.timeline.components.retrysendmenu
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.element.android.libraries.designsystem.preview.ElementPreviewLight
+import io.element.android.libraries.designsystem.theme.LocalColors
+import io.element.android.libraries.designsystem.theme.components.Text
+import kotlinx.coroutines.launch
+
+@Composable
+internal fun RetrySendMessageMenu(
+    state: RetrySendMenuState,
+    modifier: Modifier = Modifier,
+) {
+    val isVisible = state.selectedEvent != null
+
+    fun onDismiss() {
+        state.eventSink(RetrySendMenuEvents.Dismiss)
+    }
+
+    fun onRetry() {
+        state.eventSink(RetrySendMenuEvents.RetrySend)
+    }
+
+    fun onRemoveFailed() {
+        state.eventSink(RetrySendMenuEvents.RemoveFailed)
+    }
+
+    RetrySendMessageMenuContents(
+        modifier = modifier,
+        isVisible = isVisible,
+        onRetry = ::onRetry,
+        onRemoveFailed = ::onRemoveFailed,
+        onDismiss = ::onDismiss
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun RetrySendMessageMenuContents(
+    isVisible: Boolean,
+    onRetry: () -> Unit,
+    onRemoveFailed: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    val coroutineScope = rememberCoroutineScope()
+
+    if (isVisible) {
+        ModalBottomSheet(
+            modifier = modifier,
+//            modifier = modifier.navigationBarsPadding() - FIXME after https://issuetracker.google.com/issues/275849044
+//                    .imePadding()
+            sheetState = sheetState,
+            onDismissRequest = {
+                coroutineScope.launch {
+                    sheetState.hide()
+                    onDismiss()
+                }
+            }
+        ) {
+            ListItem(headlineContent = {
+                Text("Your message failed to send", fontWeight = FontWeight.Medium)
+            })
+            ListItem(
+                headlineContent = {
+                    Text("Send again")
+                },
+                modifier = Modifier.clickable {
+                    coroutineScope.launch {
+                        sheetState.hide()
+                        onRetry()
+                    }
+                }
+            )
+            ListItem(
+                headlineContent = {
+                    Text("Remove")
+                },
+                colors = ListItemDefaults.colors(headlineColor = LocalColors.current.textActionCritical),
+                modifier = Modifier.clickable {
+                    coroutineScope.launch {
+                        sheetState.hide()
+                        onRemoveFailed()
+                    }
+                }
+            )
+            // FIXME remove after https://issuetracker.google.com/issues/275849044
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Preview
+@Composable
+internal fun RetrySendMessageMenuPreview() {
+    ElementPreviewLight {
+        RetrySendMessageMenuContents(
+            isVisible = true,
+            onRetry = {},
+            onRemoveFailed = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
@@ -72,6 +72,7 @@ class TimelineItemEventFactory @Inject constructor(
         return TimelineItem.Event(
             id = currentTimelineItem.uniqueId,
             eventId = currentTimelineItem.eventId,
+            transactionId = currentTimelineItem.transactionId,
             senderId = currentSender,
             senderDisplayName = senderDisplayName,
             senderAvatar = senderAvatarData,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/TimelineItem.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/TimelineItem.kt
@@ -52,6 +52,7 @@ sealed interface TimelineItem {
     data class Event(
         val id: String,
         val eventId: EventId? = null,
+        val transactionId: String? = null,
         val senderId: UserId,
         val senderDisplayName: String?,
         val senderAvatar: AvatarData,

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
@@ -29,6 +29,7 @@ import io.element.android.features.messages.impl.actionlist.ActionListPresenter
 import io.element.android.features.messages.impl.actionlist.model.TimelineItemAction
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerPresenter
 import io.element.android.features.messages.impl.timeline.TimelinePresenter
+import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMenuPresenter
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemFileContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemImageContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContent
@@ -322,15 +323,18 @@ class MessagesPresenterTest {
             flavorShortDescription = "",
         )
         val actionListPresenter = ActionListPresenter(buildMeta = buildMeta)
+        val retrySendMenuPresenter = RetrySendMenuPresenter(room = matrixRoom)
         return MessagesPresenter(
             room = matrixRoom,
             composerPresenter = messageComposerPresenter,
             timelinePresenter = timelinePresenter,
             actionListPresenter = actionListPresenter,
+            retrySendMenuPresenter = retrySendMenuPresenter,
             networkMonitor = FakeNetworkMonitor(),
             snackbarDispatcher = SnackbarDispatcher(),
             messageSummaryFormatter = FakeMessageSummaryFormatter(),
             dispatchers = testCoroutineDispatchers(),
         )
+
     }
 }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/timeline/components/retrysendmenu/RetrySendMenuPresenterTests.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/timeline/components/retrysendmenu/RetrySendMenuPresenterTests.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.timeline.components.retrysendmenu
+
+import app.cash.molecule.RecompositionClock
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.messages.impl.timeline.aTimelineItemEvent
+import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMenuEvents
+import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMenuPresenter
+import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RetrySendMenuPresenterTests {
+
+    private val room = FakeMatrixRoom()
+    private val presenter = RetrySendMenuPresenter(room)
+
+    @Test
+    fun `present - handle event selected`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val selectedEvent = aTimelineItemEvent()
+            initialState.eventSink(RetrySendMenuEvents.EventSelected(selectedEvent))
+
+            assertThat(awaitItem().selectedEvent).isSameInstanceAs(selectedEvent)
+        }
+    }
+
+    @Test
+    fun `present - handle dismiss`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val selectedEvent = aTimelineItemEvent()
+            initialState.eventSink(RetrySendMenuEvents.EventSelected(selectedEvent))
+            skipItems(1)
+
+            initialState.eventSink(RetrySendMenuEvents.Dismiss)
+            assertThat(awaitItem().selectedEvent).isNull()
+        }
+    }
+
+    @Test
+    fun `present - handle resend with transactionId`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val selectedEvent = aTimelineItemEvent(transactionId = "AN_ID")
+            initialState.eventSink(RetrySendMenuEvents.EventSelected(selectedEvent))
+            skipItems(1)
+
+            initialState.eventSink(RetrySendMenuEvents.RetrySend)
+            assertThat(room.retrySendMessageCount).isEqualTo(1)
+            assertThat(awaitItem().selectedEvent).isNull()
+        }
+    }
+
+    @Test
+    fun `present - handle resend without transactionId`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val selectedEvent = aTimelineItemEvent(transactionId = null)
+            initialState.eventSink(RetrySendMenuEvents.EventSelected(selectedEvent))
+            skipItems(1)
+
+            initialState.eventSink(RetrySendMenuEvents.RetrySend)
+            assertThat(room.retrySendMessageCount).isEqualTo(0)
+            assertThat(awaitItem().selectedEvent).isNull()
+        }
+    }
+
+    @Test
+    fun `present - handle resend with error`() = runTest {
+        room.givenRetrySendMessageResult(Result.failure(IllegalStateException("An error")))
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val selectedEvent = aTimelineItemEvent(transactionId = "AN_ID")
+            initialState.eventSink(RetrySendMenuEvents.EventSelected(selectedEvent))
+            skipItems(1)
+
+            initialState.eventSink(RetrySendMenuEvents.RetrySend)
+            assertThat(room.retrySendMessageCount).isEqualTo(1)
+            assertThat(awaitItem().selectedEvent).isNull()
+        }
+    }
+
+    @Test
+    fun `present - handle remove failed message with transactionId`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val selectedEvent = aTimelineItemEvent(transactionId = "AN_ID")
+            initialState.eventSink(RetrySendMenuEvents.EventSelected(selectedEvent))
+            skipItems(1)
+
+            initialState.eventSink(RetrySendMenuEvents.RemoveFailed)
+            assertThat(room.cancelSendCount).isEqualTo(1)
+            assertThat(awaitItem().selectedEvent).isNull()
+        }
+    }
+
+    @Test
+    fun `present - handle remove failed message without transactionId`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val selectedEvent = aTimelineItemEvent(transactionId = null)
+            initialState.eventSink(RetrySendMenuEvents.EventSelected(selectedEvent))
+            skipItems(1)
+
+            initialState.eventSink(RetrySendMenuEvents.RemoveFailed)
+            assertThat(room.cancelSendCount).isEqualTo(0)
+            assertThat(awaitItem().selectedEvent).isNull()
+        }
+    }
+
+    @Test
+    fun `present - handle remove failed message with error`() = runTest {
+        room.givenRetrySendMessageResult(Result.failure(IllegalStateException("An error")))
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val selectedEvent = aTimelineItemEvent(transactionId = "AN_ID")
+            initialState.eventSink(RetrySendMenuEvents.EventSelected(selectedEvent))
+            skipItems(1)
+
+            initialState.eventSink(RetrySendMenuEvents.RemoveFailed)
+            assertThat(room.cancelSendCount).isEqualTo(1)
+            assertThat(awaitItem().selectedEvent).isNull()
+        }
+    }
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -83,6 +83,10 @@ interface MatrixRoom : Closeable {
 
     suspend fun sendReaction(emoji: String, eventId: EventId): Result<Unit>
 
+    suspend fun retrySendMessage(transactionId: String): Result<Unit>
+
+    suspend fun cancelSend(transactionId: String): Result<Unit>
+
     suspend fun leave(): Result<Unit>
 
     suspend fun acceptInvitation(): Result<Unit>

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/MatrixTimelineItem.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/MatrixTimelineItem.kt
@@ -24,6 +24,7 @@ sealed interface MatrixTimelineItem {
     data class Event(val event: EventTimelineItem) : MatrixTimelineItem {
         val uniqueId: String = event.uniqueIdentifier
         val eventId: EventId? = event.eventId
+        val transactionId: String? = event.transactionId
     }
 
     data class Virtual(val virtual: VirtualTimelineItem) : MatrixTimelineItem

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/EventTimelineItem.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/EventTimelineItem.kt
@@ -23,6 +23,7 @@ import io.element.android.libraries.matrix.api.timeline.item.TimelineItemDebugIn
 data class EventTimelineItem(
     val uniqueIdentifier: String,
     val eventId: EventId?,
+    val transactionId: String?,
     val isEditable: Boolean,
     val isLocal: Boolean,
     val isOwn: Boolean,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -34,6 +34,7 @@ import io.element.android.libraries.matrix.impl.media.map
 import io.element.android.libraries.matrix.impl.timeline.RustMatrixTimeline
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -263,6 +264,20 @@ class RustMatrixRoom(
             innerRoom.sendReaction(key = emoji, eventId = eventId.value)
         }
     }
+
+    override suspend fun retrySendMessage(transactionId: String): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                innerRoom.retrySend(transactionId)
+            }
+        }
+
+    override suspend fun cancelSend(transactionId: String): Result<Unit>  =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                innerRoom.cancelSend(transactionId)
+            }
+        }
 
     @OptIn(ExperimentalUnsignedTypes::class)
     override suspend fun updateAvatar(mimeType: String, data: ByteArray): Result<Unit> =

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/EventTimelineItemMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/EventTimelineItemMapper.kt
@@ -35,6 +35,7 @@ class EventTimelineItemMapper(private val contentMapper: TimelineEventContentMap
         EventTimelineItem(
             uniqueIdentifier = it.uniqueIdentifier(),
             eventId = it.eventId()?.let(::EventId),
+            transactionId = it.transactionId(),
             isEditable = it.isEditable(),
             isLocal = it.isLocal(),
             isOwn = it.isOwn(),

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -71,11 +71,19 @@ class FakeMatrixRoom(
     private var updateAvatarResult = Result.success(Unit)
     private var removeAvatarResult = Result.success(Unit)
     private var sendReactionResult = Result.success(Unit)
+    private var retrySendMessageResult = Result.success(Unit)
+    private var cancelSendResult = Result.success(Unit)
 
     var sendMediaCount = 0
         private set
 
     var sendReactionCount = 0
+        private set
+
+    var retrySendMessageCount: Int = 0
+        private set
+
+    var cancelSendCount: Int = 0
         private set
 
     var isInviteAccepted: Boolean = false
@@ -131,6 +139,16 @@ class FakeMatrixRoom(
     override suspend fun sendReaction(emoji: String, eventId: EventId): Result<Unit> {
         sendReactionCount++
         return sendReactionResult
+    }
+
+    override suspend fun retrySendMessage(transactionId: String): Result<Unit> {
+        retrySendMessageCount++
+        return retrySendMessageResult
+    }
+
+    override suspend fun cancelSend(transactionId: String): Result<Unit> {
+        cancelSendCount++
+        return cancelSendResult
     }
 
     var editMessageParameter: String? = null
@@ -291,5 +309,13 @@ class FakeMatrixRoom(
 
     fun givenSendReactionResult(result: Result<Unit>) {
         sendReactionResult = result
+    }
+
+    fun givenRetrySendMessageResult(result: Result<Unit>) {
+        retrySendMessageResult = result
+    }
+
+    fun givenCancelSendResult(result: Result<Unit>) {
+        cancelSendResult = result
     }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/RoomSummaryFixture.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/RoomSummaryFixture.kt
@@ -89,6 +89,7 @@ fun aRoomMessage(
 fun anEventTimelineItem(
     uniqueIdentifier: String = A_UNIQUE_ID,
     eventId: EventId = AN_EVENT_ID,
+    transactionId: String? = null,
     isEditable: Boolean = false,
     isLocal: Boolean = false,
     isOwn: Boolean = false,
@@ -103,6 +104,7 @@ fun anEventTimelineItem(
 ) = EventTimelineItem(
     uniqueIdentifier = uniqueIdentifier,
     eventId = eventId,
+    transactionId = transactionId,
     isEditable = isEditable,
     isLocal = isLocal,
     isOwn = isOwn,


### PR DESCRIPTION
## Changes

- Added a retry sending menu that appears when tapping on the timestamp view of a failed to send message: it allows you to retry sending the message or delete them from your local echoes.
- Fixed an issue that retrieved the original state of the event instead of the current one when using this feature, so the `sendState` sometimes wasn't updated.
- Added extra touch area to the timestamp.

## Why

Fixes #487.

## Test

- Open a room.
- Enable airplane mode (disable any network connection).
- Send a couple of messages.
- Disable airplane mode, wait until you have internet connection.
- Retry sending one of the messages and removing the other one.

It could be interesting to also try re-sending the message with no network connection, although it worked fine in my tests.

**Note:** there is an issue currently that causes the sliding sync loop to be stopped when network connection is lost and it never recovers. This means that sending messages from the previously offline device works, but you won't see any incoming messages or the room list updated.