### PR TITLE
Fix excludes so screenshot tests are only run once

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,7 +152,7 @@ allprojects {
             maxHeapSize = "1g"
         } else {
             // Disable screenshot tests by default
-            exclude("**/ScreenshotTest*")
+            exclude("ui/S.class")
         }
     }
 }


### PR DESCRIPTION
This is reproducible locally and also in the CI (some PRs are not passing because of OOM errors).