### PR TITLE
Use alpha version of the library `androidx.security:security-crypto`

### DIFF
--- a/changelog.d/1101.bugfix
+++ b/changelog.d/1101.bugfix
@@ -1,0 +1,1 @@
+Fix crash RuntimeException "No matching key found for the ciphertext in the stream"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,7 @@ androidx_browser = { module = "androidx.browser:browser", version.ref = "browser
 androidx_lifecycle_runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx_lifecycle_process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle" }
 androidx_splash = "androidx.core:core-splashscreen:1.0.1"
-androidx_security_crypto = "androidx.security:security-crypto:1.0.0"
+androidx_security_crypto = "androidx.security:security-crypto:1.1.0-alpha06"
 androidx_media3_exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
 androidx_media3_ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/file/EncryptedFileFactory.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/file/EncryptedFileFactory.kt
@@ -18,7 +18,7 @@ package io.element.android.libraries.androidutils.file
 
 import android.content.Context
 import androidx.security.crypto.EncryptedFile
-import androidx.security.crypto.MasterKeys
+import androidx.security.crypto.MasterKey
 import java.io.File
 
 class EncryptedFileFactory(
@@ -26,11 +26,13 @@ class EncryptedFileFactory(
 ) {
     fun create(file: File): EncryptedFile {
         // We need to use the same key for all the encrypted files.
-        val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
         return EncryptedFile.Builder(
-            file,
             context,
-            masterKeyAlias,
+            file,
+            masterKey,
             EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
         ).build()
     }


### PR DESCRIPTION
To fix crash `RuntimeException "No matching key found for the ciphertext in the stream"`.

Fixes #1099