### PR TITLE
Fix message long click not always working

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessageEventBubble.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessageEventBubble.kt
@@ -42,9 +42,9 @@ import io.element.android.features.messages.impl.timeline.model.bubble.BubbleSta
 import io.element.android.libraries.core.extensions.to01
 import io.element.android.libraries.designsystem.preview.ElementPreviewDark
 import io.element.android.libraries.designsystem.preview.ElementPreviewLight
-import io.element.android.libraries.theme.ElementTheme
 import io.element.android.libraries.designsystem.theme.components.Surface
 import io.element.android.libraries.designsystem.theme.components.Text
+import io.element.android.libraries.theme.ElementTheme
 
 private val BUBBLE_RADIUS = 12.dp
 private val BUBBLE_INCOMING_OFFSET = 16.dp

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineEventTimestampView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineEventTimestampView.kt
@@ -16,7 +16,8 @@
 
 package io.element.android.features.messages.impl.timeline.components
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -45,11 +46,13 @@ import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.matrix.api.timeline.item.event.EventSendState
 import io.element.android.libraries.ui.strings.CommonStrings
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TimelineEventTimestampView(
     event: TimelineItem.Event,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val formattedTime = event.sentTime
     val hasMessageSendingFailed = event.sendState is EventSendState.SendingFailed
@@ -57,8 +60,9 @@ fun TimelineEventTimestampView(
     val tint = if (hasMessageSendingFailed) MaterialTheme.colorScheme.error else null
     Row(
         modifier = Modifier
-            .clickable(
+            .combinedClickable(
                 onClick = onClick,
+                onLongClick = onLongClick,
                 enabled = true,
                 indication = rememberRipple(bounded = false),
                 interactionSource = MutableInteractionSource()
@@ -101,6 +105,7 @@ internal fun TimelineEventTimestampViewDarkPreview(@PreviewParameter(TimelineIte
 private fun ContentToPreview(event: TimelineItem.Event) {
     TimelineEventTimestampView(
         event = event,
-        onClick = {}
+        onClick = {},
+        onLongClick = {},
     )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -227,6 +227,10 @@ private fun MessageEventBubbleContent(
     val isMediaItem = event.content is TimelineItemImageContent || event.content is TimelineItemVideoContent
     val replyToDetails = event.inReplyTo as? InReplyTo.Ready
 
+    // Long clicks are not not automatically propagated from a `clickable`
+    // to its `combinedClickable` parent so we do it manually
+    fun onTimestampLongClick() = onMessageLongClick()
+
     @Composable
     fun ContentView(
         modifier: Modifier = Modifier
@@ -254,6 +258,7 @@ private fun MessageEventBubbleContent(
                 TimelineEventTimestampView(
                     event = event,
                     onClick = onTimestampClicked,
+                    onLongClick = ::onTimestampLongClick,
                     modifier = timestampModifier
                         .padding(horizontal = 4.dp, vertical = 4.dp) // Outer padding
                         .background(ElementTheme.legacyColors.gray300, RoundedCornerShape(10.0.dp))
@@ -267,6 +272,7 @@ private fun MessageEventBubbleContent(
                 TimelineEventTimestampView(
                     event = event,
                     onClick = onTimestampClicked,
+                    onLongClick = ::onTimestampLongClick,
                     modifier = timestampModifier
                         .align(Alignment.BottomEnd)
                         .padding(horizontal = 8.dp, vertical = 4.dp)


### PR DESCRIPTION
## Changes

The root cause of #705 seems to be that a clickable child composable will consume long clicks, preventing its parent from receiving them, regardless of whether the child has a long click listener set.

The solution in this PR is to manually propagate long presses from the timestamp listener to the parent message listener.

I couldn't find much about this behaviour online but I did come across [this Stack Overflow post](https://stackoverflow.com/questions/74690306/jetpack-compose-long-press-propagation-from-child-to-parent) describing the same.

## Context
- Fixes #705 

## Screenshots

### Before

[before-timestamp.webm](https://github.com/vector-im/element-x-android/assets/4940864/1f2ec2b5-5d4e-45da-910f-8c862b4a2fbe)

### After

[after-timestamp.webm](https://github.com/vector-im/element-x-android/assets/4940864/96c0640a-fd9c-4ac8-b022-989a08278e2f)

