### PR TITLE
Force the default locale to the selected one for screenshot tests

### DIFF
--- a/tests/uitests/src/test/kotlin/io/element/android/tests/uitests/ScreenshotTest.kt
+++ b/tests/uitests/src/test/kotlin/io/element/android/tests/uitests/ScreenshotTest.kt
@@ -81,6 +81,8 @@ class ScreenshotTest {
         @TestParameter(value = ["1.0"/*, "1.5"*/]) fontScale: Float,
         @TestParameter(value = ["en" /*"fr", "de", "ru"*/]) localeStr: String,
     ) {
+        val locale = localeStr.toLocale()
+        Locale.setDefault(locale) // Needed for regional settings, as first day of week
         paparazzi.unsafeUpdateConfig(
             deviceConfig = baseDeviceConfig.deviceConfig.copy(
                 softButtons = false
@@ -95,7 +97,7 @@ class ScreenshotTest {
                     fontScale = fontScale
                 ),
                 LocalConfiguration provides Configuration().apply {
-                    setLocales(LocaleList(localeStr.toLocale()))
+                    setLocales(LocaleList(locale))
                     // Dark mode previews have name "N" so their component name contains "- N"
                     if (componentTestPreview.name.contains("- $NIGHT_MODE_NAME")){
                         uiMode = Configuration.UI_MODE_NIGHT_YES
@@ -122,7 +124,7 @@ class ScreenshotTest {
 
 private fun String.toLocale(): Locale {
     return when (this) {
-        "en" -> Locale.ENGLISH
+        "en" -> Locale.US
         "fr" -> Locale.FRANCE
         "de" -> Locale.GERMAN
         else -> Locale.Builder().setLanguage(this).build()


### PR DESCRIPTION
This should force the locale used for `DatePicker` to `en_US` on screenshot tests, making them usable again locally.

Right now we have an issue with the first day of week and `DatePicker` that makes verification always fail locally.