### PR TITLE
Correct location event body

### DIFF
--- a/features/location/impl/build.gradle.kts
+++ b/features/location/impl/build.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     implementation(projects.libraries.uiStrings)
     implementation(libs.dagger)
     implementation(projects.anvilannotations)
-    implementation(projects.services.toolbox.api)
     anvil(projects.anvilcodegen)
     ksp(libs.showkase.processor)
 

--- a/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/send/SendLocationPresenter.kt
+++ b/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/send/SendLocationPresenter.kt
@@ -36,12 +36,7 @@ import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.location.AssetType
 import io.element.android.services.analytics.api.AnalyticsService
-import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.launch
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 class SendLocationPresenter @Inject constructor(
@@ -50,7 +45,6 @@ class SendLocationPresenter @Inject constructor(
     private val analyticsService: AnalyticsService,
     private val messageComposerContext: MessageComposerContext,
     private val locationActions: LocationActions,
-    private val systemClock: SystemClock,
     private val buildMeta: BuildMeta,
 ) : Presenter<SendLocationState> {
 
@@ -115,7 +109,7 @@ class SendLocationPresenter @Inject constructor(
             SendLocationState.Mode.PinLocation -> {
                 val geoUri = event.cameraPosition.toGeoUri()
                 room.sendLocation(
-                    body = generateBody(geoUri, systemClock.epochMillis()),
+                    body = generateBody(geoUri),
                     geoUri = geoUri,
                     description = null,
                     zoomLevel = MapDefaults.DEFAULT_ZOOM.toInt(),
@@ -134,7 +128,7 @@ class SendLocationPresenter @Inject constructor(
             SendLocationState.Mode.SenderLocation -> {
                 val geoUri = event.toGeoUri()
                 room.sendLocation(
-                    body = generateBody(geoUri, systemClock.epochMillis()),
+                    body = generateBody(geoUri),
                     geoUri = geoUri,
                     description = null,
                     zoomLevel = MapDefaults.DEFAULT_ZOOM.toInt(),
@@ -158,7 +152,4 @@ private fun SendLocationEvents.SendLocation.toGeoUri(): String = location?.toGeo
 
 private fun SendLocationEvents.SendLocation.CameraPosition.toGeoUri(): String = "geo:$lat,$lon"
 
-private fun generateBody(uri: String, epochMillis: Long): String {
-    val timestamp = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT)
-    return "Location was shared at $uri as of $timestamp"
-}
+private fun generateBody(uri: String): String = "Location was shared at $uri"

--- a/features/location/impl/src/test/kotlin/io/element/android/features/location/impl/send/SendLocationPresenterTest.kt
+++ b/features/location/impl/src/test/kotlin/io/element/android/features/location/impl/send/SendLocationPresenterTest.kt
@@ -34,7 +34,6 @@ import io.element.android.libraries.matrix.test.core.aBuildMeta
 import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
 import io.element.android.libraries.matrix.test.room.SendLocationInvocation
 import io.element.android.libraries.textcomposer.MessageComposerMode
-import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -46,7 +45,6 @@ class SendLocationPresenterTest {
     private val fakeAnalyticsService = FakeAnalyticsService()
     private val messageComposerContextFake = MessageComposerContextFake()
     private val fakeLocationActions = FakeLocationActions()
-    private val fakeSystemClock = SystemClock { 0L }
     private val fakeBuildMeta = aBuildMeta(applicationName = "app name")
     private val sendLocationPresenter: SendLocationPresenter = SendLocationPresenter(
         permissionsPresenterFactory = object : PermissionsPresenter.Factory {
@@ -56,7 +54,6 @@ class SendLocationPresenterTest {
         analyticsService = fakeAnalyticsService,
         messageComposerContext = messageComposerContextFake,
         locationActions = fakeLocationActions,
-        systemClock = fakeSystemClock,
         buildMeta = fakeBuildMeta,
     )
 
@@ -292,7 +289,7 @@ class SendLocationPresenterTest {
             Truth.assertThat(fakeMatrixRoom.sentLocations.size).isEqualTo(1)
             Truth.assertThat(fakeMatrixRoom.sentLocations.last()).isEqualTo(
                 SendLocationInvocation(
-                    body = "Location was shared at geo:3.0,4.0;u=5.0 as of 1970-01-01T00:00:00Z",
+                    body = "Location was shared at geo:3.0,4.0;u=5.0",
                     geoUri = "geo:3.0,4.0;u=5.0",
                     description = null,
                     zoomLevel = 15,
@@ -349,7 +346,7 @@ class SendLocationPresenterTest {
             Truth.assertThat(fakeMatrixRoom.sentLocations.size).isEqualTo(1)
             Truth.assertThat(fakeMatrixRoom.sentLocations.last()).isEqualTo(
                 SendLocationInvocation(
-                    body = "Location was shared at geo:0.0,1.0 as of 1970-01-01T00:00:00Z",
+                    body = "Location was shared at geo:0.0,1.0",
                     geoUri = "geo:0.0,1.0",
                     description = null,
                     zoomLevel = 15,


### PR DESCRIPTION
- Now sending the correct body format as agreed with design. This won't be show in EX clients though.

Related to:
- https://github.com/vector-im/element-meta/issues/1682