### PR TITLE
Linkify raw links in HTML message contents

### DIFF
--- a/changelog.d/1079.bugfix
+++ b/changelog.d/1079.bugfix
@@ -1,0 +1,1 @@
+Linkify links in HTML contents.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
@@ -16,10 +16,6 @@
 
 package io.element.android.features.messages.impl.timeline.components.event
 
-import android.text.SpannableString
-import android.text.style.URLSpan
-import android.text.util.Linkify.PHONE_NUMBERS
-import android.text.util.Linkify.WEB_URLS
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,20 +24,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.text.util.LinkifyCompat
 import io.element.android.features.messages.impl.timeline.components.html.HtmlDocument
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemTextBasedContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemTextBasedContentProvider
 import io.element.android.libraries.designsystem.components.ClickableLinkText
 import io.element.android.libraries.designsystem.preview.ElementPreviewDark
 import io.element.android.libraries.designsystem.preview.ElementPreviewLight
-import io.element.android.libraries.theme.LinkColor
 import io.element.android.libraries.designsystem.text.toAnnotatedString
 
 @Composable
@@ -69,45 +61,17 @@ fun TimelineItemTextView(
         }
     } else {
         Box(modifier) {
-            val linkStyle = SpanStyle(
-                color = LinkColor,
-            )
-            val styledText = remember(content.body) {
-                content.body.linkify(linkStyle) + extraPadding.getStr(16.sp).toAnnotatedString()
+            val textWithPadding = remember(content.body) {
+                content.body + extraPadding.getStr(16.sp).toAnnotatedString()
             }
             ClickableLinkText(
-                text = styledText,
+                text = textWithPadding,
                 linkAnnotationTag = "URL",
                 onClick = onTextClicked,
                 onLongClick = onTextLongClicked,
                 interactionSource = interactionSource
             )
         }
-    }
-}
-
-private fun String.linkify(
-    linkStyle: SpanStyle,
-) = buildAnnotatedString {
-    append(this@linkify)
-    val spannable = SpannableString(this@linkify)
-    LinkifyCompat.addLinks(spannable, WEB_URLS or PHONE_NUMBERS)
-
-    val spans = spannable.getSpans(0, spannable.length, URLSpan::class.java)
-    for (span in spans) {
-        val start = spannable.getSpanStart(span)
-        val end = spannable.getSpanEnd(span)
-        addStyle(
-            start = start,
-            end = end,
-            style = linkStyle,
-        )
-        addStringAnnotation(
-            tag = "URL",
-            annotation = span.url,
-            start = start,
-            end = end
-        )
     }
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
@@ -576,7 +576,7 @@ private fun HtmlText(
 ) {
     val inlineContentMap = persistentMapOf<String, InlineTextContent>()
     ClickableLinkText(
-        text = text,
+        annotatedString = text,
         linkAnnotationTag = "URL",
         style = style,
         modifier = modifier,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
@@ -104,10 +104,7 @@ private fun HtmlBody(
             when (val node = nodes.next()) {
                 is TextNode -> {
                     if (!node.isBlank) {
-                        Text(
-                            text = node.text(),
-                            color = MaterialTheme.colorScheme.primary,
-                        )
+                        ClickableLinkText(text = node.text(), interactionSource = interactionSource)
                     }
                 }
                 is Element -> {

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ClickableLinkText.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ClickableLinkText.kt
@@ -61,7 +61,7 @@ fun ClickableLinkText(
     inlineContent: ImmutableMap<String, InlineTextContent> = persistentMapOf(),
 ) {
     ClickableLinkText(
-        text = AnnotatedString(text),
+        annotatedString = AnnotatedString(text),
         interactionSource = interactionSource,
         modifier = modifier,
         linkify = linkify,
@@ -76,7 +76,7 @@ fun ClickableLinkText(
 @OptIn(ExperimentalTextApi::class)
 @Composable
 fun ClickableLinkText(
-    text: AnnotatedString,
+    annotatedString: AnnotatedString,
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
     linkify: Boolean = true,
@@ -86,10 +86,12 @@ fun ClickableLinkText(
     style: TextStyle = LocalTextStyle.current,
     inlineContent: ImmutableMap<String, InlineTextContent> = persistentMapOf(),
 ) {
-    val processedText = if (linkify) {
-        text.linkify(SpanStyle(color = LinkColor))
-    } else {
-        text
+    val processedText = remember(annotatedString) {
+        if (linkify) {
+            annotatedString.linkify(SpanStyle(color = LinkColor))
+        } else {
+            annotatedString
+        }
     }
     val uriHandler = LocalUriHandler.current
     val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
@@ -111,10 +113,10 @@ fun ClickableLinkText(
         ) { offset ->
             layoutResult.value?.let { layoutResult ->
                 val position = layoutResult.getOffsetForPosition(offset)
-                val linkUrlAnnotations = text.getUrlAnnotations(position, position)
+                val linkUrlAnnotations = annotatedString.getUrlAnnotations(position, position)
                     .map { AnnotatedString.Range(it.item.url, it.start, it.end, linkAnnotationTag) }
                 val linkStringAnnotations = linkUrlAnnotations +
-                    text.getStringAnnotations(linkAnnotationTag, position, position)
+                    annotatedString.getStringAnnotations(linkAnnotationTag, position, position)
                 if (linkStringAnnotations.isEmpty()) {
                     onClick()
                 } else {
@@ -174,7 +176,7 @@ internal fun ClickableLinkTextPreview() =
 @Composable
 private fun ContentToPreview() {
     ClickableLinkText(
-        text = AnnotatedString("Hello", ParagraphStyle()),
+        annotatedString = AnnotatedString("Hello", ParagraphStyle()),
         linkAnnotationTag = "",
         onClick = {},
         onLongClick = {},


### PR DESCRIPTION
## Changes

- Creates a `ClickableLinkText` for `String`.
- Adds a `linkify` parameter to the original function, which is `true` by default.
- Does the linkify logic inside that component, if `linkify` is true.
- Makes sure we don't linkify urls that are already inside url annotations or domains that are parts of user mentions or room aliases.

## Why

Fixes #1079.

## Screenshots

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src='https://github.com/vector-im/element-x-android/assets/480955/e3e5097a-794a-447a-9742-b4e9eec1bbf5' />
 <td><img src='https://github.com/vector-im/element-x-android/assets/480955/a4905ea5-ad13-46ad-adb2-72b04245df5f' />
</table>