### PR TITLE
Fix notification rendering by removing leftover test code

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/NotificationMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/NotificationMapper.kt
@@ -40,7 +40,6 @@ class NotificationMapper(
         roomId: RoomId,
         notificationItem: NotificationItem
     ): NotificationData {
-        notificationItem.event.use { (it as NotificationEvent.Timeline).event }
         val senderId = UserId(notificationItem.senderInfo.senderId)
         return notificationItem.use { item ->
             NotificationData(


### PR DESCRIPTION
It seems like this code was merged in some of my PRs, while it was only some left over test code, that will some times fail and throw an exception, resulting in fallback notifications being rendered instead of the correct ones.