### PR TITLE
Make links in messages clickable again

### DIFF
--- a/changelog.d/1111.bugfix
+++ b/changelog.d/1111.bugfix
@@ -1,0 +1,1 @@
+Make links in messages clickable again.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
@@ -66,7 +66,6 @@ fun TimelineItemTextView(
             }
             ClickableLinkText(
                 text = textWithPadding,
-                linkAnnotationTag = "URL",
                 onClick = onTextClicked,
                 onLongClick = onTextLongClicked,
                 interactionSource = interactionSource

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
@@ -582,7 +582,6 @@ private fun HtmlText(
     val inlineContentMap = persistentMapOf<String, InlineTextContent>()
     ClickableLinkText(
         annotatedString = text,
-        linkAnnotationTag = "URL",
         style = style,
         modifier = modifier,
         inlineContent = inlineContentMap,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ClickableLinkText.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ClickableLinkText.kt
@@ -48,13 +48,15 @@ import io.element.android.libraries.theme.LinkColor
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
 
+const val LINK_TAG = "URL"
+
 @Composable
 fun ClickableLinkText(
     text: String,
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
     linkify: Boolean = true,
-    linkAnnotationTag: String = "",
+    linkAnnotationTag: String = LINK_TAG,
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = {},
     style: TextStyle = LocalTextStyle.current,
@@ -80,13 +82,14 @@ fun ClickableLinkText(
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
     linkify: Boolean = true,
-    linkAnnotationTag: String = "",
+    linkAnnotationTag: String = LINK_TAG,
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = {},
     style: TextStyle = LocalTextStyle.current,
     inlineContent: ImmutableMap<String, InlineTextContent> = persistentMapOf(),
 ) {
-    val processedText = remember(annotatedString) {
+    @Suppress("NAME_SHADOWING")
+    val annotatedString = remember(annotatedString) {
         if (linkify) {
             annotatedString.linkify(SpanStyle(color = LinkColor))
         } else {
@@ -126,7 +129,7 @@ fun ClickableLinkText(
         }
     }
     Text(
-        text = processedText,
+        text = annotatedString,
         modifier = modifier.then(pressIndicator),
         style = style,
         onTextLayout = {
@@ -158,7 +161,7 @@ fun AnnotatedString.linkify(linkStyle: SpanStyle): AnnotatedString {
                     style = linkStyle,
                 )
                 addStringAnnotation(
-                    tag = "URL",
+                    tag = LINK_TAG,
                     annotation = span.url,
                     start = start,
                     end = end


### PR DESCRIPTION
## Changes

- Creates a `LINK_TAG` constant to use as default in `ClickableLinkText`.
- Renames `processedText` to `annotatedString` to make links work again in linkified texts (suppressing shadowing, which is justified here IMO since we don't care about the original value anymore).

## Why

Fixes #1111.