### PR TITLE
Fix gradle warning

### DIFF
--- a/plugins/settings.gradle.kts
+++ b/plugins/settings.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+rootProject.name = "ElementX_plugins"
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()


### PR DESCRIPTION
This PR fix the warning below:

"Project accessors enabled, but root project name not explicitly set for 'plugins'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking caching."

Not sure about the impact, but should not have any bad side effects.