### PR TITLE
When event has no id, just cancel parsing the latest room message

### DIFF
--- a/changelog.d/1125.bugfix
+++ b/changelog.d/1125.bugfix
@@ -1,0 +1,1 @@
+When event has no id, just cancel parsing the latest room message for a room.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/message/RoomMessageFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/message/RoomMessageFactory.kt
@@ -25,7 +25,7 @@ class RoomMessageFactory {
         eventTimelineItem ?: return null
         val mappedTimelineItem = EventTimelineItemMapper().map(eventTimelineItem)
         return RoomMessage(
-            eventId = mappedTimelineItem.eventId!!,
+            eventId = mappedTimelineItem.eventId ?: return null,
             event = mappedTimelineItem,
             sender = mappedTimelineItem.sender,
             originServerTs = mappedTimelineItem.timestamp,


### PR DESCRIPTION
Fixes #1125 (I hope, since I couldn't reproduce it).