### PR TITLE
Rework the way we init and close the RustMatrixRoom

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -63,7 +63,11 @@ interface MatrixRoom : Closeable {
 
     val timeline: MatrixTimeline
 
-    fun open(): Result<Unit>
+    fun destroy()
+
+    fun subscribeToSync()
+
+    fun unsubscribeFromSync()
 
     suspend fun userDisplayName(userId: UserId): Result<String?>
 
@@ -133,6 +137,8 @@ interface MatrixRoom : Closeable {
         zoomLevel: Int? = null,
         assetType: AssetType? = null,
     ): Result<Unit>
+
+    override fun close() = destroy()
 }
 
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -40,9 +40,6 @@ import io.element.android.libraries.matrix.impl.core.toProgressWatcher
 import io.element.android.libraries.matrix.impl.media.map
 import io.element.android.libraries.matrix.impl.room.location.toInner
 import io.element.android.libraries.matrix.impl.timeline.RustMatrixTimeline
-import io.element.android.libraries.matrix.impl.timeline.backPaginationStatusFlow
-import io.element.android.libraries.matrix.impl.timeline.eventOrigin
-import io.element.android.libraries.matrix.impl.timeline.timelineDiffFlow
 import io.element.android.libraries.sessionstorage.api.SessionData
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.CoroutineScope
@@ -51,11 +48,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.matrix.rustcomponents.sdk.EventItemOrigin
 import org.matrix.rustcomponents.sdk.RequiredState
 import org.matrix.rustcomponents.sdk.Room
 import org.matrix.rustcomponents.sdk.RoomListItem
@@ -65,7 +58,6 @@ import org.matrix.rustcomponents.sdk.genTransactionId
 import org.matrix.rustcomponents.sdk.messageEventContentFromMarkdown
 import timber.log.Timber
 import java.io.File
-import java.util.concurrent.atomic.AtomicBoolean
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RustMatrixRoom(
@@ -89,7 +81,6 @@ class RustMatrixRoom(
 
     private val roomCoroutineScope = sessionCoroutineScope.childScope(coroutineDispatchers.main, "RoomScope-$roomId")
     private val _membersStateFlow = MutableStateFlow<MatrixRoomMembersState>(MatrixRoomMembersState.Unknown)
-    private val isInit = AtomicBoolean(false)
     private val _syncUpdateFlow = MutableStateFlow(0L)
     private val _timeline by lazy {
         RustMatrixTimeline(
@@ -98,6 +89,7 @@ class RustMatrixRoom(
             roomCoroutineScope = roomCoroutineScope,
             dispatcher = roomDispatcher,
             lastLoginTimestamp = sessionData.loginTimestamp,
+            onNewSyncedEvent = { _syncUpdateFlow.value = systemClock.epochMillis() }
         )
     }
 
@@ -107,48 +99,27 @@ class RustMatrixRoom(
 
     override val timeline: MatrixTimeline = _timeline
 
-    override fun open(): Result<Unit> {
-        return if (isInit.getAndSet(true)) {
-            Result.failure(IllegalStateException("Listener already registered"))
-        } else {
-            val settings = RoomSubscription(
-                requiredState = listOf(
-                    RequiredState(key = EventType.STATE_ROOM_CANONICAL_ALIAS, value = ""),
-                    RequiredState(key = EventType.STATE_ROOM_TOPIC, value = ""),
-                    RequiredState(key = EventType.STATE_ROOM_JOIN_RULES, value = ""),
-                    RequiredState(key = EventType.STATE_ROOM_POWER_LEVELS, value = ""),
-                ),
-                timelineLimit = null
-            )
-            roomListItem.subscribe(settings)
-            roomCoroutineScope.launch(roomDispatcher) {
-                innerRoom.timelineDiffFlow { initialList ->
-                    _timeline.postItems(initialList)
-                }.onEach { diff ->
-                    if (diff.eventOrigin() == EventItemOrigin.SYNC) {
-                        _syncUpdateFlow.value = systemClock.epochMillis()
-                    }
-                    _timeline.postDiff(diff)
-                }.launchIn(this)
-
-                innerRoom.backPaginationStatusFlow()
-                    .onEach {
-                        _timeline.postPaginationStatus(it)
-                    }.launchIn(this)
-
-                fetchMembers()
-            }
-            Result.success(Unit)
-        }
+    override fun subscribeToSync() {
+        val settings = RoomSubscription(
+            requiredState = listOf(
+                RequiredState(key = EventType.STATE_ROOM_CANONICAL_ALIAS, value = ""),
+                RequiredState(key = EventType.STATE_ROOM_TOPIC, value = ""),
+                RequiredState(key = EventType.STATE_ROOM_JOIN_RULES, value = ""),
+                RequiredState(key = EventType.STATE_ROOM_POWER_LEVELS, value = ""),
+            ),
+            timelineLimit = null
+        )
+        roomListItem.subscribe(settings)
     }
 
-    override fun close() {
-        if (isInit.getAndSet(false)) {
-            roomCoroutineScope.cancel()
-            roomListItem.unsubscribe()
-            innerRoom.destroy()
-            roomListItem.destroy()
-        }
+    override fun unsubscribeFromSync() {
+        roomListItem.unsubscribe()
+    }
+
+    override fun destroy() {
+        roomCoroutineScope.cancel()
+        innerRoom.destroy()
+        roomListItem.destroy()
     }
 
     override val name: String?
@@ -362,12 +333,6 @@ class RustMatrixRoom(
     override suspend fun setTopic(topic: String): Result<Unit> = withContext(roomDispatcher) {
         runCatching {
             innerRoom.setTopic(topic)
-        }
-    }
-
-    private suspend fun fetchMembers() = withContext(roomDispatcher) {
-        runCatching {
-            innerRoom.fetchMembers()
         }
     }
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -100,7 +100,6 @@ class FakeMatrixRoom(
     private val _sentLocations = mutableListOf<SendLocationInvocation>()
     val sentLocations: List<SendLocationInvocation> = _sentLocations
 
-
     var invitedUserId: UserId? = null
         private set
 
@@ -128,9 +127,11 @@ class FakeMatrixRoom(
 
     override val timeline: MatrixTimeline = matrixTimeline
 
-    override fun open(): Result<Unit> {
-        return Result.success(Unit)
-    }
+    override fun subscribeToSync() = Unit
+
+    override fun unsubscribeFromSync() = Unit
+
+    override fun destroy() = Unit
 
     override suspend fun userDisplayName(userId: UserId): Result<String?> = simulateLongTask {
         userDisplayNameResult
@@ -282,8 +283,6 @@ class FakeMatrixRoom(
         _sentLocations.add(SendLocationInvocation(body, geoUri, description, zoomLevel, assetType))
         return sendLocationResult
     }
-
-    override fun close() = Unit
 
     fun givenLeaveRoomError(throwable: Throwable?) {
         this.leaveRoomError = throwable

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
@@ -87,7 +87,6 @@ class RoomListScreen(
             Singleton.appScope.launch {
                 withContext(coroutineDispatchers.io) {
                     matrixClient.getRoom(roomId)!!.use { room ->
-                        room.open()
                         room.timeline.paginateBackwards(20, 50)
                     }
                 }


### PR DESCRIPTION
Rework the way we init and close the RustMatrixRoom.

Closes #951.

We will be careful when integrating Appyx 2.0.0 regarding potential changes about lifecycle of Node and View...