### PR TITLE
More log and various fixes

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/MainActivity.kt
+++ b/app/src/main/kotlin/io/element/android/x/MainActivity.kt
@@ -52,8 +52,7 @@ class MainActivity : NodeComponentActivity() {
         Timber.tag(loggerTag.value).w("onCreate, with savedInstanceState: ${savedInstanceState != null}")
         installSplashScreen()
         super.onCreate(savedInstanceState)
-        appBindings = bindings<AppBindings>()
-        appBindings.matrixClientsHolder().restore(savedInstanceState)
+        appBindings = bindings()
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             MainContent(appBindings)
@@ -124,10 +123,5 @@ class MainActivity : NodeComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         Timber.tag(loggerTag.value).w("onDestroy")
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        bindings<AppBindings>().matrixClientsHolder().onSaveInstanceState(outState)
     }
 }

--- a/app/src/main/kotlin/io/element/android/x/di/AppBindings.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/AppBindings.kt
@@ -17,13 +17,11 @@
 package io.element.android.x.di
 
 import com.squareup.anvil.annotations.ContributesTo
-import io.element.android.appnav.di.MatrixClientsHolder
 import io.element.android.libraries.designsystem.utils.SnackbarDispatcher
 import io.element.android.libraries.di.AppScope
 
 @ContributesTo(AppScope::class)
 interface AppBindings {
-    fun matrixClientsHolder(): MatrixClientsHolder
     fun mainDaggerComponentOwner(): MainDaggerComponentsOwner
     fun snackbarDispatcher(): SnackbarDispatcher
 }

