### PR TITLE
Use for instead of forEach with ranges

### DIFF
--- a/changelog.d/1035.bugfix
+++ b/changelog.d/1035.bugfix
@@ -1,0 +1,1 @@
+Use `for` instead of `forEach` in `DefaultDiffCacheInvalidator` to improve performance.

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/diff/DiffCacheInvalidator.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/diff/DiffCacheInvalidator.kt
@@ -38,9 +38,9 @@ interface DiffCacheInvalidator<T> {
 class DefaultDiffCacheInvalidator<T> : DiffCacheInvalidator<T> {
 
     override fun onChanged(position: Int, count: Int, cache: MutableDiffCache<T>) {
-        (position until position + count).forEach {
+        for (i in position until position + count) {
             // Invalidate cache
-            cache[it] = null
+            cache[i] = null
         }
     }
 


### PR DESCRIPTION
`forEach` is several times slower when used with ranges: https://medium.com/mobile-app-development-publication/kotlin-for-loop-vs-foreach-7eb594960333

This was discovered by a detekt rule in another branch which won't be merged.