### PR TITLE
Feature/fga/media upload progress

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -65,6 +65,7 @@ import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.networkmonitor.api.ui.ConnectivityIndicatorView
 import io.element.android.libraries.androidutils.ui.hideKeyboard
 import io.element.android.libraries.designsystem.components.ProgressDialog
+import io.element.android.libraries.designsystem.components.ProgressDialogType
 import io.element.android.libraries.designsystem.components.avatar.Avatar
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.button.BackButton
@@ -196,7 +197,15 @@ private fun AttachmentStateView(
         is AttachmentsState.Previewing -> LaunchedEffect(state) {
             onPreviewAttachments(state.attachments)
         }
-        is AttachmentsState.Sending -> ProgressDialog(text = stringResource(id = CommonStrings.common_loading))
+        is AttachmentsState.Sending -> {
+            ProgressDialog(
+                type = when (state) {
+                    is AttachmentsState.Sending.Uploading -> ProgressDialogType.Determinate(state.progress)
+                    is AttachmentsState.Sending.Processing -> ProgressDialogType.Indeterminate
+                },
+                text = stringResource(id = CommonStrings.common_sending)
+            )
+        }
     }
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewState.kt
@@ -17,10 +17,21 @@
 package io.element.android.features.messages.impl.attachments.preview
 
 import io.element.android.features.messages.impl.attachments.Attachment
-import io.element.android.libraries.architecture.Async
 
 data class AttachmentsPreviewState(
     val attachment: Attachment,
-    val sendActionState: Async<Unit>,
+    val sendActionState: SendActionState,
     val eventSink: (AttachmentsPreviewEvents) -> Unit
 )
+
+sealed interface SendActionState {
+    object Idle : SendActionState
+    sealed interface Sending : SendActionState {
+        object Processing : Sending
+        data class Uploading(val progress: Float) : Sending
+    }
+
+    data class Failure(val error: Throwable) : SendActionState
+    object Done : SendActionState
+}
+

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewStateProvider.kt
@@ -22,23 +22,21 @@ import io.element.android.features.messages.impl.attachments.Attachment
 import io.element.android.features.messages.impl.media.local.LocalMedia
 import io.element.android.features.messages.impl.media.local.MediaInfo
 import io.element.android.features.messages.impl.media.local.aFileInfo
-import io.element.android.features.messages.impl.media.local.aVideoInfo
 import io.element.android.features.messages.impl.media.local.anImageInfo
