### PR TITLE
Fix rendering of inline elements in list items in messages

### DIFF
--- a/changelog.d/1090.bugfix
+++ b/changelog.d/1090.bugfix
@@ -1,0 +1,1 @@
+Fix rendering of inline elements in list items.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/DocumentProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/DocumentProvider.kt
@@ -44,13 +44,13 @@ open class DocumentProvider : PreviewParameterProvider<Document> {
             "<ol><li>ol item 1</li><li>ol item 2</li></ol>",
             "<ol><li><i>ol item 1 italic</i></li><li><b>ol item 2 bold</b></li></ol>",
             "<ul><li>ul item 1</li><li>ul item 2</li></ul>",
-            "<ol><li>Testing <a href='#'>link</a> item.</li><li>And <a href='#'>another</a> item.</li></ol>",
-            "<ul><li>Testing <a href='#'>link</a> item.</li><li>And <a href='#'>another</a> item.</li></ul>",
             "<blockquote>blockquote</blockquote>",
             // TODO Find a way to make is work with `pre`. For now there is an error with
             // jsoup: java.lang.NoSuchMethodError: 'org.jsoup.nodes.Element org.jsoup.nodes.Element.firstElementChild()'
             // "<pre>pre</pre>",
             "<mx-reply><blockquote><a href=\\\"https://matrix.to/#/!roomId/\$eventId?via=matrix.org\\\">In reply to</a> " +
                 "<a href=\\\"https://matrix.to/#/@alice:matrix.org\\\">@alice:matrix.org</a><br>original message</blockquote></mx-reply>reply",
+            "<ol><li>Testing <a href='#'>link</a> item.</li><li>And <a href='#'>another</a> item.</li></ol>",
+            "<ul><li>Testing <a href='#'>link</a> item.</li><li>And <a href='#'>another</a> item.</li></ul>",
         ).map { Jsoup.parse(it) }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/DocumentProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/DocumentProvider.kt
