### PR TITLE
Disable Paparazzi tasks when Kover is running.

### DIFF
--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -29,8 +29,11 @@ jobs:
       - name: ⚙️ Run unit tests, debug and release
         run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES
 
-      - name: 📈 Run screenshot tests, generate kover report and verify coverage
-        run: ./gradlew verifyPaparazziDebug koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+      - name: 📸 Run screenshot tests
+        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES
+
+      - name: 📈 Generate kover report and verify coverage
+        run: ./gradlew koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
 
       - name: ✅ Upload kover report
         if: always()

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -51,6 +51,12 @@ jobs:
           name: linting-report
           path: |
             */build/reports/**/*.*
+      - name: 🔊 Publish results to Sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          ORG_GRADLE_PROJECT_SONAR_LOGIN: ${{ secrets.SONAR_TOKEN }}
+        if: ${{ always() && env.SONAR_TOKEN != '' && env.ORG_GRADLE_PROJECT_SONAR_LOGIN != '' }}
+        run: ./gradlew sonar $CI_GRADLE_ARG_PROPERTIES
       - name: Prepare Danger
         if: always()
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,13 +83,6 @@ jobs:
             **/out/failures/
             **/build/reports/tests/*UnitTest/
 
-      - name: 🔊 Publish results to Sonar
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          ORG_GRADLE_PROJECT_SONAR_LOGIN: ${{ secrets.SONAR_TOKEN }}
-        if: ${{ always() && env.SONAR_TOKEN != '' && env.ORG_GRADLE_PROJECT_SONAR_LOGIN != '' }}
-        run: ./gradlew sonar $CI_GRADLE_ARG_PROPERTIES
-
       # https://github.com/codecov/codecov-action
       - name: ☂️ Upload coverage reports to codecov
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,11 @@ jobs:
       - name: ⚙️ Run unit tests, debug and release
         run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES
 
-      - name: 📈 Run screenshot tests, generate kover report and verify coverage
-        run: ./gradlew verifyPaparazziDebug koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
+      - name: 📸 Run screenshot tests
+        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES
+
+      - name: 📈Generate kover report and verify coverage
+        run: ./gradlew koverMergedReport koverMergedVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true
 
       - name: 🚫 Upload kover failed coverage reports
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -283,13 +283,6 @@ koverMerged {
     }
 }
 
-// Make Kover depend on Paparazzi
-tasks.whenTaskAdded {
-    if (name.startsWith("koverMerged")) {
-        dependsOn(":tests:uitests:verifyPaparazziDebug")
-    }
-}
-
 // When running on the CI, run only debug test variants
 val ciBuildProperty = "ci-build"
 val isCiBuild = if (project.hasProperty(ciBuildProperty)) {

--- a/tests/uitests/build.gradle.kts
+++ b/tests/uitests/build.gradle.kts
@@ -17,6 +17,8 @@
 import extension.allFeaturesImpl
 import extension.allLibrariesImpl
 import extension.allServicesImpl
+import kotlinx.kover.tasks.KoverReportTask
+import org.gradle.api.internal.provider.DefaultProvider
 
 plugins {
     id("io.element.android-compose-library")
@@ -26,6 +28,16 @@ plugins {
 
 android {
     namespace = "io.element.android.tests.uitests"
+}
+
+// Workaround: `kover` tasks somehow trigger the screenshot tests with a broken configuration, removing
+// any previous test results and not creating new ones. This is a workaround to disable the screenshot tests
+// when the `kover` tasks are detected.
+tasks.withType<Test>() {
+    if (project.gradle.startParameter.taskNames.any { it.contains("kover", ignoreCase = true) }) {
+        println("WARNING: Kover task detected, disabling screenshot test task $name.")
+        isEnabled = false
+    }
 }
 
 dependencies {

--- a/tests/uitests/build.gradle.kts
+++ b/tests/uitests/build.gradle.kts
@@ -17,8 +17,6 @@
 import extension.allFeaturesImpl
 import extension.allLibrariesImpl
 import extension.allServicesImpl
-import kotlinx.kover.tasks.KoverReportTask
-import org.gradle.api.internal.provider.DefaultProvider
 
 plugins {
     id("io.element.android-compose-library")


### PR DESCRIPTION
It allows us to split the test jobs between unit tests, screenshot test and coverage reports.

I moved the `sonar` job to the quality workflow, as it seems more related to quality than tests, and we're not collecting coverage from the tests anyway, but maybe it should have its own workflow?