### PR TITLE
Display the "verification success" Snackbar only when the state is `VerificationFlowState.Finished`.

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInEventProcessor.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInEventProcessor.kt
@@ -24,7 +24,7 @@ import io.element.android.libraries.matrix.api.verification.VerificationFlowStat
 import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -47,12 +47,15 @@ class LoggedInEventProcessor @Inject constructor(
 
     fun observeEvents(coroutineScope: CoroutineScope) {
         observingJob = coroutineScope.launch {
-            displayLeftRoomMessage.onEach {
-                displayMessage(CommonStrings.common_current_user_left_room)
-            }.launchIn(this)
+            displayLeftRoomMessage
+                .filter { it }
+                .onEach {
+                    displayMessage(CommonStrings.common_current_user_left_room)
+                }
+                .launchIn(this)
 
             displayVerificationSuccessfulMessage
-                .drop(1)
+                .filter { it }
                 .onEach {
                     displayMessage(CommonStrings.common_verification_complete)
                 }.launchIn(this)


### PR DESCRIPTION
Apply the same fix for `displayLeftRoomMessage`

Closes #809 

I have detected another issue: we can start the verification from the settings now and when complete, the snackbar will be displayed only when back to the room list. I will handle that separately. #812 

Test: verify the session, cancel it, let it timeout, verify again, play a lot with it. Before the fix the Snackbar was displayed a lot. With the fix it is displayed only when the verification is successful.