### PR TITLE
Don't show own user in search results

### DIFF
--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsPresenter.kt
@@ -100,7 +100,7 @@ class RoomMemberDetailsPresenter @AssistedInject constructor(
             avatarUrl = userAvatar,
             isBlocked = isBlocked.value,
             displayConfirmationDialog = confirmationDialog,
-            isCurrentUser = roomMember?.userId == client.sessionId,
+            isCurrentUser = client.isMe(roomMember?.userId),
             eventSink = ::handleEvents
         )
     }

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
@@ -62,7 +62,7 @@ class DefaultRoomLastMessageFormatter @Inject constructor(
 ) : RoomLastMessageFormatter {
 
     override fun format(event: EventTimelineItem, isDmRoom: Boolean): CharSequence? {
-        val isOutgoing = event.sender == matrixClient.sessionId
+        val isOutgoing = matrixClient.isMe(event.sender)
         val senderDisplayName = (event.senderProfile as? ProfileTimelineDetails.Ready)?.displayName ?: event.sender.value
         return when (val content = event.content) {
             is MessageContent -> processMessageContents(content, senderDisplayName, isDmRoom)

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultTimelineEventFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultTimelineEventFormatter.kt
@@ -49,7 +49,7 @@ class DefaultTimelineEventFormatter @Inject constructor(
 ) : TimelineEventFormatter {
 
     override fun format(event: EventTimelineItem): CharSequence? {
-        val isOutgoing = event.sender == matrixClient.sessionId
+        val isOutgoing = matrixClient.isMe(event.sender)
         val senderDisplayName = (event.senderProfile as? ProfileTimelineDetails.Ready)?.displayName ?: event.sender.value
         return when (val content = event.content) {
             is RoomMembershipContent -> {

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/RoomMembershipContentFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/RoomMembershipContentFormatter.kt
@@ -33,7 +33,7 @@ class RoomMembershipContentFormatter @Inject constructor(
         senderIsYou: Boolean,
     ): CharSequence? {
         val userId = membershipContent.userId
-        val memberIsYou = userId == matrixClient.sessionId
+        val memberIsYou = matrixClient.isMe(userId)
         return when (val change = membershipContent.change) {
             MembershipChange.JOINED -> if (memberIsYou) {
                 sp.getString(R.string.state_event_room_join_by_you)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -60,4 +60,6 @@ interface MatrixClient : Closeable {
     suspend fun loadUserAvatarURLString(): Result<String?>
     suspend fun uploadMedia(mimeType: String, data: ByteArray, progressCallback: ProgressCallback?): Result<String>
     fun roomMembershipObserver(): RoomMembershipObserver
+
+    fun isMe(userId: UserId?) = userId == sessionId
 }


### PR DESCRIPTION
Anywhere we do a global search (starting a DM, creating a room, inviting a user to a room) should filter out the local user.