### PR TITLE
Feature/fga/coroutine dispatcher

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/di/AppModule.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/AppModule.kt
@@ -37,10 +37,8 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.plus
 import java.io.File
-import java.util.concurrent.Executors
 
 @Module
 @ContributesTo(AppScope::class)
@@ -99,7 +97,6 @@ object AppModule {
             io = Dispatchers.IO,
             computation = Dispatchers.Default,
             main = Dispatchers.Main,
-            diffUpdateDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
         )
     }
 

--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/CoroutineDispatchers.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/CoroutineDispatchers.kt
@@ -22,5 +22,4 @@ data class CoroutineDispatchers(
     val io: CoroutineDispatcher,
     val computation: CoroutineDispatcher,
     val main: CoroutineDispatcher,
-    val diffUpdateDispatcher: CoroutineDispatcher,
 )

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomSummaryDataSource.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomSummaryDataSource.kt
@@ -16,9 +16,9 @@
 
 package io.element.android.libraries.matrix.impl.room
 
-import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.room.RoomSummary
 import io.element.android.libraries.matrix.api.room.RoomSummaryDataSource
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,7 +41,7 @@ import timber.log.Timber
 internal class RustRoomSummaryDataSource(
     private val roomListService: RoomListService,
     private val sessionCoroutineScope: CoroutineScope,
-    coroutineDispatchers: CoroutineDispatchers,
+    dispatcher: CoroutineDispatcher,
     roomSummaryDetailsFactory: RoomSummaryDetailsFactory = RoomSummaryDetailsFactory(),
 ) : RoomSummaryDataSource {
 
@@ -53,7 +53,7 @@ internal class RustRoomSummaryDataSource(
     private val inviteRoomsListProcessor = RoomSummaryListProcessor(inviteRooms, roomListService, roomSummaryDetailsFactory, shouldFetchFullRoom = true)
 
     init {
-        sessionCoroutineScope.launch(coroutineDispatchers.computation) {
+        sessionCoroutineScope.launch(dispatcher) {
             val allRooms = roomListService.allRooms()
             allRooms
                 .observeEntriesWithProcessor(allRoomsListProcessor)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
@@ -16,7 +16,6 @@
 
 package io.element.android.libraries.matrix.impl.timeline
 
-import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.timeline.MatrixTimeline
@@ -25,6 +24,7 @@ import io.element.android.libraries.matrix.impl.timeline.item.event.EventMessage
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventTimelineItemMapper
 import io.element.android.libraries.matrix.impl.timeline.item.event.TimelineEventContentMapper
 import io.element.android.libraries.matrix.impl.timeline.item.virtual.VirtualTimelineItemMapper
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
@@ -45,7 +45,7 @@ class RustMatrixTimeline(
     roomCoroutineScope: CoroutineScope,
     private val matrixRoom: MatrixRoom,
     private val innerRoom: Room,
-    private val coroutineDispatchers: CoroutineDispatchers,
+    private val dispatcher: CoroutineDispatcher,
 ) : MatrixTimeline {
 
     private val _timelineItems: MutableStateFlow<List<MatrixTimelineItem>> =
@@ -109,13 +109,13 @@ class RustMatrixTimeline(
         }
     }
 
-    override suspend fun fetchDetailsForEvent(eventId: EventId): Result<Unit> = withContext(coroutineDispatchers.io) {
+    override suspend fun fetchDetailsForEvent(eventId: EventId): Result<Unit> = withContext(dispatcher) {
         runCatching {
             innerRoom.fetchDetailsForEvent(eventId.value)
         }
     }
 
-    override suspend fun paginateBackwards(requestSize: Int, untilNumberOfItems: Int): Result<Unit> = withContext(coroutineDispatchers.io) {
+    override suspend fun paginateBackwards(requestSize: Int, untilNumberOfItems: Int): Result<Unit> = withContext(dispatcher) {
         runCatching {
             Timber.v("Start back paginating for room ${matrixRoom.roomId} ")
             val paginationOptions = PaginationOptions.UntilNumItems(
@@ -131,7 +131,7 @@ class RustMatrixTimeline(
         }
     }
 
-    override suspend fun sendReadReceipt(eventId: EventId) = withContext(coroutineDispatchers.io) {
+    override suspend fun sendReadReceipt(eventId: EventId) = withContext(dispatcher) {
         runCatching {
             innerRoom.sendReadReceipt(eventId = eventId.value)
         }

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/Singleton.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/Singleton.kt
@@ -22,10 +22,8 @@ import io.element.android.libraries.matrix.api.tracing.TracingConfigurations
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.plus
 import timber.log.Timber
-import java.util.concurrent.Executors
 
 object Singleton {
 
@@ -39,6 +37,5 @@ object Singleton {
         io = Dispatchers.IO,
         computation = Dispatchers.Default,
         main = Dispatchers.Main,
-        diffUpdateDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
     )
 }

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/TestCoroutineDispatchers.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/TestCoroutineDispatchers.kt
@@ -37,12 +37,10 @@ fun TestScope.testCoroutineDispatchers(
         io = UnconfinedTestDispatcher(testScheduler),
         computation = UnconfinedTestDispatcher(testScheduler),
         main = UnconfinedTestDispatcher(testScheduler),
-        diffUpdateDispatcher = UnconfinedTestDispatcher(testScheduler),
     )
     false -> CoroutineDispatchers(
         io = StandardTestDispatcher(testScheduler),
         computation = StandardTestDispatcher(testScheduler),
         main = StandardTestDispatcher(testScheduler),
-        diffUpdateDispatcher = StandardTestDispatcher(testScheduler),
     )
 }


### PR DESCRIPTION
Rework how we use coroutine dispatchers in matrix module so we avoid being blocked by `Dispatchers.IO` being full.

Why we need this change? Because we are wrapping every rust sdk method with `withContext` and as some of these methods can block for a long time, we can end-up not having available threads in the `Dispatchers.IO` thread pool.

This is probably a temp solution as rust-sdk methods will become suspendable soon™.

`parallelism` values given to `limitedParallelism` are kind of experimental, not sure what we should use. 
Note that this is the recommended way to use `Dispatchers.IO` for blocking calls.

See documentation of Dispatchers.IO and usage of views :


> Dispatchers.IO has a unique property of elasticity: its views obtained with CoroutineDispatcher.limitedParallelism are not restricted by the Dispatchers.IO parallelism. Conceptually, there is a dispatcher backed by an unlimited pool of threads, and both Dispatchers.IO and views of Dispatchers.IO are actually views of that dispatcher. In practice this means that, despite not abiding by Dispatchers.IO's parallelism restrictions, its views share threads and resources with it.
> In the following example
> ```
> // 100 threads for MySQL connection
> val myMysqlDbDispatcher = Dispatchers.IO.limitedParallelism(100)
> // 60 threads for MongoDB connection
> val myMongoDbDispatcher = Dispatchers.IO.limitedParallelism(60)
> ```
> 
> the system may have up to 64 + 100 + 60 threads dedicated to blocking tasks during peak loads, but during its steady state there is only a small number of threads shared among Dispatchers.IO, myMysqlDbDispatcher and myMongoDbDispatcher.
