### PR TITLE
Sentry

### DIFF
--- a/.idea/dictionaries/shared.xml
+++ b/.idea/dictionaries/shared.xml
@@ -8,6 +8,7 @@
             <w>measurables</w>
             <w>onboarding</w>
             <w>placeables</w>
+            <w>posthog</w>
             <w>showkase</w>
             <w>snackbar</w>
             <w>swipeable</w>

--- a/features/analytics/test/src/main/kotlin/io/element/android/features/analytics/test/FakeAnalyticsService.kt
+++ b/features/analytics/test/src/main/kotlin/io/element/android/features/analytics/test/FakeAnalyticsService.kt
@@ -33,7 +33,7 @@ class FakeAnalyticsService(
     private val didAskUserConsentFlow = MutableStateFlow(didAskUserConsent)
     val capturedEvents = mutableListOf<VectorAnalyticsEvent>()
 
-    override fun getAvailableAnalyticsProviders(): List<AnalyticsProvider> = emptyList()
+    override fun getAvailableAnalyticsProviders(): Set<AnalyticsProvider> = emptySet()
 
     override fun getUserConsent(): Flow<Boolean> = isEnabledFlow
 

--- a/features/preferences/impl/build.gradle.kts
+++ b/features/preferences/impl/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(projects.features.ftue.api)
     implementation(projects.libraries.matrixui)
     implementation(projects.features.logout.api)
+    implementation(projects.services.analytics.api)
     implementation(projects.services.toolbox.api)
     implementation(libs.datetime)
     implementation(libs.accompanist.placeholder)

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
@@ -58,7 +58,7 @@ fun DeveloperSettingsView(
         )
         PreferenceCategory(title = "Crash", showDivider = false) {
             PreferenceText(
-                title = "Crash the app 💥!,",
+                title = "Crash the app 💥",
                 onClick = { error("This crash is a test.") }
             )
         }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
@@ -56,6 +56,12 @@ fun DeveloperSettingsView(
         RageshakePreferencesView(
             state = state.rageshakeState,
         )
+        PreferenceCategory(title = "Crash", showDivider = false) {
+            PreferenceText(
+                title = "Crash the app 💥!,",
+                onClick = { error("This crash is a test.") }
+            )
+        }
         val cache = state.cacheSize
         PreferenceCategory(title = "Cache", showDivider = false) {
             PreferenceText(

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
@@ -35,6 +35,7 @@ import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.api.user.getCurrentUser
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
 import io.element.android.libraries.matrix.api.verification.SessionVerifiedStatus
+import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -43,6 +44,7 @@ class PreferencesRootPresenter @Inject constructor(
     private val logoutPresenter: LogoutPreferencePresenter,
     private val matrixClient: MatrixClient,
     private val sessionVerificationService: SessionVerificationService,
+    private val analyticsService: AnalyticsService,
     private val buildType: BuildType,
     private val versionFormatter: VersionFormatter,
     private val snackbarDispatcher: SnackbarDispatcher,
@@ -58,6 +60,7 @@ class PreferencesRootPresenter @Inject constructor(
         }
 
         val snackbarMessage by snackbarDispatcher.collectSnackbarMessageAsState()
+        val hasAnalyticsProviders = remember { analyticsService.getAvailableAnalyticsProviders().isNotEmpty() }
 
         // Session verification status (unknown, not verified, verified)
         val sessionVerifiedStatus by sessionVerificationService.sessionVerifiedStatus.collectAsState()
@@ -72,6 +75,7 @@ class PreferencesRootPresenter @Inject constructor(
             myUser = matrixUser.value,
             version = versionFormatter.get(),
             showCompleteVerification = sessionIsNotVerified,
+            showAnalyticsSettings = hasAnalyticsProviders,
             showDeveloperSettings = showDeveloperSettings,
             snackbarMessage = snackbarMessage,
         )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootState.kt
@@ -25,6 +25,7 @@ data class PreferencesRootState(
     val myUser: MatrixUser?,
     val version: String,
     val showCompleteVerification: Boolean,
+    val showAnalyticsSettings: Boolean,
     val showDeveloperSettings: Boolean,
     val snackbarMessage: SnackbarMessage?,
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootStateProvider.kt
@@ -25,6 +25,7 @@ fun aPreferencesRootState() = PreferencesRootState(
     myUser = null,
     version = "Version 1.1 (1)",
     showCompleteVerification = true,
+    showAnalyticsSettings = true,
     showDeveloperSettings = true,
     snackbarMessage = SnackbarMessage(CommonStrings.common_verification_complete),
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootView.kt
@@ -82,11 +82,13 @@ fun PreferencesRootView(
             )
             Divider()
         }
-        PreferenceText(
-            title = stringResource(id = CommonStrings.common_analytics),
-            icon = Icons.Outlined.InsertChart,
-            onClick = onOpenAnalytics,
-        )
+        if (state.showAnalyticsSettings) {
+            PreferenceText(
+                title = stringResource(id = CommonStrings.common_analytics),
+                icon = Icons.Outlined.InsertChart,
+                onClick = onOpenAnalytics,
+            )
+        }
         PreferenceText(
             title = stringResource(id = CommonStrings.action_report_bug),
             icon = Icons.Outlined.BugReport,

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenterTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenterTest.kt
@@ -20,6 +20,7 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import io.element.android.features.analytics.test.FakeAnalyticsService
 import io.element.android.features.logout.impl.DefaultLogoutPreferencePresenter
 import io.element.android.libraries.architecture.Async
 import io.element.android.libraries.core.meta.BuildType
@@ -41,6 +42,7 @@ class PreferencesRootPresenterTest {
             logoutPresenter,
             matrixClient,
             FakeSessionVerificationService(),
+            FakeAnalyticsService(),
             BuildType.DEBUG,
             FakeVersionFormatter(),
             SnackbarDispatcher(),
@@ -61,6 +63,7 @@ class PreferencesRootPresenterTest {
                 )
             )
             assertThat(loadedState.showDeveloperSettings).isEqualTo(true)
+            assertThat(loadedState.showAnalyticsSettings).isEqualTo(false)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -163,7 +163,7 @@ maplibre_annotation = "org.maplibre.gl:android-plugin-annotation-v9:2.0.0"
 
 # Analytics
 posthog = "com.posthog.android:posthog:2.0.3"
-sentry_android = "io.sentry:sentry-android:6.26.0"
+sentry = "io.sentry:sentry-android:6.26.0"
 matrix_analytics_events = "com.github.matrix-org:matrix-analytics-events:42b2faa417c1e95f430bf8f6e379adba25ad5ef8"
 
 # Di

--- a/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
+++ b/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
@@ -103,6 +103,8 @@ fun DependencyHandlerScope.allLibrariesImpl() {
 }
 
 fun DependencyHandlerScope.allServicesImpl() {
+    // For analytics configuration, either use noop, or use the impl, with at least one analyticsproviders implementation
+    // implementation(project(":services:analytics:noop"))
     implementation(project(":services:analytics:impl"))
     implementation(project(":services:analyticsproviders:posthog"))
     implementation(project(":services:apperror:impl"))

--- a/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
+++ b/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
@@ -107,6 +107,8 @@ fun DependencyHandlerScope.allServicesImpl() {
     // implementation(project(":services:analytics:noop"))
     implementation(project(":services:analytics:impl"))
     implementation(project(":services:analyticsproviders:posthog"))
+    implementation(project(":services:analyticsproviders:sentry"))
+
     implementation(project(":services:apperror:impl"))
     implementation(project(":services:appnavstate:impl"))
     implementation(project(":services:toolbox:impl"))

--- a/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/AnalyticsService.kt
+++ b/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/AnalyticsService.kt
@@ -22,7 +22,10 @@ import io.element.android.services.analyticsproviders.api.trackers.ErrorTracker
 import kotlinx.coroutines.flow.Flow
 
 interface AnalyticsService: AnalyticsTracker, ErrorTracker {
-    fun getAvailableAnalyticsProviders(): List<AnalyticsProvider>
+    /**
+     * Get the available analytics providers.
+     */
+    fun getAvailableAnalyticsProviders(): Set<AnalyticsProvider>
 
     /**
      * Return a Flow of Boolean, true if the user has given their consent.

--- a/services/analytics/impl/src/main/kotlin/io/element/android/services/analytics/impl/DefaultAnalyticsService.kt
+++ b/services/analytics/impl/src/main/kotlin/io/element/android/services/analytics/impl/DefaultAnalyticsService.kt
@@ -56,8 +56,8 @@ class DefaultAnalyticsService @Inject constructor(
         observeSessions()
     }
 
-    override fun getAvailableAnalyticsProviders(): List<AnalyticsProvider> {
-        return analyticsProviders.sortedBy { it.index }
+    override fun getAvailableAnalyticsProviders(): Set<AnalyticsProvider> {
+        return analyticsProviders
     }
 
     override fun getUserConsent(): Flow<Boolean> {

--- a/services/analytics/noop/build.gradle.kts
+++ b/services/analytics/noop/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 }
 
 android {
-    namespace = "io.element.android.services.analytics.impl"
+    namespace = "io.element.android.services.analytics.noop"
 }
 
 anvil {
@@ -28,6 +28,7 @@ anvil {
 
 dependencies {
     implementation(libs.dagger)
+    implementation(projects.libraries.architecture)
     implementation(projects.libraries.di)
     api(projects.services.analytics.api)
 }

--- a/services/analytics/noop/src/main/kotlin/io/element/android/services/analytics/noop/NoopAnalyticsService.kt
+++ b/services/analytics/noop/src/main/kotlin/io/element/android/services/analytics/noop/NoopAnalyticsService.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.services.analytics.noop
+
+import com.squareup.anvil.annotations.ContributesBinding
+import im.vector.app.features.analytics.itf.VectorAnalyticsEvent
+import im.vector.app.features.analytics.itf.VectorAnalyticsScreen
+import im.vector.app.features.analytics.plan.UserProperties
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.di.SingleIn
+import io.element.android.services.analytics.api.AnalyticsService
+import io.element.android.services.analyticsproviders.api.AnalyticsProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class NoopAnalyticsService @Inject constructor(
+) : AnalyticsService {
+    override fun getAvailableAnalyticsProviders(): Set<AnalyticsProvider> = emptySet()
+    override fun getUserConsent(): Flow<Boolean> = flowOf(false)
+    override suspend fun setUserConsent(userConsent: Boolean) = Unit
+    override fun didAskUserConsent(): Flow<Boolean> = flowOf(true)
+    override suspend fun setDidAskUserConsent() = Unit
+    override fun getAnalyticsId(): Flow<String> = flowOf("")
+    override suspend fun setAnalyticsId(analyticsId: String) = Unit
+    override suspend fun onSignOut() = Unit
+    override suspend fun reset() = Unit
+    override fun capture(event: VectorAnalyticsEvent) = Unit
+    override fun screen(screen: VectorAnalyticsScreen) = Unit
+    override fun updateUserProperties(userProperties: UserProperties) = Unit
+    override fun trackError(throwable: Throwable) = Unit
+}

--- a/services/analyticsproviders/api/src/main/kotlin/io/element/android/services/analyticsproviders/api/AnalyticsProvider.kt
+++ b/services/analyticsproviders/api/src/main/kotlin/io/element/android/services/analyticsproviders/api/AnalyticsProvider.kt
@@ -21,11 +21,6 @@ import io.element.android.services.analyticsproviders.api.trackers.ErrorTracker
 
 interface AnalyticsProvider: AnalyticsTracker, ErrorTracker {
     /**
-     * Allow to sort providers, from lower index to higher index.
-     */
-    val index: Int
-
-    /**
      * User friendly name.
      */
     val name: String

--- a/services/analyticsproviders/posthog/src/main/kotlin/io/element/android/services/analyticsproviders/posthog/PosthogAnalyticsProvider.kt
+++ b/services/analyticsproviders/posthog/src/main/kotlin/io/element/android/services/analyticsproviders/posthog/PosthogAnalyticsProvider.kt
@@ -35,7 +35,6 @@ import javax.inject.Inject
 class PosthogAnalyticsProvider @Inject constructor(
     private val postHogFactory: PostHogFactory,
 ) : AnalyticsProvider {
-    override val index = PosthogConfig.index
     override val name = PosthogConfig.name
 
     private var posthog: PostHog? = null

--- a/services/analyticsproviders/posthog/src/main/kotlin/io/element/android/services/analyticsproviders/posthog/PosthogConfig.kt
+++ b/services/analyticsproviders/posthog/src/main/kotlin/io/element/android/services/analyticsproviders/posthog/PosthogConfig.kt
@@ -17,7 +17,6 @@
 package io.element.android.services.analyticsproviders.posthog
 
 object PosthogConfig {
-    const val index = 0
     const val name = "Posthog"
     const val postHogHost = "https://posthog.element.dev"
     const val postHogApiKey = "phc_VtA1L35nw3aeAtHIx1ayrGdzGkss7k1xINeXcoIQzXN"

--- a/services/analyticsproviders/posthog/src/main/kotlin/io/element/android/services/analyticsproviders/posthog/log/AnalyticsLoggerTag.kt
+++ b/services/analyticsproviders/posthog/src/main/kotlin/io/element/android/services/analyticsproviders/posthog/log/AnalyticsLoggerTag.kt
@@ -18,4 +18,4 @@ package io.element.android.services.analyticsproviders.posthog.log
 
 import io.element.android.libraries.core.log.logger.LoggerTag
 
-val analyticsTag = LoggerTag("Analytics")
+internal val analyticsTag = LoggerTag("Posthog")

--- a/services/analyticsproviders/sentry/build.gradle.kts
+++ b/services/analyticsproviders/sentry/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id("io.element.android-library")
+    alias(libs.plugins.anvil)
+}
+
+android {
+    namespace = "io.element.android.services.analyticsproviders.sentry"
+}
+
+anvil {
+    generateDaggerFactories.set(true)
+}
+
+dependencies {
+    implementation(libs.dagger)
+    implementation(libs.sentry)
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.di)
+    implementation(projects.services.analyticsproviders.api)
+}

--- a/services/analyticsproviders/sentry/src/main/AndroidManifest.xml
+++ b/services/analyticsproviders/sentry/src/main/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2023 New Vector Ltd
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <!-- Sentry auto-initialization disabled -->
+        <meta-data
+            android:name="io.sentry.auto-init"
+            android:value="false" />
+    </application>
+
+</manifest>

--- a/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryAnalyticsProvider.kt
+++ b/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryAnalyticsProvider.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.services.analyticsproviders.sentry
+
+import android.content.Context
+import com.squareup.anvil.annotations.ContributesMultibinding
+import im.vector.app.features.analytics.itf.VectorAnalyticsEvent
+import im.vector.app.features.analytics.itf.VectorAnalyticsScreen
+import im.vector.app.features.analytics.plan.UserProperties
+import io.element.android.libraries.core.meta.BuildMeta
+import io.element.android.libraries.core.meta.BuildType
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.di.ApplicationContext
+import io.element.android.services.analyticsproviders.api.AnalyticsProvider
+import io.element.android.services.analyticsproviders.sentry.log.analyticsTag
+import io.sentry.Sentry
+import io.sentry.SentryOptions
+import io.sentry.android.core.SentryAndroid
+import timber.log.Timber
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class SentryAnalyticsProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val buildMeta: BuildMeta,
+) : AnalyticsProvider {
+    override val name = SentryConfig.name
+
+    override fun init() {
+        Timber.tag(analyticsTag.value).d("Initializing Sentry")
+        if (Sentry.isEnabled()) return
+        SentryAndroid.init(context) { options ->
+            options.dsn = SentryConfig.dns
+            options.beforeSend = SentryOptions.BeforeSendCallback { event, _ -> event }
+            options.tracesSampleRate = 1.0
+            options.isEnableUserInteractionTracing = true
+            options.environment = buildMeta.buildType.toSentryEnv()
+            options.diagnosticLevel
+        }
+    }
+
+    override fun stop() {
+        Timber.tag(analyticsTag.value).d("Stopping Sentry")
+        Sentry.close()
+    }
+
+    override fun capture(event: VectorAnalyticsEvent) {
+    }
+
+    override fun screen(screen: VectorAnalyticsScreen) {
+    }
+
+    override fun updateUserProperties(userProperties: UserProperties) {
+    }
+
+    override fun trackError(throwable: Throwable) {
+        Sentry.captureException(throwable)
+    }
+}
+
+private fun BuildType.toSentryEnv() = when (this) {
+    BuildType.RELEASE -> SentryConfig.envRelease
+    BuildType.NIGHTLY,
+    BuildType.DEBUG -> SentryConfig.envDebug
+}

--- a/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryConfig.kt
+++ b/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryConfig.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.services.analyticsproviders.sentry
+
+object SentryConfig {
+    const val name = "Sentry"
+    const val dns = "https://f6acc9cfc2024641b28c87ad95e73e66@sentry.tools.element.io/49"
+    const val envDebug = "DEBUG"
+    const val envRelease = "RELEASE"
+}

--- a/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryConfig.kt
+++ b/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryConfig.kt
@@ -18,7 +18,7 @@ package io.element.android.services.analyticsproviders.sentry
 
 object SentryConfig {
     const val name = "Sentry"
-    const val dns = "https://f6acc9cfc2024641b28c87ad95e73e66@sentry.tools.element.io/49"
+    const val dns = "https://32f7ff6a6e724f90838b7654042b2e81@sentry.tools.element.io/59"
     const val envDebug = "DEBUG"
     const val envRelease = "RELEASE"
 }

--- a/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/log/AnalyticsLoggerTag.kt
+++ b/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/log/AnalyticsLoggerTag.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.services.analyticsproviders.sentry.log
+
+import io.element.android.libraries.core.log.logger.LoggerTag
+
+internal val analyticsTag = LoggerTag("Sentry")

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.preferences.impl.developer_null_DefaultGroup_DeveloperSettingsViewDarkPreview_0_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.preferences.impl.developer_null_DefaultGroup_DeveloperSettingsViewDarkPreview_0_null_0,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb77df9e072715ed947537e4474d504b5b5d533bfe9cd888362a421fea5b53b5
-size 44068
+oid sha256:6c0a16524e1017274eeb0f07a50a47c6351af9a901355b54cccbc9ec799e79f4
+size 45174

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.preferences.impl.developer_null_DefaultGroup_DeveloperSettingsViewDarkPreview_0_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.preferences.impl.developer_null_DefaultGroup_DeveloperSettingsViewDarkPreview_0_null_1,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb77df9e072715ed947537e4474d504b5b5d533bfe9cd888362a421fea5b53b5
-size 44068
+oid sha256:6c0a16524e1017274eeb0f07a50a47c6351af9a901355b54cccbc9ec799e79f4
+size 45174

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.preferences.impl.developer_null_DefaultGroup_DeveloperSettingsViewLightPreview_0_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.preferences.impl.developer_null_DefaultGroup_DeveloperSettingsViewLightPreview_0_null_0,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:004a25de04aac1ca9cbbad77581e0b52a6f8fba30aa2e64c03a791c54b297d5a
-size 48875
+oid sha256:abb7854a1e47764a907434cdf32e138b95c947bab682da485eea86f9726cf3b9
+size 49946

--- a/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.preferences.impl.developer_null_DefaultGroup_DeveloperSettingsViewLightPreview_0_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/io.element.android.tests.uitests_ScreenshotTest_preview_tests[io.element.android.features.preferences.impl.developer_null_DefaultGroup_DeveloperSettingsViewLightPreview_0_null_1,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:004a25de04aac1ca9cbbad77581e0b52a6f8fba30aa2e64c03a791c54b297d5a
-size 48875
+oid sha256:abb7854a1e47764a907434cdf32e138b95c947bab682da485eea86f9726cf3b9
+size 49946


### PR DESCRIPTION
Still waiting for sentry dns, but in the mean time this PR can be reviewed.

It also includes some fixes around analytics:
- be able (for fork) to fully disable analytics.
- cleanup of the code.
- add a "Crash me" item in the developer settings.

Screenshot recording on progress.

Closes #618 