### PR TITLE
alternateText can't be an empty string. #955

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
@@ -544,14 +544,24 @@ private fun AnnotatedString.Builder.appendLink(link: Element) {
             pop()
         }
         is PermalinkData.RoomEmailInviteLink -> {
-            appendInlineContent(CHIP_ID, link.ownText())
+            safeAppendInlineContent(CHIP_ID, link.ownText())
         }
         is PermalinkData.RoomLink -> {
-            appendInlineContent(CHIP_ID, link.ownText())
+            safeAppendInlineContent(CHIP_ID, link.ownText())
         }
         is PermalinkData.UserLink -> {
-            appendInlineContent(CHIP_ID, link.ownText())
+            safeAppendInlineContent(CHIP_ID, link.ownText())
         }
+    }
+}
+
+fun AnnotatedString.Builder.safeAppendInlineContent(chipId: String, ownText: String) {
+    if (ownText.isEmpty()) {
+        // alternateText cannot be empty and default parameter value is private,
+        // so just omit the second param here.
+        appendInlineContent(chipId)
+    } else {
+        appendInlineContent(chipId, ownText)
     }
 }
 


### PR DESCRIPTION
Fixes #955 

- send a message in a room with empty link on a room permalink. for instance: `[](https://matrix.to/#/!hiTxAqnIVpMUQTHCUN:matrix.org?via=matrix.org)`
- Open the room with this message on Element X Android.

### Previous behavior

The app crash

### With this PR

The app is not crashing and is displaying a fallback string in the timeline:

<img width="163" alt="image" src="https://github.com/vector-im/element-x-android/assets/3940906/7d082477-d651-420c-91a4-e355f6a38d83">

Note: The PR fixes the crashes, but does not improve rendering of pills, this will be done when we will integrate the rich text editor.