### PR TITLE
Feature/fga/timeline back pagination

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -59,16 +59,16 @@ class TimelinePresenter @Inject constructor(
         var lastReadMarkerIndex by rememberSaveable { mutableStateOf(Int.MAX_VALUE) }
         var lastReadMarkerId by rememberSaveable { mutableStateOf<EventId?>(null) }
 
-        val timelineItems = timelineItemsFactory.collectItemsAsState()
-        val paginationState = timeline.paginationState.collectAsState()
+        val timelineItems by timelineItemsFactory.collectItemsAsState()
+        val paginationState by timeline.paginationState.collectAsState()
 
         fun handleEvents(event: TimelineEvents) {
             when (event) {
-                TimelineEvents.LoadMore -> localCoroutineScope.loadMore(paginationState.value)
+                TimelineEvents.LoadMore -> localCoroutineScope.loadMore(paginationState)
                 is TimelineEvents.SetHighlightedEvent -> highlightedEventId.value = event.eventId
                 is TimelineEvents.OnScrollFinished -> {
                     // Get last valid EventId seen by the user, as the first index might refer to a Virtual item
-                    val eventId = getLastEventIdBeforeOrAt(event.firstIndex, timelineItems.value) ?: return
+                    val eventId = getLastEventIdBeforeOrAt(event.firstIndex, timelineItems) ?: return
                     if (event.firstIndex <= lastReadMarkerIndex && eventId != lastReadMarkerId) {
                         lastReadMarkerIndex = event.firstIndex
                         lastReadMarkerId = eventId
@@ -82,13 +82,18 @@ class TimelinePresenter @Inject constructor(
             timeline
                 .timelineItems
                 .onEach(timelineItemsFactory::replaceWith)
+                .onEach { timelineItems ->
+                    if (timelineItems.isEmpty()) {
+                        loadMore(paginationState)
+                    }
+                }
                 .launchIn(this)
         }
 
         return TimelineState(
             highlightedEventId = highlightedEventId.value,
-            paginationState = paginationState.value,
-            timelineItems = timelineItems.value,
+            paginationState = paginationState,
+            timelineItems = timelineItems,
             eventSink = ::handleEvents
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -59,13 +59,8 @@ class TimelinePresenter @Inject constructor(
         var lastReadMarkerIndex by rememberSaveable { mutableStateOf(Int.MAX_VALUE) }
         var lastReadMarkerId by rememberSaveable { mutableStateOf<EventId?>(null) }
 
-        val timelineItems = timelineItemsFactory
-            .flow()
-            .collectAsState()
-
-        val paginationState = timeline
-            .paginationState()
-            .collectAsState()
+        val timelineItems = timelineItemsFactory.collectItemsAsState()
+        val paginationState = timeline.paginationState.collectAsState()
 
         fun handleEvents(event: TimelineEvents) {
             when (event) {
@@ -85,13 +80,8 @@ class TimelinePresenter @Inject constructor(
 
         LaunchedEffect(Unit) {
             timeline
-                .timelineItems()
+                .timelineItems
                 .onEach(timelineItemsFactory::replaceWith)
-                .onEach { timelineItems ->
-                    if (timelineItems.isEmpty()) {
-                        loadMore(paginationState.value)
-                    }
-                }
                 .launchIn(this)
         }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
@@ -62,7 +61,6 @@ import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.UserId
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 @Composable
@@ -123,8 +121,7 @@ fun TimelineView(
 
         TimelineScrollHelper(
             lazyListState = lazyListState,
-            timelineItems = state.timelineItems,
-            onLoadMore = ::onReachedLoadMore
+            timelineItems = state.timelineItems
         )
     }
 }
@@ -222,7 +219,6 @@ fun TimelineItemRow(
 internal fun BoxScope.TimelineScrollHelper(
     lazyListState: LazyListState,
     timelineItems: ImmutableList<TimelineItem>,
-    onLoadMore: () -> Unit = {},
 ) {
     val coroutineScope = rememberCoroutineScope()
     val firstVisibleItemIndex by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
@@ -234,24 +230,6 @@ internal fun BoxScope.TimelineScrollHelper(
         ) coroutineScope.launch {
             lazyListState.animateScrollToItem(0)
         }
-    }
-
-    // Handle load more preloading
-    val loadMore by remember {
-        derivedStateOf {
-            val layoutInfo = lazyListState.layoutInfo
-            val totalItemsNumber = layoutInfo.totalItemsCount
-            val lastVisibleItemIndex = (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) + 1
-            lastVisibleItemIndex > (totalItemsNumber - 30)
-        }
-    }
-
-    LaunchedEffect(loadMore) {
-        snapshotFlow { loadMore }
-            .distinctUntilChanged()
-            .collect {
-                onLoadMore()
-            }
     }
 
     // Jump to bottom button

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
@@ -16,6 +16,9 @@
 
 package io.element.android.features.messages.impl.timeline.factories
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
 import androidx.recyclerview.widget.DiffUtil
 import io.element.android.features.messages.impl.timeline.diff.CacheInvalidator
 import io.element.android.features.messages.impl.timeline.diff.MatrixTimelineItemsDiffCallback
@@ -27,11 +30,8 @@ import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -55,7 +55,10 @@ class TimelineItemsFactory @Inject constructor(
     private val lock = Mutex()
     private val cacheInvalidator = CacheInvalidator(timelineItemsCache)
 
-    fun flow(): StateFlow<ImmutableList<TimelineItem>> = timelineItems.asStateFlow()
+    @Composable
+    fun collectItemsAsState(): State<ImmutableList<TimelineItem>> {
+        return timelineItems.collectAsState()
+    }
 
     suspend fun replaceWith(
         timelineItems: List<MatrixTimelineItem>,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/MatrixTimeline.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/MatrixTimeline.kt
@@ -27,8 +27,8 @@ interface MatrixTimeline {
         val canBackPaginate: Boolean
     )
 
-    fun paginationState(): StateFlow<PaginationState>
-    fun timelineItems(): Flow<List<MatrixTimelineItem>>
+    val paginationState: StateFlow<PaginationState>
+    val timelineItems: Flow<List<MatrixTimelineItem>>
 
     suspend fun paginateBackwards(requestSize: Int, untilNumberOfItems: Int): Result<Unit>
     suspend fun fetchDetailsForEvent(eventId: EventId): Result<Unit>

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/timeline/FakeMatrixTimeline.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/timeline/FakeMatrixTimeline.kt
@@ -23,33 +23,30 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.getAndUpdate
 
 class FakeMatrixTimeline(
     initialTimelineItems: List<MatrixTimelineItem> = emptyList(),
     initialPaginationState: MatrixTimeline.PaginationState = MatrixTimeline.PaginationState(canBackPaginate = true, isBackPaginating = false)
 ) : MatrixTimeline {
 
-    private val paginationState: MutableStateFlow<MatrixTimeline.PaginationState> = MutableStateFlow(initialPaginationState)
-    private val timelineItems: MutableStateFlow<List<MatrixTimelineItem>> = MutableStateFlow(initialTimelineItems)
+    private val _paginationState: MutableStateFlow<MatrixTimeline.PaginationState> = MutableStateFlow(initialPaginationState)
+    private val _timelineItems: MutableStateFlow<List<MatrixTimelineItem>> = MutableStateFlow(initialTimelineItems)
 
     var sendReadReceiptCount = 0
         private set
 
     fun updatePaginationState(update: (MatrixTimeline.PaginationState.() -> MatrixTimeline.PaginationState)) {
-        paginationState.value = update(paginationState.value)
+        _paginationState.getAndUpdate(update)
     }
 
     fun updateTimelineItems(update: (items: List<MatrixTimelineItem>) -> List<MatrixTimelineItem>) {
-        timelineItems.value = update(timelineItems.value)
+        _timelineItems.getAndUpdate(update)
     }
 
-    override fun paginationState(): StateFlow<MatrixTimeline.PaginationState> {
-        return paginationState
-    }
+    override val paginationState: StateFlow<MatrixTimeline.PaginationState> = _paginationState
 
-    override fun timelineItems(): Flow<List<MatrixTimelineItem>> {
-        return timelineItems
-    }
+    override val timelineItems: Flow<List<MatrixTimelineItem>> = _timelineItems
 
     override suspend fun paginateBackwards(requestSize: Int, untilNumberOfItems: Int): Result<Unit> {
         updatePaginationState {

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
@@ -82,11 +82,7 @@ class RoomListScreen(
                 withContext(coroutineDispatchers.io) {
                     matrixClient.getRoom(roomId)!!.use { room ->
                         room.open()
-                        val timeline = room.timeline
-                        timeline.apply {
-                            // TODO This doesn't work reliably as initialize is asynchronous, and the timeline can't be used until it's finished
-                            paginateBackwards(20, 50)
-                        }
+                        room.timeline.paginateBackwards(20, 50)
                     }
                 }
             }


### PR DESCRIPTION
This PR:
- Fixes a crash when leaving a room (new because of syncUpdateFlow being used correctly).
- Disable pre-fetching in the timeline, as it causes more issues than it solves for now (lets make it better when rust room cache will be smarter).
- Convert a bunch of flows exposed as `fun` to `val`