### PR TITLE
Do not fail the whole build if Diawi upload fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,8 @@ jobs:
             app/build/outputs/apk/debug/*.apk
       - uses: rnkdsh/action-upload-diawi@v1.5.0
         id: diawi
+        # Do not fail the whole build if Diawi upload fails
+        continue-on-error: true
         env:
           token: ${{ secrets.DIAWI_TOKEN }}
         if: ${{ github.event_name == 'pull_request' && env.token != '' }}


### PR DESCRIPTION
Uploading to Diawi is failing at the moment since the APK is greater than 75MB (after we integrate the MapLibre dependency).

This PR let the GitHub action finish even if Diawi upload step is failing. We should not prevent the PR from being merged because of that failure.

Successful if the CI run on this PR is all green despite the Diawi upload failure.