### PR TITLE
Fix push store crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ captures/
 # IntelliJ
 *.iml
 .idea/.name
+.idea/androidTestResultsUserPreferences.xml
 .idea/assetWizardSettings.xml
 .idea/compiler.xml
 .idea/deploymentTargetDropDown.xml

--- a/features/analytics/impl/build.gradle.kts
+++ b/features/analytics/impl/build.gradle.kts
@@ -52,6 +52,4 @@ dependencies {
     testImplementation(projects.libraries.matrix.test)
     testImplementation(projects.features.analytics.test)
     testImplementation(projects.features.analytics.impl)
-
-    androidTestImplementation(libs.test.junitext)
 }

--- a/features/createroom/impl/build.gradle.kts
+++ b/features/createroom/impl/build.gradle.kts
@@ -66,7 +66,5 @@ dependencies {
     testImplementation(projects.libraries.mediaupload.test)
     testImplementation(projects.libraries.usersearch.test)
 
-    androidTestImplementation(libs.test.junitext)
-
     ksp(libs.showkase.processor)
 }

--- a/features/login/impl/build.gradle.kts
+++ b/features/login/impl/build.gradle.kts
@@ -61,6 +61,4 @@ dependencies {
     testImplementation(libs.test.turbine)
     testImplementation(projects.libraries.matrix.test)
     testImplementation(projects.tests.testutils)
-
-    androidTestImplementation(libs.test.junitext)
 }

--- a/features/logout/impl/build.gradle.kts
+++ b/features/logout/impl/build.gradle.kts
@@ -48,6 +48,4 @@ dependencies {
     testImplementation(libs.test.truth)
     testImplementation(libs.test.turbine)
     testImplementation(projects.libraries.matrix.test)
-
-    androidTestImplementation(libs.test.junitext)
 }

--- a/features/messages/impl/build.gradle.kts
+++ b/features/messages/impl/build.gradle.kts
@@ -78,6 +78,5 @@ dependencies {
     testImplementation(projects.libraries.mediapickers.test)
     testImplementation(libs.test.mockk)
 
-    androidTestImplementation(libs.test.junitext)
     ksp(libs.showkase.processor)
 }

--- a/features/onboarding/impl/build.gradle.kts
+++ b/features/onboarding/impl/build.gradle.kts
@@ -48,6 +48,4 @@ dependencies {
     testImplementation(libs.test.truth)
     testImplementation(libs.test.turbine)
     testImplementation(projects.libraries.matrix.test)
-
-    androidTestImplementation(libs.test.junitext)
 }

--- a/features/preferences/impl/build.gradle.kts
+++ b/features/preferences/impl/build.gradle.kts
@@ -68,6 +68,4 @@ dependencies {
     testImplementation(projects.features.analytics.test)
     testImplementation(projects.features.analytics.impl)
     testImplementation(projects.tests.testutils)
-
-    androidTestImplementation(libs.test.junitext)
 }

--- a/features/rageshake/impl/build.gradle.kts
+++ b/features/rageshake/impl/build.gradle.kts
@@ -56,6 +56,4 @@ dependencies {
     testImplementation(libs.test.mockk)
     testImplementation(projects.libraries.matrix.test)
     testImplementation(projects.features.rageshake.test)
-
-    androidTestImplementation(libs.test.junitext)
 }

--- a/features/roomlist/impl/build.gradle.kts
+++ b/features/roomlist/impl/build.gradle.kts
@@ -71,6 +71,4 @@ dependencies {
     testImplementation(projects.features.networkmonitor.test)
     testImplementation(projects.tests.testutils)
     testImplementation(projects.features.leaveroom.fake)
-
-    androidTestImplementation(libs.test.junitext)
 }

--- a/libraries/permissions/impl/build.gradle.kts
+++ b/libraries/permissions/impl/build.gradle.kts
@@ -57,7 +57,5 @@ dependencies {
     testImplementation(libs.test.turbine)
     testImplementation(projects.libraries.matrix.test)
 
-    androidTestImplementation(libs.test.junitext)
-
     ksp(libs.showkase.processor)
 }

