### PR TITLE
Update matrix.org homeserver string

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderProvider.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderProvider.kt
@@ -32,7 +32,7 @@ open class AccountProviderProvider : PreviewParameterProvider<AccountProvider> {
 
 fun anAccountProvider() = AccountProvider(
     title = "matrix.org",
-    subtitle = "Matrix.org is an open network for secure, decentralized communication.",
+    subtitle = "Matrix.org is a large, free server on the public Matrix network for secure, decentralised communication, run by the Matrix.org Foundation.",
     isPublic = true,
     isMatrixOrg = true,
     isValid = true,


### PR DESCRIPTION
Fixes #1132 and replaces the string with "Matrix.org is a large, free server on the public Matrix network for secure, decentralized communication, run by the Matrix.org Foundation"