### PR TITLE
Change app name in maestro tests

### DIFF
--- a/.maestro/tests/assertions/assertAnalyticsDisplayed.yaml
+++ b/.maestro/tests/assertions/assertAnalyticsDisplayed.yaml
@@ -1,5 +1,5 @@
 appId: ${APP_ID}
 ---
 - extendedWaitUntil:
-    visible: "Help improve ElementX dbg"
+    visible: "Help improve Element X dbg"
     timeout: 10_000


### PR DESCRIPTION
App name has changed so now maestro tests fail.