### PR TITLE
MatrixRoom API refinement

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -99,7 +99,7 @@ class MessagesPresenter @AssistedInject constructor(
         val customReactionState = customReactionPresenter.present()
         val retryState = retrySendMenuPresenter.present()
 
-        val syncUpdateFlow = room.syncUpdateFlow().collectAsState(0L)
+        val syncUpdateFlow = room.syncUpdateFlow.collectAsState()
         val userHasPermissionToSendMessage by room.canSendEventAsState(type = MessageEventType.ROOM_MESSAGE, updateKey = syncUpdateFlow.value)
         val roomName: MutableState<String?> = rememberSaveable {
             mutableStateOf(null)
@@ -112,7 +112,7 @@ class MessagesPresenter @AssistedInject constructor(
 
         val snackbarMessage by snackbarDispatcher.collectSnackbarMessageAsState()
 
-        LaunchedEffect(syncUpdateFlow) {
+        LaunchedEffect(syncUpdateFlow.value) {
             roomAvatar.value =
                 AvatarData(
                     id = room.roomId.value,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -43,7 +43,7 @@ class TimelinePresenter @Inject constructor(
     room: MatrixRoom,
 ) : Presenter<TimelineState> {
 
-    private val timeline = room.timeline()
+    private val timeline = room.timeline
 
     @Composable
     override fun present(): TimelineState {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditPresenter.kt
@@ -52,7 +52,7 @@ class RoomDetailsEditPresenter @Inject constructor(
 
     @Composable
     override fun present(): RoomDetailsEditState {
-        val roomSyncUpdateFlow = room.syncUpdateFlow().collectAsState(0L)
+        val roomSyncUpdateFlow = room.syncUpdateFlow.collectAsState()
 
         // Since there is no way to obtain the new avatar uri after uploading a new avatar,
         // just erase the local value when the room field has changed

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -58,9 +58,9 @@ interface MatrixRoom : Closeable {
      */
     suspend fun updateMembers(): Result<Unit>
 
-    fun syncUpdateFlow(): Flow<Long>
+    val syncUpdateFlow: StateFlow<Long>
 
-    fun timeline(): MatrixTimeline
+    val timeline: MatrixTimeline
 
     fun open(): Result<Unit>
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -73,10 +73,10 @@ import org.matrix.rustcomponents.sdk.RoomVisibility as RustRoomVisibility
 class RustMatrixClient constructor(
     private val client: Client,
     private val sessionStore: SessionStore,
-    private val appCoroutineScope: CoroutineScope,
+    appCoroutineScope: CoroutineScope,
     private val dispatchers: CoroutineDispatchers,
     private val baseDirectory: File,
-    private val baseCacheDirectory: File,
+    baseCacheDirectory: File,
     private val clock: SystemClock,
 ) : MatrixClient {
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -34,9 +34,8 @@ import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.test.timeline.FakeMatrixTimeline
 import io.element.android.tests.testutils.simulateLongTask
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.StateFlow
 import java.io.File
 
 class FakeMatrixRoom(
@@ -126,13 +125,9 @@ class FakeMatrixRoom(
         updateMembersResult
     }
 
-    override fun syncUpdateFlow(): Flow<Long> {
-        return emptyFlow()
-    }
+    override val syncUpdateFlow: StateFlow<Long> = MutableStateFlow(0L)
 
-    override fun timeline(): MatrixTimeline {
-        return matrixTimeline
-    }
+    override val timeline: MatrixTimeline = matrixTimeline
 
     override fun open(): Result<Unit> {
         return Result.success(Unit)

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
@@ -82,7 +82,7 @@ class RoomListScreen(
                 withContext(coroutineDispatchers.io) {
                     matrixClient.getRoom(roomId)!!.use { room ->
                         room.open()
-                        val timeline = room.timeline()
+                        val timeline = room.timeline
                         timeline.apply {
                             // TODO This doesn't work reliably as initialize is asynchronous, and the timeline can't be used until it's finished
                             paginateBackwards(20, 50)


### PR DESCRIPTION
- `syncUpdateFlow` becomes a `val` and always returns the same instance of the underlying `StateFlow` instead of different `Flow` instances to allow consumers not to remember the `Flow` and not to specify an unneeded initial value.
- `timeline` becomes a `val` as it already always returns the same instance.
- Amends calling code accordingly
- nit: Removes a few unneeded `val`s in `RustMatrixClient`
- Fixes a small bug in `MessagesPresenter` that allowed to sometime show a newly created room's name as "Empty room" (changes `LaunchedEffect(syncUpdateFlow)` to `LaunchedEffect(syncUpdateFlow.value)`)