### PR TITLE
Use github action that caches LFS files when checking out the repo

### DIFF
--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -18,9 +18,7 @@ jobs:
     if: ${{ github.repository == 'vector-im/element-x-android' }}
     steps:
       - name: ⏬ Checkout with LFS
-        uses: actions/checkout@v3
-        with:
-          lfs: 'true'
+        uses: nschloe/action-cached-lfs-checkout@v1.2.1
 
       - name: Use JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/recordScreenshots.yml
+++ b/.github/workflows/recordScreenshots.yml
@@ -14,10 +14,9 @@ jobs:
 
     steps:
       - name: ⏬ Checkout with LFS
-        uses: actions/checkout@v3
+        uses: nschloe/action-cached-lfs-checkout@v1.2.1
         with:
           persist-credentials: false
-          lfs: 'true'
       - name: ☕️ Use JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,11 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: ⏬ Checkout with LFS
-        uses: actions/checkout@v3
+        uses: nschloe/action-cached-lfs-checkout@v1.2.1
         with:
           # Ensure we are building the branch and not the branch after being merged on develop
           # https://github.com/actions/checkout/issues/881
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
-          lfs: 'true'
       - name: ☕️ Use JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/validate-lfs.yml
+++ b/.github/workflows/validate-lfs.yml
@@ -7,9 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate
     steps:
-      - uses: actions/checkout@v3
-        with:
-          lfs: 'true'
+      - uses: nschloe/action-cached-lfs-checkout@v1.2.1
 
       - run: |
           ./tools/git/validate_lfs.sh


### PR DESCRIPTION
Uses https://github.com/nschloe/action-cached-lfs-checkout where we're using git-lfs.

This is a wrapper around `actions/checkout@v3` which uses `actions/cache@v3` to cache the files on LFS to avoid downloading them every time and spare LFS bandwidth.