### PR TITLE
Ensure pending intent data are unique.

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/PendingIntentFactory.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/PendingIntentFactory.kt
@@ -106,7 +106,7 @@ class PendingIntentFactory @Inject constructor(
     fun createDismissEventPendingIntent(sessionId: SessionId, roomId: RoomId, eventId: EventId): PendingIntent {
         val intent = Intent(context, NotificationBroadcastReceiver::class.java)
         intent.action = actionIds.dismissEvent
-        intent.data = createIgnoredUri("deleteEvent/$sessionId/$roomId")
+        intent.data = createIgnoredUri("deleteEvent/$sessionId/$roomId/$eventId")
         intent.putExtra(NotificationBroadcastReceiver.KEY_SESSION_ID, sessionId.value)
         intent.putExtra(NotificationBroadcastReceiver.KEY_ROOM_ID, roomId.value)
         intent.putExtra(NotificationBroadcastReceiver.KEY_EVENT_ID, eventId.value)


### PR DESCRIPTION
Fixes #855.

`Intent.data` of `PendingIntent` must be unique for the system not to mess up.