### PR TITLE
Add missing parameter for the SNAPSHOT version of analytics library

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -135,7 +135,8 @@ class MessageComposerPresenter @Inject constructor(
                         Composer(
                             inThread = false,
                             isEditing = composerMode.value is MessageComposerMode.Edit,
-                            isReply = composerMode.value is MessageComposerMode.Reply
+                            isReply = composerMode.value is MessageComposerMode.Reply,
+                            isLocation = false,
                         )
                     )
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -161,7 +161,7 @@ maplibre_annotation = "org.maplibre.gl:android-plugin-annotation-v9:2.0.0"
 # Analytics
 posthog = "com.posthog.android:posthog:2.0.3"
 sentry_android = "io.sentry:sentry-android:6.24.0"
-matrix_analytics_events = "com.github.matrix-org:matrix-analytics-events:main-SNAPSHOT"
+matrix_analytics_events = "com.github.matrix-org:matrix-analytics-events:42b2faa417c1e95f430bf8f6e379adba25ad5ef8"
 
 # Di
 inject = "javax.inject:javax.inject:1"


### PR DESCRIPTION
## Changes

- Adds missing parameter to analytics `Composer` event.
- Sets the analytics library version to at least a commit hash so we don't rely on `main-SNAPSHOT` anymore, since it will change and cause cache issues.

TODO in the future: use an actual defined version for the analytics library, but [the latest one](https://github.com/matrix-org/matrix-analytics-events/releases/tag/v0.5.0) is quite outdated.