### PR TITLE
React to session deletion (from another session)

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -61,6 +61,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.matrix.rustcomponents.sdk.Client
@@ -70,6 +71,7 @@ import org.matrix.rustcomponents.sdk.RoomListItem
 import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 import org.matrix.rustcomponents.sdk.CreateRoomParameters as RustCreateRoomParameters
 import org.matrix.rustcomponents.sdk.RoomPreset as RustRoomPreset
 import org.matrix.rustcomponents.sdk.RoomVisibility as RustRoomVisibility
@@ -78,7 +80,7 @@ import org.matrix.rustcomponents.sdk.RoomVisibility as RustRoomVisibility
 class RustMatrixClient constructor(
     private val client: Client,
     private val sessionStore: SessionStore,
-    appCoroutineScope: CoroutineScope,
+    private val appCoroutineScope: CoroutineScope,
     private val dispatchers: CoroutineDispatchers,
     private val baseDirectory: File,
     baseCacheDirectory: File,
@@ -104,10 +106,20 @@ class RustMatrixClient constructor(
 
     private val notificationService = RustNotificationService(notificationClient)
 
+    private val isLoggingOut = AtomicBoolean(false)
+
     private val clientDelegate = object : ClientDelegate {
         override fun didReceiveAuthError(isSoftLogout: Boolean) {
-            //TODO handle this
-            Timber.v("didReceiveAuthError(isSoftLogout=$isSoftLogout)")
+            Timber.w("didReceiveAuthError(isSoftLogout=$isSoftLogout)")
+            if (isLoggingOut.getAndSet(true).not()) {
+                Timber.v("didReceiveAuthError -> do the cleanup")
+                //TODO handle isSoftLogout parameter.
+                appCoroutineScope.launch {
+                    doLogout(doRequest = false)
+                }
+            } else {
+                Timber.v("didReceiveAuthError -> already cleaning up")
+            }
         }
     }
 
@@ -275,11 +287,15 @@ class RustMatrixClient constructor(
         baseDirectory.deleteSessionDirectory(userID = sessionId.value, deleteCryptoDb = false)
     }
 
-    override suspend fun logout() = withContext(sessionDispatcher) {
-        try {
-            client.logout()
-        } catch (failure: Throwable) {
-            Timber.e(failure, "Fail to call logout on HS. Still delete local files.")
+    override suspend fun logout() = doLogout(doRequest = true)
+
+    private suspend fun doLogout(doRequest: Boolean) = withContext(sessionDispatcher) {
+        if (doRequest) {
+            try {
+                client.logout()
+            } catch (failure: Throwable) {
+                Timber.e(failure, "Fail to call logout on HS. Still delete local files.")
+            }
         }
         close()
         baseDirectory.deleteSessionDirectory(userID = sessionId.value, deleteCryptoDb = true)


### PR DESCRIPTION
This is a quick implementation to react on session deleted on server (for instance using another session).

Design may be added later to explain why the session has been destroyed.

FTR we have this design (more or less :) ) on Element Android right now:

|Logout|Soft Logout|
|-|-|
|<img width="293" alt="image" src="https://github.com/vector-im/element-x-android/assets/3940906/bb7b2adb-6782-44dd-8783-bc72214fad47">|<img width="278" alt="image" src="https://github.com/vector-im/element-x-android/assets/3940906/dfcedff2-8008-4af6-bc5c-994918c24088">|

Also we may want to take the isSoftLogout parameter later (design also needed here).

Limited by https://github.com/matrix-org/sliding-sync/issues/212, i.e. the app will react only when user do a request that is not a sliding sync request, like loading an avatar, etc. After a cold start, the room list is not loaded, so the only way to have the logout is to try to create a room. Also, user can still logout manually.

Closes #889 