### PR TITLE
Try to improve 'Tests' CI job times

### DIFF
--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -27,10 +27,10 @@ jobs:
           java-version: '17'
 
       - name: ⚙️ Run unit tests, debug and release
-        run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+        run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES
 
       - name: 📸️ Run screenshot tests (debug)
-        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES
 
       - name: 📈 Generate kover report and verify coverage
         run: ./gradlew koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true

--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -26,11 +26,14 @@ jobs:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
 
-      - name: ⚙️ Run unit & screenshot tests, debug and release
+      - name: ⚙️ Run unit tests, debug and release
         run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
 
-      - name: ⚙️ Run unit & screenshot tests, generate kover report
-        run: ./gradlew koverMergedReport $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+      - name: 📸️ Run screenshot tests (debug)
+        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+
+      - name: 📈 Generate kover report and verify coverage
+        run: ./gradlew koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
 
       - name: ✅ Upload kover report
         if: always()

--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -29,11 +29,8 @@ jobs:
       - name: ⚙️ Run unit tests, debug and release
         run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES
 
-      - name: 📸️ Run screenshot tests (debug)
-        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES
-
-      - name: 📈 Generate kover report and verify coverage
-        run: ./gradlew koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+      - name: 📈 Run screenshot tests, generate kover report and verify coverage
+        run: ./gradlew verifyPaparazziDebug koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
 
       - name: ✅ Upload kover report
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,14 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
 
-      - name: ⚙️ Run unit & screenshot tests, debug and release
+      - name: ⚙️ Run unit tests, debug and release
         run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
 
-      - name: ⚙️ Run unit & screenshot tests, generate kover report
-        run: ./gradlew koverMergedReport $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+      - name: 📸️ Run screenshot tests (debug)
+        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
 
-      - name: 📈 Verify coverage
-        run: ./gradlew koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+      - name: 📈 Generate kover report and verify coverage
+        run: ./gradlew koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
 
       - name: 🚫 Upload kover failed coverage reports
         if: failure()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,10 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
 
       - name: ⚙️ Run unit tests, debug and release
-        run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+        run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES
 
       - name: 📸️ Run screenshot tests (debug)
-        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES
 
       - name: 📈 Generate kover report and verify coverage
         run: ./gradlew koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,11 +40,8 @@ jobs:
       - name: ⚙️ Run unit tests, debug and release
         run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES
 
-      - name: 📸️ Run screenshot tests (debug)
-        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES
-
-      - name: 📈 Generate kover report and verify coverage
-        run: ./gradlew koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+      - name: 📈 Run screenshot tests, generate kover report and verify coverage
+        run: ./gradlew verifyPaparazziDebug koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
 
       - name: 🚫 Upload kover failed coverage reports
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -255,9 +255,11 @@ koverMerged {
                 excludes += "io.element.android.libraries.push.impl.notifications.NotificationState*"
                 excludes += "io.element.android.features.messages.impl.media.local.pdf.PdfViewerState"
                 excludes += "io.element.android.features.messages.impl.media.local.LocalMediaViewState"
-                excludes += "io.element.android.features.location.impl.map.MapState"
+                excludes += "io.element.android.features.location.impl.map.MapState*"
                 excludes += "io.element.android.libraries.matrix.api.timeline.item.event.LocalEventSendState*"
                 excludes += "io.element.android.libraries.designsystem.swipe.SwipeableActionsState*"
+                excludes += "io.element.android.features.messages.impl.timeline.components.ExpandableState*"
+                excludes += "io.element.android.features.messages.impl.timeline.model.bubble.BubbleState*"
             }
             bound {
                 minValue = 90

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,7 +139,6 @@ allprojects {
         val isScreenshotTest = project.gradle.startParameter.taskNames.any { it.contains("paparazzi", ignoreCase = true) }
         if (isScreenshotTest) {
             // Increase heap size for screenshot tests
-            println("Running screenshot tests!")
             maxHeapSize = "1g"
         } else {
             // Disable screenshot tests by default

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,16 @@ allprojects {
 allprojects {
     tasks.withType<Test> {
         maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+
+        val isScreenshotTest = project.gradle.startParameter.taskNames.any { it.contains("paparazzi", ignoreCase = true) }
+        if (isScreenshotTest) {
+            // Increase heap size for screenshot tests
+            println("Running screenshot tests!")
+            maxHeapSize = "1g"
+        } else {
+            // Disable screenshot tests by default
+            exclude("**/ScreenshotTest*")
+        }
     }
 }
 


### PR DESCRIPTION
This PR separates the test CI jobs in:

- `gradle test` for debug and release modes (we were missing release mode here).
- `gradle verifyPaparazziDebug koverMergedReport koverMergedVerify` to run the screenshot tests, get coverage and verify %s (verifyPaparazziDebug and kover tasks need to run in the same gradle command to pass the coverage info).

It should decrease test times, since we avoid running the screenshot tests 3 times (twice for `test`, once for `verifyPaparazziDebug`) when we need them just once.