### PR TITLE
Sync: enable the encryption loop

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -53,7 +53,10 @@ class RustMatrixClientFactory @Inject constructor(
 
         client.restoreSession(sessionData.toSession())
 
-        val syncService = client.syncService().finish()
+        val syncService = client
+            .syncService()
+            .withEncryptionSync(withCrossProcessLock = false, appIdentifier = null)
+            .finish()
 
         RustMatrixClient(
             client = client,


### PR DESCRIPTION
Just enable the encryption loop.
Maybe wait for the next rust sdk (0.1.42) before merging