### PR TITLE
Improve block/unblock user ux

### DIFF
--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsEvents.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsEvents.kt
@@ -19,5 +19,6 @@ package io.element.android.features.roomdetails.impl.members.details
 sealed interface RoomMemberDetailsEvents {
     data class BlockUser(val needsConfirmation: Boolean = false) : RoomMemberDetailsEvents
     data class UnblockUser(val needsConfirmation: Boolean = false) : RoomMemberDetailsEvents
+    object ClearBlockUserError : RoomMemberDetailsEvents
     object ClearConfirmationDialog : RoomMemberDetailsEvents
 }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsState.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsState.kt
@@ -16,11 +16,13 @@
 
 package io.element.android.features.roomdetails.impl.members.details
 
+import io.element.android.libraries.architecture.Async
+
 data class RoomMemberDetailsState(
     val userId: String,
     val userName: String?,
     val avatarUrl: String?,
-    val isBlocked: Boolean,
+    val isBlocked: Async<Boolean>,
     val displayConfirmationDialog: ConfirmationDialog? = null,
     val isCurrentUser: Boolean,
     val eventSink: (RoomMemberDetailsEvents) -> Unit

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsStateProvider.kt
@@ -17,15 +17,17 @@
 package io.element.android.features.roomdetails.impl.members.details
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import io.element.android.libraries.architecture.Async
 
 open class RoomMemberDetailsStateProvider : PreviewParameterProvider<RoomMemberDetailsState> {
     override val values: Sequence<RoomMemberDetailsState>
         get() = sequenceOf(
             aRoomMemberDetailsState(),
             aRoomMemberDetailsState().copy(userName = null),
-            aRoomMemberDetailsState().copy(isBlocked = true),
+            aRoomMemberDetailsState().copy(isBlocked = Async.Success(true)),
             aRoomMemberDetailsState().copy(displayConfirmationDialog = RoomMemberDetailsState.ConfirmationDialog.Block),
             aRoomMemberDetailsState().copy(displayConfirmationDialog = RoomMemberDetailsState.ConfirmationDialog.Unblock),
+            aRoomMemberDetailsState().copy(isBlocked = Async.Loading(true)),
             // Add other states here
         )
 }
@@ -34,7 +36,7 @@ fun aRoomMemberDetailsState() = RoomMemberDetailsState(
     userId = "@daniel:domain.com",
     userName = "Daniel",
     avatarUrl = null,
-    isBlocked = false,
+    isBlocked = Async.Success(false),
     isCurrentUser = false,
     eventSink = {},
 )

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -38,6 +38,7 @@ import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
 import io.element.android.libraries.matrix.test.room.FakeRoomSummaryDataSource
 import io.element.android.libraries.matrix.test.sync.FakeSyncService
 import io.element.android.libraries.matrix.test.verification.FakeSessionVerificationService
+import io.element.android.tests.testutils.simulateLongTask
 import kotlinx.coroutines.delay
 
 class FakeMatrixClient(
@@ -72,11 +73,11 @@ class FakeMatrixClient(
         return findDmResult
     }
 
-    override suspend fun ignoreUser(userId: UserId): Result<Unit> {
+    override suspend fun ignoreUser(userId: UserId): Result<Unit> = simulateLongTask {
         return ignoreUserResult
     }
 
-    override suspend fun unignoreUser(userId: UserId): Result<Unit> {
+    override suspend fun unignoreUser(userId: UserId): Result<Unit> = simulateLongTask {
         return unignoreUserResult
     }
 

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewDarkPreview--3_3_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewDarkPreview--3_3_null_5,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7ca068387cff8faf728a989488e7c4b5b07983c4b24162ff82a14fd90b82d05
+size 20609

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewLightPreview--2_2_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.roomdetails.impl.members.details_null_DefaultGroup_RoomMemberDetailsViewLightPreview--2_2_null_5,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1599be0c5a37083c015378ee47a78a90dcf670f4df5d85dd25d39f4b2edbdf6
+size 21147


### PR DESCRIPTION
Fixes 846.

Add a loader during the operation, and handle error cases.

Also the value is more "live", even if during my test, I add some weird behavior. The comment `// the room member is not really live...` is still true I guess.