### PR TITLE
Fix sending read receipts when entering a room

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -92,14 +92,14 @@ class TimelinePresenter @Inject constructor(
 
         LaunchedEffect(timelineItems.size) {
             // We just loaded the initial items, we should send a read receipt
-            if (prevMostRecentItemId.value == null && timelineItems.isNotEmpty()) {
-                appScope.sendReadReceiptIfNeeded(
-                    firstVisibleIndex = 0,
-                    timelineItems = timelineItems,
-                    lastReadReceiptIndex = lastReadReceiptIndex,
-                    lastReadReceiptId = lastReadReceiptId
-                )
-            }
+//            if (prevMostRecentItemId.value == null && timelineItems.isNotEmpty()) {
+//                appScope.sendReadReceiptIfNeeded(
+//                    firstVisibleIndex = 0,
+//                    timelineItems = timelineItems,
+//                    lastReadReceiptIndex = lastReadReceiptIndex,
+//                    lastReadReceiptId = lastReadReceiptId
+//                )
+//            }
 
             computeHasNewItems(timelineItems, prevMostRecentItemId, hasNewItems)
         }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -91,6 +91,16 @@ class TimelinePresenter @Inject constructor(
         }
 
         LaunchedEffect(timelineItems.size) {
+            // We just loaded the initial items, we should send a read receipt
+            if (prevMostRecentItemId.value == null && timelineItems.isNotEmpty()) {
+                appScope.sendReadReceiptIfNeeded(
+                    firstVisibleIndex = 0,
+                    timelineItems = timelineItems,
+                    lastReadReceiptIndex = lastReadReceiptIndex,
+                    lastReadReceiptId = lastReadReceiptId
+                )
+            }
+
             computeHasNewItems(timelineItems, prevMostRecentItemId, hasNewItems)
         }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -91,17 +91,7 @@ class TimelinePresenter @Inject constructor(
         }
 
         LaunchedEffect(timelineItems.size) {
-            // We just loaded the initial items, we should send a read receipt
-//            if (prevMostRecentItemId.value == null && timelineItems.isNotEmpty()) {
-//                appScope.sendReadReceiptIfNeeded(
-//                    firstVisibleIndex = 0,
-//                    timelineItems = timelineItems,
-//                    lastReadReceiptIndex = lastReadReceiptIndex,
-//                    lastReadReceiptId = lastReadReceiptId
-//                )
-//            }
-
-            computeHasNewItems(timelineItems, prevMostRecentItemId, hasNewItems)
+             computeHasNewItems(timelineItems, prevMostRecentItemId, hasNewItems)
         }
 
         LaunchedEffect(Unit) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -140,6 +141,7 @@ fun TimelineView(
         }
 
         TimelineScrollHelper(
+            itemCount = state.timelineItems.size,
             lazyListState = lazyListState,
             hasNewItems = state.hasNewItems,
             onScrollFinishedAt = ::onScrollFinishedAt
@@ -242,6 +244,7 @@ fun TimelineItemRow(
 
 @Composable
 private fun BoxScope.TimelineScrollHelper(
+    itemCount: Int,
     lazyListState: LazyListState,
     hasNewItems: Boolean,
     onScrollFinishedAt: (Int) -> Unit,
@@ -249,6 +252,13 @@ private fun BoxScope.TimelineScrollHelper(
     val coroutineScope = rememberCoroutineScope()
     val isScrollFinished by remember { derivedStateOf { !lazyListState.isScrollInProgress } }
     val canAutoScroll by remember { derivedStateOf { lazyListState.firstVisibleItemIndex < 3 } }
+    var initialItemsLoaded by rememberSaveable { mutableStateOf(false) }
+    if (!initialItemsLoaded && itemCount > 0) {
+        initialItemsLoaded = true
+        LaunchedEffect(Unit) {
+            onScrollFinishedAt(lazyListState.firstVisibleItemIndex)
+        }
+    }
 
     LaunchedEffect(canAutoScroll, hasNewItems) {
         val shouldAutoScroll = isScrollFinished && canAutoScroll && hasNewItems

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -47,7 +47,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -141,7 +140,6 @@ fun TimelineView(
         }
 
         TimelineScrollHelper(
-            itemCount = state.timelineItems.size,
             lazyListState = lazyListState,
             hasNewItems = state.hasNewItems,
             onScrollFinishedAt = ::onScrollFinishedAt
@@ -244,7 +242,6 @@ fun TimelineItemRow(
 
 @Composable
 private fun BoxScope.TimelineScrollHelper(
-    itemCount: Int,
     lazyListState: LazyListState,
     hasNewItems: Boolean,
     onScrollFinishedAt: (Int) -> Unit,
@@ -252,13 +249,6 @@ private fun BoxScope.TimelineScrollHelper(
     val coroutineScope = rememberCoroutineScope()
     val isScrollFinished by remember { derivedStateOf { !lazyListState.isScrollInProgress } }
     val canAutoScroll by remember { derivedStateOf { lazyListState.firstVisibleItemIndex < 3 } }
-    var initialItemsLoaded by rememberSaveable { mutableStateOf(false) }
-    if (!initialItemsLoaded && itemCount > 0) {
-        initialItemsLoaded = true
-        LaunchedEffect(Unit) {
-            onScrollFinishedAt(lazyListState.firstVisibleItemIndex)
-        }
-    }
 
     LaunchedEffect(canAutoScroll, hasNewItems) {
         val shouldAutoScroll = isScrollFinished && canAutoScroll && hasNewItems

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -140,6 +140,7 @@ fun TimelineView(
         }
 
         TimelineScrollHelper(
+            isTimelineEmpty = state.timelineItems.isEmpty(),
             lazyListState = lazyListState,
             hasNewItems = state.hasNewItems,
             onScrollFinishedAt = ::onScrollFinishedAt
@@ -242,6 +243,7 @@ fun TimelineItemRow(
 
 @Composable
 private fun BoxScope.TimelineScrollHelper(
+    isTimelineEmpty: Boolean,
     lazyListState: LazyListState,
     hasNewItems: Boolean,
     onScrollFinishedAt: (Int) -> Unit,
@@ -259,8 +261,8 @@ private fun BoxScope.TimelineScrollHelper(
         }
     }
 
-    LaunchedEffect(isScrollFinished) {
-        if (isScrollFinished) {
+    LaunchedEffect(isScrollFinished, isTimelineEmpty) {
+        if (isScrollFinished && !isTimelineEmpty) {
             // Notify the parent composable about the first visible item index when scrolling finishes
             onScrollFinishedAt(lazyListState.firstVisibleItemIndex)
         }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/timeline/TimelinePresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/timeline/TimelinePresenterTest.kt
@@ -119,7 +119,7 @@ class TimelinePresenterTest {
     }
 
     @Test
-    fun `present - on scroll finished will not send read receipt no event is before the index`() = runTest {
+    fun `present - on scroll finished will not send read receipt if no event is before the index`() = runTest {
         val timeline = FakeMatrixTimeline(
             initialTimelineItems = listOf(
                 MatrixTimelineItem.Event(0, anEventTimelineItem())


### PR DESCRIPTION
The callback in `TimelineScrollHelper` was only called when the timeline items were empty, so no initial read receipt was sent anymore.

Instead, we're sending a read receipt when the initial items for the timeline are loaded.