### PR TITLE
Make renovate ignore maplibre pre-releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,12 @@
         "org.jetbrains.kotlinx.kover"
       ],
       "enabled" : false
+    },
+    {
+      "matchPackageNames" : [
+        "^org.maplibre"
+      ],
+      "versioning" : "semver"
     }
   ]
 }


### PR DESCRIPTION
Maplibre uses semver, so pre-releases look like `1.2.3-something`, but renovate defaults to a looser version matching when using maven (to allow for weird things like 1.2.3-android being stable).