@@ -44,6 +44,8 @@ open class DocumentProvider : PreviewParameterProvider<Document> {
             "<ol><li>ol item 1</li><li>ol item 2</li></ol>",
             "<ol><li><i>ol item 1 italic</i></li><li><b>ol item 2 bold</b></li></ol>",
             "<ul><li>ul item 1</li><li>ul item 2</li></ul>",
+            "<ol><li>Testing <a href='#'>link</a> item.</li><li>And <a href='#'>another</a> item.</li></ol>",
+            "<ul><li>Testing <a href='#'>link</a> item.</li><li>And <a href='#'>another</a> item.</li></ul>",
             "<blockquote>blockquote</blockquote>",
             // TODO Find a way to make is work with `pre`. For now there is an error with
             // jsoup: java.lang.NoSuchMethodError: 'org.jsoup.nodes.Element org.jsoup.nodes.Element.firstElementChild()'

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
@@ -419,7 +419,7 @@ private fun HtmlUnorderedList(
     onTextClicked: () -> Unit = {},
     onTextLongClicked: () -> Unit = {},
 ) {
-    val marker = "•"
+    val marker = "・"
     HtmlListItems(
         list = unorderedList,
         marker = { marker },
@@ -443,7 +443,7 @@ private fun HtmlListItems(
             val areAllChildrenInline = node.childNodes().all { it is TextNode || it is Element && it.isInline() }
             if (areAllChildrenInline) {
                 val text = buildAnnotatedString {
-                    append("${marker(index + 1)}  ")
+                    append("${marker(index + 1)} ")
                     appendInlineChildrenElements(node.childNodes(), MaterialTheme.colorScheme)
                 }
                 HtmlText(text = text, interactionSource = remember { MutableInteractionSource() })
@@ -453,7 +453,7 @@ private fun HtmlListItems(
                         is TextNode -> {
                             if (!innerNode.isBlank) {
                                 val text = buildAnnotatedString {
-                                    append("${marker(index + 1)}  ")
+                                    append("${marker(index + 1)} ")
                                 }
                                 HtmlText(
                                     text = text, onClick = onTextClicked,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
@@ -408,15 +408,7 @@ private fun HtmlOrderedList(
         modifier = modifier,
         onTextClicked = onTextClicked, onTextLongClicked = onTextLongClicked,
         interactionSource = interactionSource
-    ) {
-        val text = buildAnnotatedString {
-            append("${number++}$delimiter ${it.text()}")
-        }
-        HtmlText(
-            text = text, onClick = onTextClicked,
-            onLongClick = onTextLongClicked, interactionSource = interactionSource
-        )
-    }
+    )
 }
 
 @Composable
@@ -434,15 +426,7 @@ private fun HtmlUnorderedList(
         modifier = modifier,
         onTextClicked = onTextClicked, onTextLongClicked = onTextLongClicked,
         interactionSource = interactionSource
-    ) {
-        val text = buildAnnotatedString {
-            append("$marker ${it.text()}")
-        }
-        HtmlText(
-            text = text, onClick = onTextClicked,
-            onLongClick = onTextLongClicked, interactionSource = interactionSource
-        )
-    }
+    )
 }
 
 @Composable
@@ -453,11 +437,10 @@ private fun HtmlListItems(
     modifier: Modifier = Modifier,
     onTextClicked: () -> Unit = {},
     onTextLongClicked: () -> Unit = {},
-    content: @Composable (node: TextNode) -> Unit = {}
 ) {
     Column(modifier = modifier) {
         for ((index, node) in list.children().withIndex()) {
-            val areAllChildrenInline = node.childNodes().all { it is TextNode || (it is Element && it.isInline()) }
+            val areAllChildrenInline = node.childNodes().all { it is TextNode || it is Element && it.isInline() }
             if (areAllChildrenInline) {
                 val text = buildAnnotatedString {
                     append("${marker(index + 1)}  ")
@@ -468,7 +451,15 @@ private fun HtmlListItems(
                 for (innerNode in node.childNodes()) {
                     when (innerNode) {
                         is TextNode -> {
-                            if (!innerNode.isBlank) content(innerNode)
+                            if (!innerNode.isBlank) {
+                                val text = buildAnnotatedString {
+                                    append("${marker(index + 1)}  ")
+                                }
+                                HtmlText(
+                                    text = text, onClick = onTextClicked,
+                                    onLongClick = onTextLongClicked, interactionSource = interactionSource
+                                )
+                            }
                         }
                         is Element -> HtmlBlock(
                             element = innerNode,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
@@ -400,7 +400,6 @@ private fun HtmlOrderedList(
     onTextClicked: () -> Unit = {},
     onTextLongClicked: () -> Unit = {},
 ) {
-    var number = 1
     val delimiter = "."
     HtmlListItems(
         list = orderedList,

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentDark_0_null_16,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentDark_0_null_16,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb0d3bfcfd75cbd75fd9270ff1dc27090e5dbac79ca8db8a46d91a4c12bc966b
-size 4457
+oid sha256:41d154cec3a16351c3c071ec8a198d36ed3d7745f8500f641fd765ad22f693df
+size 10877

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentDark_0_null_20,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentDark_0_null_20,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce52e4fba5279920db75565f4cdcf1ca761a8aad7b09ad9428e490c396527294
+size 11600

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentDark_0_null_21,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentDark_0_null_21,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c24f6dd8748dc3d262f5590a281ac1caee261046943ade6170ac7fcadb6d4fa
+size 11516

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentLight_0_null_16,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentLight_0_null_16,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb0d3bfcfd75cbd75fd9270ff1dc27090e5dbac79ca8db8a46d91a4c12bc966b
-size 4457
+oid sha256:7240b9666592f3627bb2e944cc83ab31eface8139c5c98dcc6c1ad9e7ca9b8b6
+size 11285

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentLight_0_null_20,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentLight_0_null_20,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c0a959f003d8eedf2a4b9284f63ea77a608e272d0dd8e564bbbbf3686c88758
+size 11572

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentLight_0_null_21,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components.html_null_HtmlDocumentLight_0_null_21,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3a3ffdc5062cea8c3226df50b0876a3ca02045a19e05974b95e5ac83b813f39
+size 11502


### PR DESCRIPTION
When inline elements such as links were used inside list items, they were being added as block elements, and sometimes not   even added at all, only as a line break with the list item marker.

Fixes #1090.