### PR TITLE
Fix on composition log.

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/LogCompositions.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/LogCompositions.kt
@@ -30,7 +30,7 @@ fun LogCompositions(tag: String, msg: String) {
     if (BuildConfig.DEBUG) {
         val ref = remember { Ref(0) }
         SideEffect { ref.value++ }
-        Timber.d(tag, "Compositions: $msg ${ref.value}")
+        Timber.tag(tag).d("Compositions: $msg ${ref.value}")
     }
 }
 


### PR DESCRIPTION
Fix regression from 9bf7c1ccf8dac08d9abb3929870c5ccf62bb8187

We had

```
2023-07-24T13:39:25*128GMT+00:00Z 125 D/ Tag: RoomListScreen
2023-07-24T13:39:25*133GMT+00:00Z 125 D/ Tag: RoomListScreen
```

Instead of

```
2023-07-24T13:39:25*128GMT+00:00Z 125 D/ /RoomListScreen: Compositions: Content 0
2023-07-24T13:39:25*133GMT+00:00Z 125 D/ /RoomListScreen: Compositions: TopBar 0
```