### PR TITLE
Add '.' to MATRIX_ROOM_IDENTIFIER_REGEX

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/core/MatrixPatterns.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/core/MatrixPatterns.kt
@@ -34,7 +34,7 @@ object MatrixPatterns {
     val PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER = MATRIX_USER_IDENTIFIER_REGEX.toRegex(RegexOption.IGNORE_CASE)
 
     // regex pattern to find room ids in a string.
-    private const val MATRIX_ROOM_IDENTIFIER_REGEX = "![A-Z0-9-]+$DOMAIN_REGEX"
+    private const val MATRIX_ROOM_IDENTIFIER_REGEX = "![A-Z0-9.-]+$DOMAIN_REGEX"
     private val PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER = MATRIX_ROOM_IDENTIFIER_REGEX.toRegex(RegexOption.IGNORE_CASE)
 
     // regex pattern to find room aliases in a string.


### PR DESCRIPTION
Similar to https://github.com/vector-im/element-x-android/pull/416, somehow wasn't a problem on non-X Element.

Fixes app crashing whenever e.g. `!ping-v10.1:maunium.net` is in room list:

```
FATAL EXCEPTION ElementX Version : 1.0Phone : Pixel 3 (eng.root.20230416.031326 12 REL)
Memory statuses 
usedSize   36 MB
freeSize   16 MB
totalSize   53 MB
Thread: DefaultDispatcher-worker-13, Exception: java.lang.IllegalStateException: `!ping-v10.1:maunium.net` is not a valid room id.
 Example room id: `!room_id:domain`.
	at io.element.android.libraries.matrix.api.core.RoomId.constructor-impl(RoomId.kt:27)
	at io.element.android.libraries.matrix.impl.room.RoomSummaryDetailsFactory.create(RoomSummaryDetailsFactory.kt:33)
	at io.element.android.libraries.matrix.impl.room.RustRoomSummaryDataSource.buildRoomSummaryForIdentifier(RustRoomSummaryDataSource.kt:191)
	at io.element.android.libraries.matrix.impl.room.RustRoomSummaryDataSource.buildSummaryForRoomListEntry(RustRoomSummaryDataSource.kt:179)
	at io.element.android.libraries.matrix.impl.room.RustRoomSummaryDataSource.applyDiff(RustRoomSummaryDataSource.kt:149)
	at io.element.android.libraries.matrix.impl.room.RustRoomSummaryDataSource.access$applyDiff(RustRoomSummaryDataSource.kt:48)
	at io.element.android.libraries.matrix.impl.room.RustRoomSummaryDataSource$init$1$2$1.invoke(RustRoomSummaryDataSource.kt:72)
	at io.element.android.libraries.matrix.impl.room.RustRoomSummaryDataSource$init$1$2$1.invoke(RustRoomSummaryDataSource.kt:71)
	at io.element.android.libraries.matrix.impl.room.RustRoomSummaryDataSource$updateRoomSummaries$2.invokeSuspend(RustRoomSummaryDataSource.kt:201)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:920)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@d9fae62, Dispatchers.IO]
```