### PR TITLE
Snackbar fix

### DIFF
--- a/.idea/dictionaries/shared.xml
+++ b/.idea/dictionaries/shared.xml
@@ -8,6 +8,7 @@
             <w>onboarding</w>
             <w>placeables</w>
             <w>showkase</w>
+            <w>snackbar</w>
             <w>textfields</w>
         </words>
     </dictionary>

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import io.element.android.features.logout.api.LogoutPreferencePresenter
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.core.meta.BuildType
+import io.element.android.libraries.designsystem.utils.SnackbarDispatcher
+import io.element.android.libraries.designsystem.utils.collectSnackbarMessageAsState
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.api.user.getCurrentUser
@@ -43,6 +45,7 @@ class PreferencesRootPresenter @Inject constructor(
     private val sessionVerificationService: SessionVerificationService,
     private val buildType: BuildType,
     private val versionFormatter: VersionFormatter,
+    private val snackbarDispatcher: SnackbarDispatcher,
 ) : Presenter<PreferencesRootState> {
 
     @Composable
@@ -53,6 +56,8 @@ class PreferencesRootPresenter @Inject constructor(
         LaunchedEffect(Unit) {
             initialLoad(matrixUser)
         }
+
+        val snackbarMessage by snackbarDispatcher.collectSnackbarMessageAsState()
 
         // Session verification status (unknown, not verified, verified)
         val sessionVerifiedStatus by sessionVerificationService.sessionVerifiedStatus.collectAsState()
@@ -67,7 +72,8 @@ class PreferencesRootPresenter @Inject constructor(
             myUser = matrixUser.value,
             version = versionFormatter.get(),
             showCompleteVerification = sessionIsNotVerified,
-            showDeveloperSettings = showDeveloperSettings
+            showDeveloperSettings = showDeveloperSettings,
+            snackbarMessage = snackbarMessage,
         )
     }
 

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootState.kt
@@ -17,6 +17,7 @@
 package io.element.android.features.preferences.impl.root
 
 import io.element.android.features.logout.api.LogoutPreferenceState
+import io.element.android.libraries.designsystem.utils.SnackbarMessage
 import io.element.android.libraries.matrix.api.user.MatrixUser
 
 data class PreferencesRootState(
@@ -24,5 +25,6 @@ data class PreferencesRootState(
     val myUser: MatrixUser?,
     val version: String,
     val showCompleteVerification: Boolean,
-    val showDeveloperSettings: Boolean
+    val showDeveloperSettings: Boolean,
+    val snackbarMessage: SnackbarMessage?,
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootStateProvider.kt
@@ -17,11 +17,14 @@
 package io.element.android.features.preferences.impl.root
 
 import io.element.android.features.logout.api.aLogoutPreferenceState
+import io.element.android.libraries.designsystem.utils.SnackbarMessage
+import io.element.android.libraries.ui.strings.CommonStrings
 
 fun aPreferencesRootState() = PreferencesRootState(
     logoutState = aLogoutPreferenceState(),
     myUser = null,
     version = "Version 1.1 (1)",
     showCompleteVerification = true,
-    showDeveloperSettings = true
+    showDeveloperSettings = true,
+    snackbarMessage = SnackbarMessage(CommonStrings.common_verification_complete),
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootView.kt
@@ -24,6 +24,9 @@ import androidx.compose.material.icons.outlined.DeveloperMode
 import androidx.compose.material.icons.outlined.Help
 import androidx.compose.material.icons.outlined.InsertChart
 import androidx.compose.material.icons.outlined.VerifiedUser
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -39,6 +42,7 @@ import io.element.android.libraries.designsystem.preview.ElementPreviewLight
 import io.element.android.libraries.designsystem.preview.LargeHeightPreview
 import io.element.android.libraries.designsystem.theme.components.Divider
 import io.element.android.libraries.designsystem.theme.components.Text
+import io.element.android.libraries.designsystem.utils.rememberSnackbarHostState
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.ui.components.MatrixUserProvider
 import io.element.android.libraries.theme.ElementTheme
@@ -55,11 +59,22 @@ fun PreferencesRootView(
     onOpenDeveloperSettings: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val snackbarHostState = rememberSnackbarHostState(snackbarMessage = state.snackbarMessage)
+
     // Include pref from other modules
     PreferenceView(
         modifier = modifier,
         onBackPressed = onBackPressed,
-        title = stringResource(id = CommonStrings.common_settings)
+        title = stringResource(id = CommonStrings.common_settings),
+        snackbarHost = {
+            SnackbarHost(snackbarHostState) { data ->
+                Snackbar(
+                    snackbarData = data,
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
     ) {
         UserPreferences(state.myUser)
         if (state.showCompleteVerification) {

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootView.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.outlined.DeveloperMode
 import androidx.compose.material.icons.outlined.Help
 import androidx.compose.material.icons.outlined.InsertChart
 import androidx.compose.material.icons.outlined.VerifiedUser
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.runtime.Composable
@@ -70,8 +69,6 @@ fun PreferencesRootView(
             SnackbarHost(snackbarHostState) { data ->
                 Snackbar(
                     snackbarData = data,
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                    contentColor = MaterialTheme.colorScheme.primary
                 )
             }
         }

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenterTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenterTest.kt
@@ -23,6 +23,7 @@ import com.google.common.truth.Truth.assertThat
 import io.element.android.features.logout.impl.DefaultLogoutPreferencePresenter
 import io.element.android.libraries.architecture.Async
 import io.element.android.libraries.core.meta.BuildType
+import io.element.android.libraries.designsystem.utils.SnackbarDispatcher
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.test.AN_AVATAR_URL
 import io.element.android.libraries.matrix.test.A_USER_NAME
@@ -41,7 +42,8 @@ class PreferencesRootPresenterTest {
             matrixClient,
             FakeSessionVerificationService(),
             BuildType.DEBUG,
-            FakeVersionFormatter()
+            FakeVersionFormatter(),
+            SnackbarDispatcher(),
         )
         moleculeFlow(RecompositionClock.Immediate) {
             presenter.present()

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
@@ -231,8 +231,6 @@ fun RoomListContent(
             SnackbarHost(snackbarHostState) { data ->
                 Snackbar(
                     snackbarData = data,
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                    contentColor = MaterialTheme.colorScheme.primary
                 )
             }
         },

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceScreen.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceScreen.kt
@@ -50,6 +50,7 @@ fun PreferenceView(
     title: String,
     modifier: Modifier = Modifier,
     onBackPressed: () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Scaffold(
@@ -64,6 +65,7 @@ fun PreferenceView(
                 onBackPressed = onBackPressed,
             )
         },
+        snackbarHost = snackbarHost,
         content = {
             Column(
                 modifier = Modifier

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/Snackbar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/Snackbar.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/Snackbar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/Snackbar.kt
@@ -69,14 +69,13 @@ fun SnackbarDispatcher.collectSnackbarMessageAsState(): State<SnackbarMessage?> 
 @Composable
 fun rememberSnackbarHostState(snackbarMessage: SnackbarMessage?): SnackbarHostState {
     val snackbarHostState = remember { SnackbarHostState() }
-    val coroutineScope = rememberCoroutineScope()
     val snackbarMessageText = snackbarMessage?.let {
         stringResource(id = snackbarMessage.messageResId)
     }
     val dispatcher = LocalSnackbarDispatcher.current
     LaunchedEffect(snackbarMessage) {
         if (snackbarMessageText == null) return@LaunchedEffect
-        coroutineScope.launch {
+        launch {
             snackbarHostState.showSnackbar(
                 message = snackbarMessageText,
                 duration = snackbarMessage.duration,


### PR DESCRIPTION
Fixes #812

Start a verification from the settings screen and observe that the snackbar is now display on the setting root screen.

Also fix a color issue on Snackbar. Did not change the colors for the`MediaViewerView`, which is forced to DarkTheme.