### PR TITLE
Set right timestamp for fallback notifications

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationFactory.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationFactory.kt
@@ -232,6 +232,7 @@ class NotificationFactory @Inject constructor(
             .setSmallIcon(smallIcon)
             .setColor(accentColor)
             .setAutoCancel(true)
+            .setWhen(fallbackNotifiableEvent.timestamp)
             // Ideally we'd use `createOpenRoomPendingIntent` here, but the broken notification might apply to an invite
             // and the user won't have access to the room yet, resulting in an error screen.
             .setContentIntent(pendingIntentFactory.createOpenSessionPendingIntent(fallbackNotifiableEvent.sessionId))


### PR DESCRIPTION
When I created this new type of notifications I used as a base a type that didn't set up the `when` property of a Notification, so all fallback notifications appear as received 'now'. This should fix it.