### PR TITLE
Send read receipts

### DIFF
--- a/changelog.d/671.feature
+++ b/changelog.d/671.feature
@@ -1,0 +1,1 @@
+Send read receipts for rooms.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineEvents.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineEvents.kt
@@ -21,4 +21,5 @@ import io.element.android.libraries.matrix.api.core.EventId
 sealed interface TimelineEvents {
     object LoadMore : TimelineEvents
     data class SetHighlightedEvent(val eventId: EventId?) : TimelineEvents
+    data class SendReadReceipt(val eventId: EventId) : TimelineEvents
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineEvents.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineEvents.kt
@@ -21,5 +21,5 @@ import io.element.android.libraries.matrix.api.core.EventId
 sealed interface TimelineEvents {
     object LoadMore : TimelineEvents
     data class SetHighlightedEvent(val eventId: EventId?) : TimelineEvents
-    data class SendReadReceipt(val eventId: EventId) : TimelineEvents
+    data class OnScrollFinished(val firstIndex: Int) : TimelineEvents
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -64,6 +64,7 @@ class TimelinePresenter @Inject constructor(
             when (event) {
                 TimelineEvents.LoadMore -> localCoroutineScope.loadMore(paginationState.value)
                 is TimelineEvents.SetHighlightedEvent -> highlightedEventId.value = event.eventId
+                is TimelineEvents.SendReadReceipt -> localCoroutineScope.sendReadReceipt(event.eventId)
             }
         }
 
@@ -93,5 +94,9 @@ class TimelinePresenter @Inject constructor(
         } else {
             Timber.v("Can't back paginate as paginationState = $paginationState")
         }
+    }
+
+    private fun CoroutineScope.sendReadReceipt(eventId: EventId) = launch {
+        timeline.sendReadReceipt(eventId)
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -20,14 +20,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import io.element.android.features.messages.impl.timeline.factories.TimelineItemsFactory
+import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.timeline.MatrixTimeline
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -52,6 +56,9 @@ class TimelinePresenter @Inject constructor(
             mutableStateOf(null)
         }
 
+        var lastReadMarkerIndex by rememberSaveable { mutableStateOf(Int.MAX_VALUE) }
+        var lastReadMarkerId by rememberSaveable { mutableStateOf<EventId?>(null) }
+
         val timelineItems = timelineItemsFactory
             .flow()
             .collectAsState()
@@ -64,7 +71,15 @@ class TimelinePresenter @Inject constructor(
             when (event) {
                 TimelineEvents.LoadMore -> localCoroutineScope.loadMore(paginationState.value)
                 is TimelineEvents.SetHighlightedEvent -> highlightedEventId.value = event.eventId
-                is TimelineEvents.SendReadReceipt -> localCoroutineScope.sendReadReceipt(event.eventId)
+                is TimelineEvents.OnScrollFinished -> {
+                    // Get last valid EventId seen by the user, as the first index might refer to a Virtual item
+                    val eventId = getLastEventIdBeforeOrAt(event.firstIndex, timelineItems.value) ?: return
+                    if (event.firstIndex <= lastReadMarkerIndex && eventId != lastReadMarkerId) {
+                        lastReadMarkerIndex = event.firstIndex
+                        lastReadMarkerId = eventId
+                        localCoroutineScope.sendReadReceipt(eventId)
+                    }
+                }
             }
         }
 
@@ -86,6 +101,15 @@ class TimelinePresenter @Inject constructor(
             timelineItems = timelineItems.value,
             eventSink = ::handleEvents
         )
+    }
+
+    private fun getLastEventIdBeforeOrAt(index: Int, items: ImmutableList<TimelineItem>): EventId? {
+        for (item in items.subList(index, items.count())) {
+            if (item is TimelineItem.Event) {
+                return item.eventId
+            }
+        }
+        return null
     }
 
     private fun CoroutineScope.loadMore(paginationState: MatrixTimeline.PaginationState) = launch {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -91,13 +91,16 @@ fun TimelineView(
 
     // Send a read receipt when the user has finished scrolling to an item in an index <= the last one
     // and the event ids are different.
-    LaunchedEffect(lazyListState.firstVisibleItemIndex, lazyListState.isScrollInProgress) {
-        val firstVisibleIndex = lazyListState.firstVisibleItemIndex
-        val event = state.timelineItems.getOrNull(lazyListState.firstVisibleItemIndex) as? TimelineItem.Event
-        if (!lazyListState.isScrollInProgress && firstVisibleIndex <= lastReadMarkerIndex && event?.eventId != null && event.eventId != lastReadMarkerId) {
+    val firstVisibleIndex by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
+    val isScrollFinished by remember { derivedStateOf { !lazyListState.isScrollInProgress } }
+    LaunchedEffect(firstVisibleIndex, isScrollFinished) {
+        if (!isScrollFinished) return@LaunchedEffect
+        val eventId = (state.timelineItems.getOrNull(firstVisibleIndex) as? TimelineItem.Event)?.eventId
+            ?: return@LaunchedEffect
+        if (firstVisibleIndex <= lastReadMarkerIndex && eventId != lastReadMarkerId) {
             lastReadMarkerIndex = firstVisibleIndex
-            lastReadMarkerId = event.eventId
-            state.eventSink(TimelineEvents.SendReadReceipt(event.eventId))
+            lastReadMarkerId = eventId
+            state.eventSink(TimelineEvents.SendReadReceipt(eventId))
         }
     }
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/timeline/TimelinePresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/timeline/TimelinePresenterTest.kt
@@ -25,6 +25,7 @@ import io.element.android.features.messages.impl.timeline.TimelineEvents
 import io.element.android.features.messages.impl.timeline.TimelinePresenter
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
+import io.element.android.libraries.matrix.test.timeline.FakeMatrixTimeline
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -85,6 +86,26 @@ class TimelinePresenterTest {
             initialState.eventSink.invoke(TimelineEvents.SetHighlightedEvent(null))
             val withoutHighlightedState = awaitItem()
             assertThat(withoutHighlightedState.highlightedEventId).isNull()
+        }
+    }
+
+    @Test
+    fun `present - send read receipt`() = runTest {
+        val timeline = FakeMatrixTimeline()
+        val room = FakeMatrixRoom(matrixTimeline = timeline)
+        val presenter = TimelinePresenter(
+            timelineItemsFactory = aTimelineItemsFactory(),
+            room = room,
+        )
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(timeline.sendReadReceiptCount).isEqualTo(0)
+
+            initialState.eventSink.invoke(TimelineEvents.SendReadReceipt(AN_EVENT_ID))
+
+            assertThat(timeline.sendReadReceiptCount).isEqualTo(1)
         }
     }
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/MatrixTimeline.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/MatrixTimeline.kt
@@ -32,4 +32,6 @@ interface MatrixTimeline {
 
     suspend fun paginateBackwards(requestSize: Int, untilNumberOfItems: Int): Result<Unit>
     suspend fun fetchDetailsForEvent(eventId: EventId): Result<Unit>
+
+    suspend fun sendReadReceipt(eventId: EventId): Result<Unit>
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
@@ -107,4 +107,10 @@ class RustMatrixTimeline(
             Timber.v("Success back paginating for room ${matrixRoom.roomId}")
         }
     }
+
+    override suspend fun sendReadReceipt(eventId: EventId) = withContext(coroutineDispatchers.io) {
+        runCatching {
+            innerRoom.sendReadReceipt(eventId = eventId.value)
+        }
+    }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/timeline/FakeMatrixTimeline.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/timeline/FakeMatrixTimeline.kt
@@ -32,6 +32,9 @@ class FakeMatrixTimeline(
     private val paginationState: MutableStateFlow<MatrixTimeline.PaginationState> = MutableStateFlow(initialPaginationState)
     private val timelineItems: MutableStateFlow<List<MatrixTimelineItem>> = MutableStateFlow(initialTimelineItems)
 
+    var sendReadReceiptCount = 0
+        private set
+
     fun updatePaginationState(update: (MatrixTimeline.PaginationState.() -> MatrixTimeline.PaginationState)) {
         paginationState.value = update(paginationState.value)
     }
@@ -64,6 +67,11 @@ class FakeMatrixTimeline(
 
 
     override suspend fun fetchDetailsForEvent(eventId: EventId): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun sendReadReceipt(eventId: EventId): Result<Unit> {
+        sendReadReceiptCount++
         return Result.success(Unit)
     }
 }


### PR DESCRIPTION
## Changes

- Add a `sendReadReceipt` method to `MatrixTimeline`.
- Send a read receipt for the latest read message in the timeline. The implemented logic is:
  - The `LazyColumn` stopped scrolling.
  - The index of the first visible item in the timeline (in reverse order) is <= the index of the last event we sent a read receipt for so if we were at the latest message (0) and a new one comes, we can send another read receipt.
  - The event id of the event at that index doesn't match the last one we sent.

## Why

Closes #671 .

## Test

- Open a room with unread messages, the room will be marked as read soon after.
- When at the last message on a room, receive a message. The room should be marked as read automatically.
- When the last message of the room is no longer visible, receive a message. The room should **not** be marked as read in this case.