### PR TITLE
Detect missing translations.

### DIFF
--- a/tools/check/check_code_quality.sh
+++ b/tools/check/check_code_quality.sh
@@ -38,7 +38,7 @@ else
 fi
 
 echo
-echo "Search for forbidden patterns in code..."
+echo "Search for forbidden patterns in Kotlin source files..."
 
 # list all Kotlin folders of the project.
 allKotlinDirs=`find . -type d |grep -v build |grep -v \.git |grep -v \.gradle |grep kotlin$`
@@ -47,9 +47,20 @@ ${searchForbiddenStringsScript} ./tools/check/forbidden_strings_in_code.txt $all
 
 resultForbiddenStringInCode=$?
 
-if [[ ${resultForbiddenStringInCode} -eq 0 ]]; then
-   echo "MAIN OK"
+echo
+echo "Search for forbidden patterns in XML resource files..."
+
+# list all res folders of the project.
+allResDirs=`find . -type d |grep -v build |grep -v \.git |grep -v \.gradle |grep /res$`
+
+${searchForbiddenStringsScript} ./tools/check/forbidden_strings_in_xml.txt $allResDirs
+
+resultForbiddenStringInXml=$?
+
+if [[ ${resultForbiddenStringInCode} -eq 0 ]] \
+   && [[ ${resultForbiddenStringInXml} -eq 0 ]]; then
+   echo "OK"
 else
-   echo "❌ MAIN ERROR"
+   echo "❌ ERROR, please check the logs above."
    exit 1
 fi

--- a/tools/check/forbidden_strings_in_xml.txt
+++ b/tools/check/forbidden_strings_in_xml.txt
@@ -1,0 +1,38 @@
+#
+# Copyright 2023 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file list String which are not allowed in resource.
+# Use Perl regex to write forbidden strings
+# Note: line cannot start with a space. Use \s instead.
+# It is possible to specify an authorized number of occurrence with === suffix. Default is 0
+# Example:
+# AuthorizedStringThreeTimes===3
+
+# Extension:xml
+
+### Empty tag detected. Empty translation or plurals?
+"></
+">""</
+
+### Rubbish from merge. Please delete those lines (sometimes in comment)
+<<<<<<<
+>>>>>>>
+
+### "DO NOT COMMIT" has been committed
+DO NOT COMMIT
+
+### Tab char is forbidden. Use only spaces
+\t


### PR DESCRIPTION
Closes #885

I did not find a way to do this with lint or any other tool out of the box, so I am use our internal forbidden patterns detector.