### PR TITLE
Improve screenshot action error handling

### DIFF
--- a/.github/workflows/scripts/recordScreenshots.sh
+++ b/.github/workflows/scripts/recordScreenshots.sh
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+set -e
+
 TOKEN=$GITHUB_TOKEN
 REPO=$GITHUB_REPOSITORY
 


### PR DESCRIPTION
If the gradle build fails for some reason, the script should bail out instead of carrying on and pushing a commit that deletes all the screenshots[1]!

`set -e` simply makes the script return the appropriate exit code immediately if any of the subcommands fails.

[1] e.g. https://github.com/vector-im/element-x-android/pull/726/commits/44014fd5e05fb2f005c5b41ec5a71c55b39a20c3