-import io.element.android.libraries.architecture.Async
 
 open class AttachmentsPreviewStateProvider : PreviewParameterProvider<AttachmentsPreviewState> {
     override val values: Sequence<AttachmentsPreviewState>
         get() = sequenceOf(
             anAttachmentsPreviewState(),
             anAttachmentsPreviewState(mediaInfo = aFileInfo()),
-            anAttachmentsPreviewState(sendActionState = Async.Loading()),
-            anAttachmentsPreviewState(sendActionState = Async.Failure(RuntimeException())),
+            anAttachmentsPreviewState(sendActionState = SendActionState.Sending.Uploading(0.5f)),
+            anAttachmentsPreviewState(sendActionState = SendActionState.Failure(RuntimeException())),
         )
 }
 
 fun anAttachmentsPreviewState(
     mediaInfo: MediaInfo = anImageInfo(),
-    sendActionState: Async<Unit> = Async.Uninitialized) = AttachmentsPreviewState(
+    sendActionState: SendActionState = SendActionState.Idle) = AttachmentsPreviewState(
     attachment = Attachment.Media(
         localMedia = LocalMedia("file://path".toUri(), mediaInfo),
         compressIfPossible = true

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerState.kt
@@ -38,5 +38,8 @@ data class MessageComposerState(
 sealed interface AttachmentsState {
     object None : AttachmentsState
     data class Previewing(val attachments: ImmutableList<Attachment>) : AttachmentsState
-    data class Sending(val attachments: ImmutableList<Attachment>) : AttachmentsState
+    sealed interface Sending : AttachmentsState {
+        data class Processing(val attachments: ImmutableList<Attachment>) : Sending
+        data class Uploading(val progress: Float) : Sending
+    }
 }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/attachments/AttachmentsPreviewPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/attachments/AttachmentsPreviewPresenterTest.kt
@@ -27,6 +27,7 @@ import io.element.android.features.messages.fixtures.aLocalMedia
 import io.element.android.features.messages.impl.attachments.Attachment
 import io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewEvents
 import io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter
+import io.element.android.features.messages.impl.attachments.preview.SendActionState
 import io.element.android.features.messages.impl.media.local.LocalMedia
 import io.element.android.libraries.architecture.Async
 import io.element.android.libraries.matrix.api.room.MatrixRoom
@@ -52,12 +53,12 @@ class AttachmentsPreviewPresenterTest {
             presenter.present()
         }.test {
             val initialState = awaitItem()
-            assertThat(initialState.sendActionState).isEqualTo(Async.Uninitialized)
+            assertThat(initialState.sendActionState).isEqualTo(SendActionState.Idle)
             initialState.eventSink(AttachmentsPreviewEvents.SendAttachment)
             val loadingState = awaitItem()
-            assertThat(loadingState.sendActionState).isEqualTo(Async.Loading<Unit>())
+            assertThat(loadingState.sendActionState).isInstanceOf(SendActionState.Sending::class.java)
             val successState = awaitItem()
-            assertThat(successState.sendActionState).isEqualTo(Async.Success(Unit))
+            assertThat(successState.sendActionState).isEqualTo(SendActionState.Done)
             assertThat(room.sendMediaCount).isEqualTo(1)
         }
     }
@@ -72,16 +73,16 @@ class AttachmentsPreviewPresenterTest {
             presenter.present()
         }.test {
             val initialState = awaitItem()
-            assertThat(initialState.sendActionState).isEqualTo(Async.Uninitialized)
+            assertThat(initialState.sendActionState).isEqualTo(SendActionState.Idle)
             initialState.eventSink(AttachmentsPreviewEvents.SendAttachment)
             val loadingState = awaitItem()
-            assertThat(loadingState.sendActionState).isEqualTo(Async.Loading<Unit>())
+            assertThat(loadingState.sendActionState).isInstanceOf(SendActionState.Sending::class.java)
             val failureState = awaitItem()
-            assertThat(failureState.sendActionState).isEqualTo(Async.Failure<Unit>(failure))
+            assertThat(failureState.sendActionState).isEqualTo((SendActionState.Failure(failure)))
             assertThat(room.sendMediaCount).isEqualTo(0)
             failureState.eventSink(AttachmentsPreviewEvents.ClearSendState)
             val clearedState = awaitItem()
-            assertThat(clearedState.sendActionState).isEqualTo(Async.Uninitialized)
+            assertThat(clearedState.sendActionState).isEqualTo(SendActionState.Idle)
         }
     }
 

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ProgressDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ProgressDialog.kt
@@ -37,10 +37,16 @@ import io.element.android.libraries.designsystem.preview.PreviewGroup
 import io.element.android.libraries.designsystem.theme.components.CircularProgressIndicator
 import io.element.android.libraries.designsystem.theme.components.Text
 
+sealed interface ProgressDialogType {
+    data class Determinate(val progress: Float) : ProgressDialogType
+    object Indeterminate : ProgressDialogType
+}
+
 @Composable
 fun ProgressDialog(
     modifier: Modifier = Modifier,
     text: String? = null,
+    type: ProgressDialogType = ProgressDialogType.Indeterminate,
     onDismiss: () -> Unit = {},
 ) {
     Dialog(
@@ -50,6 +56,21 @@ fun ProgressDialog(
         ProgressDialogContent(
             modifier = modifier,
             text = text,
+            progressIndicator = {
+                when (type) {
+                    is ProgressDialogType.Indeterminate -> {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                    is ProgressDialogType.Determinate -> {
+                        CircularProgressIndicator(
+                            progress = type.progress,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            }
         )
     }
 }
@@ -58,6 +79,11 @@ fun ProgressDialog(
 private fun ProgressDialogContent(
     modifier: Modifier = Modifier,
     text: String? = null,
+    progressIndicator: @Composable () -> Unit = {
+        CircularProgressIndicator(
+            color = MaterialTheme.colorScheme.primary
+        )
+    }
 ) {
     Box(
         contentAlignment = Alignment.Center,
@@ -71,9 +97,7 @@ private fun ProgressDialogContent(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(top = 38.dp, bottom = 32.dp, start = 40.dp, end = 40.dp)
         ) {
-            CircularProgressIndicator(
-                color = MaterialTheme.colorScheme.primary
-            )
+            progressIndicator()
             if (!text.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(22.dp))
                 Text(


### PR DESCRIPTION
Branch progress on media upload
- Introduces `Determinate` and `Indeterminate`  `DialogProgressType`
- Starts using `Indeterminate` as long as the `ProgressCallback` is not starting, and then switch to `Determinate`.