### PR TITLE
Collapse long list of message reactions

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessagesReactionsButton.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessagesReactionsButton.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CornerSize
@@ -31,18 +33,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.element.android.libraries.designsystem.ElementTextStyles
 import io.element.android.libraries.designsystem.preview.ElementPreviewDark
 import io.element.android.libraries.designsystem.preview.ElementPreviewLight
+import io.element.android.libraries.designsystem.text.toDp
 import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.Surface
+import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.theme.ElementTheme
 
 @Composable
-fun MessagesMoreReactionsButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
+fun MessagesReactionsButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    content: MessagesReactionsButtonContent,
+) {
     val buttonColor = ElementTheme.colors.bgSubtleSecondary
     Surface(
         modifier = modifier
@@ -60,28 +69,62 @@ fun MessagesMoreReactionsButton(modifier: Modifier = Modifier, onClick: () -> Un
             .padding(vertical = 4.dp, horizontal = 10.dp),
         color = buttonColor
     ) {
-            Icon(
-                imageVector = Icons.Outlined.AddReaction,
-                contentDescription = "Add emoji",
-                tint = MaterialTheme.colorScheme.secondary,
-                modifier = Modifier
-                    // Same size as the line height of reaction emoji text
-                    .size(with(LocalDensity.current) { 20.sp.toDp() })
-            )
+        when (content) {
+            is MessagesReactionsButtonContent.Icon -> IconContent(imageVector = content.imageVector)
+            is MessagesReactionsButtonContent.Text -> TextContent(text = content.text)
+        }
     }
 }
 
+sealed class MessagesReactionsButtonContent {
+    data class Text(val text: String) : MessagesReactionsButtonContent()
+    data class Icon(val imageVector: ImageVector) : MessagesReactionsButtonContent()
+}
+
+private val reactionEmojiTextSize = 20.sp
+
+@Composable
+private fun TextContent(
+    text: String,
+    modifier: Modifier = Modifier,
+) = Text(
+    modifier = modifier
+        .height(reactionEmojiTextSize.toDp()),
+    text = text,
+    style = ElementTextStyles.Regular.bodyMD
+)
+
+@Composable
+private fun IconContent(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier
+) = Icon(
+    imageVector = imageVector,
+    contentDescription = "Add emoji",
+    tint = MaterialTheme.colorScheme.secondary,
+    modifier = modifier
+        .size(reactionEmojiTextSize.toDp())
+)
+
 @Preview
 @Composable
-internal fun MessagesMoreReactionsButtonLightPreview() =
+internal fun MessagesReactionsButtonLightPreview() =
     ElementPreviewLight { ContentToPreview() }
 
 @Preview
 @Composable
-internal fun MessagesMoreReactionsButtonDarkPreview() =
+internal fun MessagesReactionsButtonDarkPreview() =
     ElementPreviewDark { ContentToPreview() }
 
 @Composable
 private fun ContentToPreview() {
-    MessagesMoreReactionsButton(onClick = {})
+    Row {
+        MessagesReactionsButton(
+            content = MessagesReactionsButtonContent.Icon(Icons.Outlined.AddReaction),
+            onClick = {})
+        MessagesReactionsButton(
+            content = MessagesReactionsButtonContent.Text("Click me"),
+            onClick = {}
+        )
+    }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -249,7 +249,7 @@ private fun TimelineItemEventRowContent(
 
         // Reactions
         if (event.reactionsState.reactions.isNotEmpty()) {
-            TimelineItemReactionsView(
+            TimelineItemReactions(
                 reactionsState = event.reactionsState,
                 mainAxisAlignment = if (event.isMine) FlowMainAxisAlignment.End else FlowMainAxisAlignment.Start,
                 onReactionClicked = onReactionClicked,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemReactionsView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemReactionsView.kt
@@ -16,59 +16,172 @@
 
 package io.element.android.features.messages.impl.timeline.components
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AddReaction
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.flowlayout.FlowMainAxisAlignment
 import com.google.accompanist.flowlayout.FlowRow
+import io.element.android.features.messages.impl.timeline.aTimelineItemReactions
+import io.element.android.features.messages.impl.timeline.model.AggregatedReaction
 import io.element.android.features.messages.impl.timeline.model.TimelineItemReactions
-import io.element.android.features.messages.impl.timeline.model.aTimelineItemReactions
-import io.element.android.libraries.designsystem.preview.ElementPreviewDark
-import io.element.android.libraries.designsystem.preview.ElementPreviewLight
+import io.element.android.libraries.designsystem.preview.DayNightPreviews
+import io.element.android.libraries.designsystem.preview.ElementPreview
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toPersistentList
+
+/**
+ * The maximum number of items that can be displayed before some items will be hidden
+ *
+ * TODO: The threshold should be based on the number of rows, rather than items.
+ *       Once items would spill onto a third row, they should be hidden.
+ */
+private const val COLLAPSE_ITEMS_THRESHOLD = 8
 
 @Composable
-fun TimelineItemReactionsView(
+fun TimelineItemReactions(
     reactionsState: TimelineItemReactions,
     mainAxisAlignment: FlowMainAxisAlignment,
     onReactionClicked: (emoji: String) -> Unit,
     onMoreReactionsClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var expanded: Boolean by remember { mutableStateOf(false) }
+
+    val reactions by remember(reactionsState, expanded) {
+        derivedStateOf {
+            val numToDisplay = if (expanded) {
+                reactionsState.reactions.count()
+            } else {
+                COLLAPSE_ITEMS_THRESHOLD
+            }
+            reactionsState.reactions.take(numToDisplay).toPersistentList()
+        }
+    }
+
+    val expandableState by remember {
+        derivedStateOf {
+            if (expanded) {
+                ExpandableState.Expanded
+            } else {
+                val hiddenItems = reactionsState.reactions.count() - reactions.count()
+                if (hiddenItems > 0) {
+                    ExpandableState.Collapsed(hidden = hiddenItems)
+                } else {
+                    ExpandableState.None
+                }
+            }
+        }
+    }
+
+    TimelineItemReactionsView(
+        modifier = modifier,
+        reactions = reactions,
+        expandableState = expandableState,
+        mainAxisAlignment = mainAxisAlignment,
+        onReactionClick = onReactionClicked,
+        onMoreReactionsClick = onMoreReactionsClicked,
+        onExpandClick = { expanded = true },
+        onCollapseClick = { expanded = false }
+    )
+}
+
+private sealed class ExpandableState {
+    object None: ExpandableState()
+    data class Collapsed(val hidden: Int): ExpandableState()
+    object Expanded : ExpandableState()
+}
+
+@Composable
+private fun TimelineItemReactionsView(
+    reactions: ImmutableList<AggregatedReaction>,
+    expandableState: ExpandableState,
+    mainAxisAlignment: FlowMainAxisAlignment,
+    onReactionClick: (emoji: String) -> Unit,
+    onMoreReactionsClick: () -> Unit,
+    onExpandClick: () -> Unit,
+    onCollapseClick: () -> Unit,
+    modifier: Modifier = Modifier
+) =
     FlowRow(
         modifier = modifier,
         mainAxisSpacing = 4.dp,
         crossAxisSpacing = 4.dp,
         mainAxisAlignment = mainAxisAlignment,
     ) {
-        reactionsState.reactions.forEach { reaction ->
+        reactions.forEach { reaction ->
             MessagesReactionButton(
                 reaction = reaction,
-                onClick = { onReactionClicked(reaction.key) }
+                onClick = { onReactionClick(reaction.key) }
             )
         }
-        MessagesMoreReactionsButton(
-            onClick = onMoreReactionsClicked
+        when (expandableState) {
+            ExpandableState.Expanded ->
+                MessagesReactionsButton(
+                    content = MessagesReactionsButtonContent.Text("Show less"),
+                    onClick = onCollapseClick,
+                )
+            is ExpandableState.Collapsed ->
+                MessagesReactionsButton(
+                    content = MessagesReactionsButtonContent.Text(text = "${expandableState.hidden} more"),
+                    onClick = onExpandClick,
+                )
+            ExpandableState.None -> {
+                // No expand or collapse action available
+            }
+        }
+        MessagesReactionsButton(
+            content = MessagesReactionsButtonContent.Icon(Icons.Outlined.AddReaction),
+            onClick = onMoreReactionsClick
         )
     }
-}
 
-@Preview
+@DayNightPreviews
 @Composable
-internal fun TimelineItemReactionsViewLightPreview() =
-    ElementPreviewLight { ContentToPreview() }
-
-@Preview
-@Composable
-internal fun TimelineItemReactionsViewDarkPreview() =
-    ElementPreviewDark { ContentToPreview() }
-
-@Composable
-private fun ContentToPreview() {
-    TimelineItemReactionsView(
-        reactionsState = aTimelineItemReactions(),
-        mainAxisAlignment = FlowMainAxisAlignment.Center,
-        onReactionClicked = {},
-        onMoreReactionsClicked = {},
+fun TimelineItemReactionsViewPreview() = ElementPreview {
+    ContentToPreview(
+        reactions = aTimelineItemReactions(count = 1).reactions,
+        expandableState = ExpandableState.None,
     )
 }
+
+@DayNightPreviews
+@Composable
+fun TimelineItemReactionsViewCollapsedPreview() = ElementPreview {
+    ContentToPreview(
+        reactions = aTimelineItemReactions(count = 3).reactions,
+        expandableState = ExpandableState.Collapsed(hidden = 7),
+    )
+}
+
+@DayNightPreviews
+@Composable
+fun TimelineItemReactionsViewExpandedPreview() = ElementPreview {
+    ContentToPreview(
+        reactions = aTimelineItemReactions(count = 10).reactions,
+        expandableState = ExpandableState.Expanded,
+    )
+}
+
+@Composable
+private fun ContentToPreview(
+    reactions: ImmutableList<AggregatedReaction>,
+    expandableState: ExpandableState
+) {
+    TimelineItemReactionsView(
+        reactions = reactions,
+        expandableState = expandableState,
+        mainAxisAlignment = FlowMainAxisAlignment.Center,
+        onReactionClick = {},
+        onMoreReactionsClick = {},
+        onExpandClick = {},
+        onCollapseClick = {}
+    )
+}
+

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/text/UnitConverters.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/text/UnitConverters.kt
@@ -29,6 +29,13 @@ import androidx.compose.ui.unit.TextUnit
 fun Dp.toSp(): TextUnit = with(LocalDensity.current) { toSp() }
 
 /**
+ * Convert Sp to Dp, regarding current density.
+ * Can be used for instance to use Sp unit for size.
+ */
+@Composable
+fun TextUnit.toDp(): Dp = with(LocalDensity.current) { toDp() }
+
+/**
  * Convert Px value to Dp, regarding current density.
  */
 @Composable


### PR DESCRIPTION
## Changes

Collapse message reactions once a threshold number of unique reactions has been added.

## Context
Part of https://github.com/vector-im/element-x-android/issues/342
