### PR TITLE
Create a dummy value by default for `LocalSnackbarDispatcher`

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/Snackbar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/Snackbar.kt
@@ -59,9 +59,7 @@ class SnackbarDispatcher {
 }
 
 /** Used to provide a [SnackbarDispatcher] to composable functions, it's needed for [rememberSnackbarHostState]. */
-val LocalSnackbarDispatcher = compositionLocalOf<SnackbarDispatcher> {
-    error("No SnackbarDispatcher provided")
-}
+val LocalSnackbarDispatcher = compositionLocalOf<SnackbarDispatcher> { SnackbarDispatcher() }
 
 @Composable
 fun SnackbarDispatcher.collectSnackbarMessageAsState(): State<SnackbarMessage?> {

--- a/tests/uitests/src/test/kotlin/io/element/android/tests/uitests/ScreenshotTest.kt
+++ b/tests/uitests/src/test/kotlin/io/element/android/tests/uitests/ScreenshotTest.kt
@@ -39,8 +39,6 @@ import com.android.ide.common.rendering.api.SessionParams
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import io.element.android.libraries.theme.ElementTheme
-import io.element.android.libraries.designsystem.utils.LocalSnackbarDispatcher
-import io.element.android.libraries.designsystem.utils.SnackbarDispatcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -98,8 +96,6 @@ class ScreenshotTest {
                 LocalConfiguration provides Configuration().apply {
                     setLocales(LocaleList(localeStr.toLocale()))
                 },
-                // Needed to display Snackbars and avoid crashes during screenshot tests
-                LocalSnackbarDispatcher provides SnackbarDispatcher(),
                 // Needed so that UI that uses it don't crash during screenshot tests
                 LocalOnBackPressedDispatcherOwner provides object : OnBackPressedDispatcherOwner {
                     override val lifecycle: Lifecycle get() = lifecycleOwner.lifecycle


### PR DESCRIPTION
This should solve the issue with needing to provide a `LocalSnackbarDispatcher` for previews and screenshot tests.