### PR TITLE
Fix bug reporter failing after not finding some files

### DIFF
--- a/changelog.d/1082.bugfix
+++ b/changelog.d/1082.bugfix
@@ -1,0 +1,1 @@
+Fix bug reporter failing after not finding some log files.


### PR DESCRIPTION
## Changes

- Make sure we propagate `CancellationException`.
- Make sure we do a cleanup of temp files.
- Make sure we don't re-compress any lingering temp files.
- Don't stop the upload process if we were able to upload some log files, even if we failed to read some others.

## Why

Fixes #1082  (hopefully).