### PR TITLE
Change MapLibre attribution tint

### DIFF
--- a/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/map/MapView.kt
+++ b/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/map/MapView.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
@@ -89,11 +90,14 @@ fun MapView(
     }
     var mapRefs by remember { mutableStateOf<MapRefs?>(null) }
 
+    val attributionColour = ElementTheme.colors.iconPrimary
+
     // Build map
     LaunchedEffect(darkMode) {
         mapView.awaitMap().let { map ->
             map.uiSettings.apply {
                 attributionGravity = Gravity.TOP
+                setAttributionTintColor(attributionColour.toArgb())
                 logoGravity = Gravity.TOP
                 isCompassEnabled = false
                 isRotateGesturesEnabled = false


### PR DESCRIPTION
Requested by design.

<img src="https://github.com/vector-im/element-x-android/assets/189133/23fad902-100a-461a-817a-7dc33277ee00" width=300><img src="https://github.com/vector-im/element-x-android/assets/189133/def578e9-d8bd-443a-827a-e55748e6849d" width=300>
