### PR TITLE
Feature/fga/fix reply timeline UI

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -243,7 +243,7 @@ private fun MessageEventBubbleContent(
     ) {
         EqualWidthColumn(modifier = modifier, spacing = 8.dp) {
             if (inReplyToDetails != null) {
-                val senderName = event.senderDisplayName ?: event.senderId.value
+                val senderName = inReplyToDetails.senderDisplayName ?: inReplyToDetails.senderId.value
                 val attachmentThumbnailInfo = attachmentThumbnailInfoForInReplyTo(inReplyToDetails)
                 ReplyToContent(
                     senderName = senderName,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -251,6 +251,7 @@ private fun MessageEventBubbleContent(
                     attachmentThumbnailInfo = attachmentThumbnailInfo,
                     modifier = Modifier
                         .padding(top = 8.dp, start = 8.dp, end = 8.dp)
+                        .clip(RoundedCornerShape(6.dp))
                         .clickable(enabled = true, onClick = inReplyToClick),
                 )
             }
@@ -295,7 +296,6 @@ private fun ReplyToContent(
     }
     Row(
         modifier
-            .clip(RoundedCornerShape(6.dp))
             .background(MaterialTheme.colorScheme.surface)
             .padding(paddings)
     ) {


### PR DESCRIPTION
2 small fixes around reply in timeline : 
- Replied sender name was using wrong one 
- Ripple on reply view was missing the rounded clip