### PR TITLE
Add userId to rageshake summary

### DIFF
--- a/features/rageshake/impl/build.gradle.kts
+++ b/features/rageshake/impl/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.designsystem)
     implementation(projects.libraries.uiStrings)
+    implementation(projects.libraries.sessionStorage.api)
     api(libs.squareup.seismic)
     api(projects.features.rageshake.api)
     implementation(libs.androidx.datastore.preferences)

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
@@ -32,6 +32,7 @@ import io.element.android.libraries.androidutils.file.compressFile
 import io.element.android.libraries.androidutils.file.safeDelete
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.core.extensions.toOnOff
+import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.core.mimetype.MimeTypes
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
@@ -68,13 +69,13 @@ class DefaultBugReporter @Inject constructor(
     private val okHttpClient: Provider<OkHttpClient>,
     private val userAgentProvider: UserAgentProvider,
     private val sessionStore: SessionStore,
+    private val buildMeta: BuildMeta,
     /*
     private val versionProvider: VersionProvider,
     private val vectorPreferences: VectorPreferences,
     private val vectorFileLogger: VectorFileLogger,
     private val systemLocaleProvider: SystemLocaleProvider,
     private val matrix: Matrix,
-    private val buildMeta: BuildMeta,
     private val processInfo: ProcessInfo,
     private val sdkIntProvider: BuildVersionSdkIntProvider,
     private val vectorLocale: VectorLocaleProvider,
@@ -268,7 +269,7 @@ class DefaultBugReporter @Inject constructor(
                 }
 
                 // add some github labels
-                // builder.addFormDataPart("label", buildMeta.versionName)
+                builder.addFormDataPart("label", buildMeta.versionName)
                 // builder.addFormDataPart("label", buildMeta.flavorDescription)
                 // builder.addFormDataPart("label", buildMeta.gitBranchName)
 

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
@@ -36,6 +36,7 @@ import io.element.android.libraries.core.mimetype.MimeTypes
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.network.useragent.UserAgentProvider
+import io.element.android.libraries.sessionstorage.api.SessionStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import okhttp3.Call
@@ -66,8 +67,8 @@ class DefaultBugReporter @Inject constructor(
     private val coroutineDispatchers: CoroutineDispatchers,
     private val okHttpClient: Provider<OkHttpClient>,
     private val userAgentProvider: UserAgentProvider,
+    private val sessionStore: SessionStore,
     /*
-    private val activeSessionHolder: ActiveSessionHolder,
     private val versionProvider: VersionProvider,
     private val vectorPreferences: VectorPreferences,
     private val vectorFileLogger: VectorFileLogger,
@@ -198,17 +199,10 @@ class DefaultBugReporter @Inject constructor(
                     ?.let { gzippedFiles.add(it) }
              */
 
-            var deviceId = "undefined"
-            var userId = "undefined"
+            val sessionData = sessionStore.getLatestSession()
+            val deviceId = sessionData?.deviceId ?: "undefined"
+            val userId = sessionData?.userId ?: "undefined"
             var olmVersion = "undefined"
-
-            /*
-            activeSessionHolder.getSafeActiveSession()?.let { session ->
-                userId = session.myUserId
-                deviceId = session.sessionParams.deviceId ?: "undefined"
-                olmVersion = session.cryptoService().getCryptoVersion(context, true)
-            }
-             */
 
             if (!mIsCancelled) {
                 val text = when (reportType) {


### PR DESCRIPTION
Fixes #833

UserId and DeviceId are always sent if available (i.e. if user is logged in), even if canContact is set to false (iso EA behavior).

Also add the version name as GitHub label, which was missing too.