### PR TITLE
Reduce code coverage threshold for presenters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -225,12 +225,9 @@ koverMerged {
                 includes += "*Presenter"
                 excludes += "*Fake*Presenter"
                 excludes += "io.element.android.appnav.loggedin.LoggedInPresenter$*"
-                // Too small presenters, cannot reach the threshold.
-                excludes += "io.element.android.features.onboarding.impl.OnBoardingPresenter"
-                excludes += "io.element.android.features.preferences.impl.about.AboutPresenter"
             }
             bound {
-                minValue = 90
+                minValue = 85
                 counter = kotlinx.kover.api.CounterType.INSTRUCTION
                 valueType = kotlinx.kover.api.VerificationValueType.COVERED_PERCENTAGE
             }


### PR DESCRIPTION
Drop from 90% to 85% to allow for smaller presenters where the number of untestable instructions generated by kotlin/compose can reach ~10% of the entire file.