### PR TITLE
Remove extra `syncService.startSync()` call

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -139,7 +139,6 @@ class LoggedInFlowNode @AssistedInject constructor(
         observeAnalyticsState()
         lifecycle.subscribe(
             onCreate = {
-                syncService.startSync()
                 plugins<LifecycleCallback>().forEach { it.onFlowCreated(id, inputs.matrixClient) }
                 val imageLoaderFactory = bindings<MatrixUIBindings>().loggedInImageLoaderFactory()
                 Coil.setImageLoader(imageLoaderFactory)


### PR DESCRIPTION
This is causing some issues with sync loops, making other very rare SS issues either appear or be easier to reproduce:

- Room joined but the invite is still on the invite list.
- Room joined but it's not present in the room list (usually at the same time as the one above).
- The same room appears twice in the room list.