### PR TITLE
Ensure files downloaded by localazy end with a new line.

### DIFF
--- a/tools/localazy/downloadStrings.sh
+++ b/tools/localazy/downloadStrings.sh
@@ -40,6 +40,12 @@ fi
 echo "Importing the strings..."
 localazy download --config ./tools/localazy/localazy.json
 
+echo "Add new lines to the end of the files..."
+find . -name 'localazy.xml' -print0 -exec bash -c "echo \"\" >> \"{}\"" \; >> /dev/null
+if [[ $allFiles == 1 ]]; then
+  find . -name 'translations.xml' -print0 -exec bash -c "echo \"\" >> \"{}\"" \; >> /dev/null
+fi
+
 echo "Removing the generated config"
 rm ./tools/localazy/localazy.json
 


### PR DESCRIPTION
To avoid touching the file when Android Studio opens it.

Tested OK locally, hopefully it will work on the CI too.