--- a/libraries/pushstore/impl/build.gradle.kts
+++ b/libraries/pushstore/impl/build.gradle.kts
@@ -20,6 +20,11 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.push.pushstore.impl"
+
+    defaultConfig {
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    }
 }
 
 anvil {
@@ -43,4 +48,13 @@ dependencies {
     testImplementation(libs.coroutines.test)
     testImplementation(projects.libraries.matrix.test)
     testImplementation(projects.services.appnavstate.test)
+
+    androidTestImplementation(libs.coroutines.test)
+    androidTestImplementation(libs.test.core)
+    androidTestImplementation(libs.test.junit)
+    androidTestImplementation(libs.test.truth)
+    androidTestImplementation(libs.test.runner)
+    androidTestImplementation(projects.libraries.sessionStorage.test)
+
+    coreLibraryDesugaring(libs.android.desugar)
 }

--- a/libraries/pushstore/impl/src/androidTest/kotlin/io/element/android/libraries/pushstore/impl/DefaultUserPushStoreFactoryTest.kt
+++ b/libraries/pushstore/impl/src/androidTest/kotlin/io/element/android/libraries/pushstore/impl/DefaultUserPushStoreFactoryTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.pushstore.impl
+
+import androidx.test.platform.app.InstrumentationRegistry
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.pushstore.api.UserPushStore
+import io.element.android.libraries.sessionstorage.test.observer.NoOpSessionObserver
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.concurrent.thread
+
+/**
+ * Note: to clear the emulator, invoke:
+ * adb uninstall io.element.android.libraries.push.pushstore.impl.test
+ */
+class DefaultUserPushStoreFactoryTest {
+
+    /**
+     * Ensure that creating UserPushStore is thread safe.
+     */
+    @Test
+    fun testParallelCreation() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        val sessionId = SessionId("@alice:server.org")
+        val userPushStoreFactory = DefaultUserPushStoreFactory(context, NoOpSessionObserver())
+        var userPushStore1: UserPushStore? = null
+        val thread1 = thread {
+            userPushStore1 = userPushStoreFactory.create(sessionId)
+        }
+        var userPushStore2: UserPushStore? = null
+        val thread2 = thread {
+            userPushStore2 = userPushStoreFactory.create(sessionId)
+        }
+        thread1.join()
+        thread2.join()
+        runBlocking {
+            userPushStore1!!.areNotificationEnabledForDevice()
+            userPushStore2!!.areNotificationEnabledForDevice()
+        }
+    }
+}

--- a/libraries/pushstore/impl/src/main/kotlin/io/element/android/libraries/pushstore/impl/DefaultUserPushStoreFactory.kt
+++ b/libraries/pushstore/impl/src/main/kotlin/io/element/android/libraries/pushstore/impl/DefaultUserPushStoreFactory.kt
@@ -41,11 +41,13 @@ class DefaultUserPushStoreFactory @Inject constructor(
     // We can have only one class accessing a single data store, so keep a cache of them.
     private val cache = mutableMapOf<SessionId, UserPushStore>()
     override fun create(userId: SessionId): UserPushStore {
-        return cache.getOrPut(userId) {
-            UserPushStoreDataStore(
-                context = context,
-                userId = userId
-            )
+        return synchronized(cache) {
+            cache.getOrPut(userId) {
+                UserPushStoreDataStore(
+                    context = context,
+                    userId = userId
+                )
+            }
         }
     }
 

--- a/libraries/pushstore/impl/src/main/kotlin/io/element/android/libraries/pushstore/impl/DefaultUserPushStoreFactory.kt
+++ b/libraries/pushstore/impl/src/main/kotlin/io/element/android/libraries/pushstore/impl/DefaultUserPushStoreFactory.kt
@@ -26,6 +26,7 @@ import io.element.android.libraries.pushstore.api.UserPushStore
 import io.element.android.libraries.pushstore.api.UserPushStoreFactory
 import io.element.android.libraries.sessionstorage.api.observer.SessionListener
 import io.element.android.libraries.sessionstorage.api.observer.SessionObserver
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
 @SingleIn(AppScope::class)
@@ -39,15 +40,13 @@ class DefaultUserPushStoreFactory @Inject constructor(
     }
 
     // We can have only one class accessing a single data store, so keep a cache of them.
-    private val cache = mutableMapOf<SessionId, UserPushStore>()
+    private val cache = ConcurrentHashMap<SessionId, UserPushStore>()
     override fun create(userId: SessionId): UserPushStore {
-        return synchronized(cache) {
-            cache.getOrPut(userId) {
-                UserPushStoreDataStore(
-                    context = context,
-                    userId = userId
-                )
-            }
+        return cache.getOrPut(userId) {
+            UserPushStoreDataStore(
+                context = context,
+                userId = userId
+            )
         }
     }
 

--- a/libraries/session-storage/test/build.gradle.kts
+++ b/libraries/session-storage/test/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id("io.element.android-library")
+}
+
+android {
+    namespace = "io.element.android.libraries.sessionstorage.test"
+}
+
+dependencies {
+    implementation(projects.libraries.sessionStorage.api)
+}

--- a/libraries/session-storage/test/src/main/kotlin/io/element/android/libraries/sessionstorage/test/observer/NoOpSessionObserver.kt
+++ b/libraries/session-storage/test/src/main/kotlin/io/element/android/libraries/sessionstorage/test/observer/NoOpSessionObserver.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.sessionstorage.test.observer
+
+import io.element.android.libraries.sessionstorage.api.observer.SessionListener
+import io.element.android.libraries.sessionstorage.api.observer.SessionObserver
+
+class NoOpSessionObserver : SessionObserver {
+    override fun addListener(listener: SessionListener) = Unit
+    override fun removeListener(listener: SessionListener) = Unit
+}

--- a/tests/uitests/build.gradle.kts
+++ b/tests/uitests/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     testImplementation(libs.test.junit)
     testImplementation(libs.test.parameter.injector)
     testImplementation(projects.libraries.designsystem)
-    androidTestImplementation(libs.test.junitext)
     ksp(libs.showkase.processor)
     kspTest(libs.showkase.processor)
 


### PR DESCRIPTION
Fixes #950.

First commit remove unused gradle dep.

I added a connected test, which has to be run manually (the CI does not run connectedAndroidTest right now).
The test was failing before the fix and is passing now.