### PR TITLE
Extract MessageComposerContext class from MessageComposerPresenter

### DIFF
--- a/features/messages/api/src/main/kotlin/io/element/android/features/messages/api/MessageComposerContext.kt
+++ b/features/messages/api/src/main/kotlin/io/element/android/features/messages/api/MessageComposerContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-plugins {
-    id("io.element.android-library")
-}
+package io.element.android.features.messages.api
 
-android {
-    namespace = "io.element.android.features.messages.api"
-}
+import io.element.android.libraries.textcomposer.MessageComposerMode
 
-dependencies {
-    implementation(projects.libraries.architecture)
-    implementation(projects.libraries.matrix.api)
-    api(projects.libraries.textcomposer)
+/**
+ * Hoist-able state of the message composer.
+ *
+ * Typical use case is inside other presenters, to know if
+ * the composer is in a thread, if it's editing a message, etc.
+ */
+interface MessageComposerContext {
+    val composerMode: MessageComposerMode
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerContextImpl.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerContextImpl.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.messagecomposer
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.features.messages.api.MessageComposerContext
+import io.element.android.libraries.di.RoomScope
+import io.element.android.libraries.di.SingleIn
+import io.element.android.libraries.textcomposer.MessageComposerMode
+import javax.inject.Inject
+
+@SingleIn(RoomScope::class)
+@ContributesBinding(RoomScope::class)
+class MessageComposerContextImpl @Inject constructor() : MessageComposerContext {
+    override var composerMode: MessageComposerMode by mutableStateOf(MessageComposerMode.Normal(""))
+        internal set
+}

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
@@ -31,6 +31,7 @@ import io.element.android.features.messages.impl.MessagesPresenter
 import io.element.android.features.messages.impl.actionlist.ActionListPresenter
 import io.element.android.features.messages.impl.actionlist.ActionListState
 import io.element.android.features.messages.impl.actionlist.model.TimelineItemAction
+import io.element.android.features.messages.impl.messagecomposer.MessageComposerContextImpl
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerEvents
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerPresenter
 import io.element.android.features.messages.impl.timeline.TimelinePresenter
@@ -568,6 +569,7 @@ class MessagesPresenterTest {
             mediaSender = MediaSender(FakeMediaPreProcessor(), matrixRoom),
             snackbarDispatcher = SnackbarDispatcher(),
             analyticsService = FakeAnalyticsService(),
+            messageComposerContext = MessageComposerContextImpl(),
         )
         val timelinePresenter = TimelinePresenter(
             timelineItemsFactory = aTimelineItemsFactory(),

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/textcomposer/MessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/textcomposer/MessageComposerPresenterTest.kt
@@ -26,6 +26,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.analytics.test.FakeAnalyticsService
 import io.element.android.features.messages.impl.messagecomposer.AttachmentsState
+import io.element.android.features.messages.impl.messagecomposer.MessageComposerContextImpl
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerEvents
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerPresenter
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerState
@@ -503,7 +504,8 @@ class MessageComposerPresenterTest {
         localMediaFactory,
         MediaSender(mediaPreProcessor, room),
         snackbarDispatcher,
-        FakeAnalyticsService()
+        FakeAnalyticsService(),
+        MessageComposerContextImpl(),
     )
 }
 

--- a/features/messages/test/build.gradle.kts
+++ b/features/messages/test/build.gradle.kts
@@ -19,11 +19,9 @@ plugins {
 }
 
 android {
-    namespace = "io.element.android.features.messages.api"
+    namespace = "io.element.android.features.messages.test"
 }
 
 dependencies {
-    implementation(projects.libraries.architecture)
-    implementation(projects.libraries.matrix.api)
-    api(projects.libraries.textcomposer)
+    api(projects.features.messages.api)
 }

--- a/features/messages/test/src/main/kotlin/io/element/android/features/messages/test/MessageComposerContextFake.kt
+++ b/features/messages/test/src/main/kotlin/io/element/android/features/messages/test/MessageComposerContextFake.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-plugins {
-    id("io.element.android-library")
-}
+package io.element.android.features.messages.test
 
-android {
-    namespace = "io.element.android.features.messages.api"
-}
+import io.element.android.features.messages.api.MessageComposerContext
+import io.element.android.libraries.textcomposer.MessageComposerMode
 
-dependencies {
-    implementation(projects.libraries.architecture)
-    implementation(projects.libraries.matrix.api)
-    api(projects.libraries.textcomposer)
-}
+class MessageComposerContextFake(
+    override var composerMode: MessageComposerMode = MessageComposerMode.Normal(null)
+) : MessageComposerContext

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ sqldelight = "1.5.5"
 telephoto = "0.4.0"
 
 # DI
-dagger = "2.46.1"
+dagger = "2.47"
 anvil = "2.4.6"
 
 # Auto service

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ sqldelight = "1.5.5"
 telephoto = "0.4.0"
 
 # DI
-dagger = "2.47"
+dagger = "2.46.1"
 anvil = "2.4.6"
 
 # Auto service

--- a/libraries/textcomposer/src/main/kotlin/io/element/android/libraries/textcomposer/MessageComposerMode.kt
+++ b/libraries/textcomposer/src/main/kotlin/io/element/android/libraries/textcomposer/MessageComposerMode.kt
@@ -51,4 +51,13 @@ sealed interface MessageComposerMode : Parcelable {
             is Quote -> eventId
             is Reply -> eventId
         }
+
+    val isEditing: Boolean
+        get() = this is Edit
+
+    val isReply: Boolean
+        get() = this is Reply
+
+    val inThread: Boolean
+        get() = false // TODO
 }


### PR DESCRIPTION
When sending "Composer" analytics from screens other than the composer's (e.g. send location from map) we need to know the composer's mode in order to properly fill the analytics event. `MessageComposerContext` hoists this state so that other presenters can also read it.

Related to:
https://github.com/vector-im/element-meta/issues/1674
https://github.com/vector-im/element-meta/issues/1682