--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -154,8 +154,6 @@ class LoggedInFlowNode @AssistedInject constructor(
                 syncService.stopSync()
             },
             onDestroy = {
-                val imageLoaderFactory = bindings<MatrixUIBindings>().notLoggedInImageLoaderFactory()
-                Coil.setImageLoader(imageLoaderFactory)
                 plugins<LifecycleCallback>().forEach { it.onFlowReleased(id, inputs.matrixClient) }
                 appNavigationStateService.onLeavingSpace(id)
                 appNavigationStateService.onLeavingSession(id)

--- a/appnav/src/main/kotlin/io/element/android/appnav/NotLoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/NotLoggedInFlowNode.kt
@@ -20,7 +20,6 @@ import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.bumble.appyx.core.composable.Children
-import com.bumble.appyx.core.lifecycle.subscribe
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.plugin.Plugin
@@ -35,7 +34,6 @@ import io.element.android.libraries.architecture.BackstackNode
 import io.element.android.libraries.architecture.animation.rememberDefaultTransitionHandler
 import io.element.android.libraries.di.AppScope
 import kotlinx.parcelize.Parcelize
-import timber.log.Timber
 
 @ContributesNode(AppScope::class)
 class NotLoggedInFlowNode @AssistedInject constructor(
@@ -51,13 +49,6 @@ class NotLoggedInFlowNode @AssistedInject constructor(
     buildContext = buildContext,
     plugins = plugins,
 ) {
-    init {
-        lifecycle.subscribe(
-            onCreate = { Timber.v("OnCreate") },
-            onDestroy = { Timber.v("OnDestroy") }
-        )
-    }
-
     sealed interface NavTarget : Parcelable {
         @Parcelize
         object OnBoarding : NavTarget

--- a/appnav/src/main/kotlin/io/element/android/appnav/NotLoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/NotLoggedInFlowNode.kt
@@ -19,7 +19,9 @@ package io.element.android.appnav
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import coil.Coil
 import com.bumble.appyx.core.composable.Children
+import com.bumble.appyx.core.lifecycle.subscribe
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.plugin.Plugin
@@ -32,7 +34,9 @@ import io.element.android.features.login.api.LoginEntryPoint
 import io.element.android.features.onboarding.api.OnBoardingEntryPoint
 import io.element.android.libraries.architecture.BackstackNode
 import io.element.android.libraries.architecture.animation.rememberDefaultTransitionHandler
+import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.matrix.ui.di.MatrixUIBindings
 import kotlinx.parcelize.Parcelize
 
 @ContributesNode(AppScope::class)
@@ -49,6 +53,16 @@ class NotLoggedInFlowNode @AssistedInject constructor(
     buildContext = buildContext,
     plugins = plugins,
 ) {
+    override fun onBuilt() {
+        super.onBuilt()
+        lifecycle.subscribe(
+            onCreate = {
+                val imageLoaderFactory = bindings<MatrixUIBindings>().notLoggedInImageLoaderFactory()
+                Coil.setImageLoader(imageLoaderFactory)
+            },
+        )
+    }
+
     sealed interface NavTarget : Parcelable {
         @Parcelize
         object OnBoarding : NavTarget

--- a/appnav/src/main/kotlin/io/element/android/appnav/NotLoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/NotLoggedInFlowNode.kt
@@ -34,9 +34,8 @@ import io.element.android.features.login.api.LoginEntryPoint
 import io.element.android.features.onboarding.api.OnBoardingEntryPoint
 import io.element.android.libraries.architecture.BackstackNode
 import io.element.android.libraries.architecture.animation.rememberDefaultTransitionHandler
-import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.di.AppScope
-import io.element.android.libraries.matrix.ui.di.MatrixUIBindings
+import io.element.android.libraries.matrix.ui.media.NotLoggedInImageLoaderFactory
 import kotlinx.parcelize.Parcelize
 
 @ContributesNode(AppScope::class)
@@ -45,6 +44,7 @@ class NotLoggedInFlowNode @AssistedInject constructor(
     @Assisted plugins: List<Plugin>,
     private val onBoardingEntryPoint: OnBoardingEntryPoint,
     private val loginEntryPoint: LoginEntryPoint,
+    private val notLoggedInImageLoaderFactory: NotLoggedInImageLoaderFactory,
 ) : BackstackNode<NotLoggedInFlowNode.NavTarget>(
     backstack = BackStack(
         initialElement = NavTarget.OnBoarding,
@@ -57,8 +57,7 @@ class NotLoggedInFlowNode @AssistedInject constructor(
         super.onBuilt()
         lifecycle.subscribe(
             onCreate = {
-                val imageLoaderFactory = bindings<MatrixUIBindings>().notLoggedInImageLoaderFactory()
-                Coil.setImageLoader(imageLoaderFactory)
+                Coil.setImageLoader(notLoggedInImageLoaderFactory)
             },
         )
     }

--- a/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
@@ -30,6 +30,7 @@ import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.node
 import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.core.plugin.plugins
+import com.bumble.appyx.core.state.MutableSavedStateMap
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.operation.pop
 import com.bumble.appyx.navmodel.backstack.operation.push
@@ -90,8 +91,14 @@ class RootFlowNode @AssistedInject constructor(
     ) {
 
     override fun onBuilt() {
+        matrixClientsHolder.restore(buildContext.savedStateMap)
         super.onBuilt()
         observeLoggedInState()
+    }
+
+    override fun onSaveInstanceState(state: MutableSavedStateMap) {
+        super.onSaveInstanceState(state)
+        matrixClientsHolder.save(state)
     }
 
     private fun observeLoggedInState() {

--- a/appnav/src/main/kotlin/io/element/android/appnav/di/MatrixClientsHolder.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/di/MatrixClientsHolder.kt
@@ -54,10 +54,12 @@ class MatrixClientsHolder @Inject constructor(private val authenticationService:
 
     @Suppress("UNCHECKED_CAST")
     fun restore(state: SavedStateMap?) {
+        Timber.d("Restore state")
         if (state == null || sessionIdsToMatrixClient.isNotEmpty()) return Unit.also {
             Timber.w("Restore with non-empty map")
         }
         val sessionIds = state[SAVE_INSTANCE_KEY] as? Array<SessionId>
+        Timber.d("Restore matrix session keys = ${sessionIds?.map { it.value }}")
         if (sessionIds.isNullOrEmpty()) return
         // Not ideal but should only happens in case of process recreation. This ensure we restore all the active sessions before restoring the node graphs.
         runBlocking {
@@ -76,7 +78,7 @@ class MatrixClientsHolder @Inject constructor(private val authenticationService:
 
     fun save(state: MutableSavedStateMap) {
         val sessionKeys = sessionIdsToMatrixClient.keys.toTypedArray()
-        Timber.d("Save matrix session keys = $sessionKeys")
+        Timber.d("Save matrix session keys = ${sessionKeys.map { it.value }}")
         state[SAVE_INSTANCE_KEY] = sessionKeys
     }
 }

--- a/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/BackstackNode.kt
+++ b/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/BackstackNode.kt
@@ -19,6 +19,7 @@ package io.element.android.libraries.architecture
 import androidx.compose.runtime.Stable
 import com.bumble.appyx.core.children.ChildEntry
 import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.navmodel.backstack.BackStack
@@ -39,4 +40,15 @@ abstract class BackstackNode<NavTarget : Any>(
     buildContext = buildContext,
     plugins = plugins,
     childKeepMode = childKeepMode,
-)
+) {
+    override fun onBuilt() {
+        super.onBuilt()
+        lifecycle.logLifecycle(this::class.java.simpleName)
+        whenChildAttached<Node> { _, child ->
+            // BackstackNode will be logged by their parent.
+            if (child !is BackstackNode<*>) {
+                child.lifecycle.logLifecycle(child::class.java.simpleName)
+            }
+        }
+    }
+}

--- a/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/LifecycleExt.kt
+++ b/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/LifecycleExt.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.architecture
+
+import androidx.lifecycle.Lifecycle
+import com.bumble.appyx.core.lifecycle.subscribe
+import timber.log.Timber
+
+fun Lifecycle.logLifecycle(name: String) {
+    subscribe(
+        onCreate = { Timber.tag("Lifecycle").d("onCreate $name") },
+        onPause = { Timber.tag("Lifecycle").d("onPause $name") },
+        onResume = { Timber.tag("Lifecycle").d("onResume $name") },
+        onDestroy = { Timber.tag("Lifecycle").d("onDestroy $name") },
+    )
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomSummaryDataSource.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomSummaryDataSource.kt
@@ -38,12 +38,13 @@ interface RoomSummaryDataSource {
 
 suspend fun RoomSummaryDataSource.awaitAllRoomsAreLoaded(timeout: Duration = Duration.INFINITE) {
     try {
+        Timber.d("awaitAllRoomsAreLoaded: wait")
         withTimeout(timeout) {
             allRoomsLoadingState().firstOrNull {
                 it is RoomSummaryDataSource.LoadingState.Loaded
             }
         }
     } catch (timeoutException: TimeoutCancellationException) {
-        Timber.v("AwaitAllRooms: no response after $timeout")
+        Timber.d("awaitAllRoomsAreLoaded: no response after $timeout")
     }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomListExtensions.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomListExtensions.kt
@@ -62,7 +62,7 @@ fun RoomListService.roomOrNull(roomId: String): RoomListItem? {
     return try {
         room(roomId)
     } catch (exception: RoomListException) {
-        Timber.e(exception, "Failed finding room with id=$roomId")
+        Timber.d(exception, "Failed finding room with id=$roomId.")
         return null
     }
 }

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/di/MatrixUIBindings.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/di/MatrixUIBindings.kt
@@ -19,10 +19,8 @@ package io.element.android.libraries.matrix.ui.di
 import com.squareup.anvil.annotations.ContributesTo
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.ui.media.LoggedInImageLoaderFactory
-import io.element.android.libraries.matrix.ui.media.NotLoggedInImageLoaderFactory
 
 @ContributesTo(SessionScope::class)
 interface MatrixUIBindings {
     fun loggedInImageLoaderFactory(): LoggedInImageLoaderFactory
-    fun notLoggedInImageLoaderFactory(): NotLoggedInImageLoaderFactory
 }


### PR DESCRIPTION
In this PR:

- Fix issue when room list was not visible if the node are destroyed (repro on Samsung S9+). `RootFlowNode.kt` is now saving and restoring the state using the `MatrixClientHolder`, which is not a singleton anymore.
- Fix issue when image are not loaded after clear cache.
- More log on Node lifecycle. Will help to see where is the user looking at the logs (and rageshakes).
- Improve some logs.

Co-authored by @ganfra.