### PR TITLE
Prevent verification while initial sync is in progress

### DIFF
--- a/changelog.d/1131.bugfix
+++ b/changelog.d/1131.bugfix
@@ -1,0 +1,1 @@
+Only display verification prompt after initial sync is done.

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
@@ -60,8 +60,8 @@ class PreferencesRootPresenter @Inject constructor(
         val snackbarMessage by snackbarDispatcher.collectSnackbarMessageAsState()
         val hasAnalyticsProviders = remember { analyticsService.getAvailableAnalyticsProviders().isNotEmpty() }
 
-        // Session verification status (unknown, not verified, verified)
-        val canVerifySession by sessionVerificationService.canVerifySessionFlow.collectAsState(false)
+        // We should display the 'complete verification' option if the current session can be verified
+        val showCompleteVerification by sessionVerificationService.canVerifySessionFlow.collectAsState(false)
 
         val accountManagementUrl: MutableState<String?> = remember {
             mutableStateOf(null)
@@ -77,7 +77,7 @@ class PreferencesRootPresenter @Inject constructor(
             logoutState = logoutState,
             myUser = matrixUser.value,
             version = versionFormatter.get(),
-            showCompleteVerification = canVerifySession,
+            showCompleteVerification = showCompleteVerification,
             accountManagementUrl = accountManagementUrl.value,
             showAnalyticsSettings = hasAnalyticsProviders,
             showDeveloperSettings = showDeveloperSettings,

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.core.meta.BuildType
 import io.element.android.libraries.designsystem.utils.SnackbarDispatcher
 import io.element.android.libraries.designsystem.utils.collectSnackbarMessageAsState
 import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.sync.SyncState
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.api.user.getCurrentUser
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
@@ -59,13 +60,15 @@ class PreferencesRootPresenter @Inject constructor(
             initialLoad(matrixUser)
         }
 
+        val syncState by matrixClient.syncService().syncState.collectAsState()
+
         val snackbarMessage by snackbarDispatcher.collectSnackbarMessageAsState()
         val hasAnalyticsProviders = remember { analyticsService.getAvailableAnalyticsProviders().isNotEmpty() }
 
         // Session verification status (unknown, not verified, verified)
         val sessionVerifiedStatus by sessionVerificationService.sessionVerifiedStatus.collectAsState()
         val sessionIsNotVerified by remember {
-            derivedStateOf { sessionVerifiedStatus == SessionVerifiedStatus.NotVerified }
+            derivedStateOf { syncState == SyncState.Running && sessionVerifiedStatus == SessionVerifiedStatus.NotVerified }
         }
 
         val accountManagementUrl: MutableState<String?> = remember {

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -36,11 +36,9 @@ import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.designsystem.utils.SnackbarDispatcher
 import io.element.android.libraries.designsystem.utils.collectSnackbarMessageAsState
 import io.element.android.libraries.matrix.api.MatrixClient
-import io.element.android.libraries.matrix.api.sync.SyncState
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.api.user.getCurrentUser
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
-import io.element.android.libraries.matrix.api.verification.SessionVerifiedStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -67,7 +65,6 @@ class RoomListPresenter @Inject constructor(
         val filteredRoomList by roomListDataSource.filteredRooms.collectAsState()
         val filter by roomListDataSource.filter.collectAsState()
         val networkConnectionStatus by networkMonitor.connectivity.collectAsState()
-        val syncState by client.syncService().syncState.collectAsState()
 
         LaunchedEffect(Unit) {
             roomListDataSource.launchIn(this)
@@ -75,11 +72,11 @@ class RoomListPresenter @Inject constructor(
         }
 
         // Session verification status (unknown, not verified, verified)
-        val sessionVerifiedStatus by sessionVerificationService.sessionVerifiedStatus.collectAsState()
+        val canVerifySession by sessionVerificationService.canVerifySessionFlow.collectAsState(initial = false)
         var verificationPromptDismissed by rememberSaveable { mutableStateOf(false) }
         // We combine both values to only display the prompt if the session is not verified and it wasn't dismissed
         val displayVerificationPrompt by remember {
-            derivedStateOf { syncState == SyncState.Running && sessionVerifiedStatus == SessionVerifiedStatus.NotVerified && !verificationPromptDismissed }
+            derivedStateOf { canVerifySession && !verificationPromptDismissed }
         }
 
         var displaySearchResults by rememberSaveable { mutableStateOf(false) }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -36,6 +36,7 @@ import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.designsystem.utils.SnackbarDispatcher
 import io.element.android.libraries.designsystem.utils.collectSnackbarMessageAsState
 import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.sync.SyncState
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.api.user.getCurrentUser
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
@@ -66,6 +67,7 @@ class RoomListPresenter @Inject constructor(
         val filteredRoomList by roomListDataSource.filteredRooms.collectAsState()
         val filter by roomListDataSource.filter.collectAsState()
         val networkConnectionStatus by networkMonitor.connectivity.collectAsState()
+        val syncState by client.syncService().syncState.collectAsState()
 
         LaunchedEffect(Unit) {
             roomListDataSource.launchIn(this)
@@ -77,7 +79,7 @@ class RoomListPresenter @Inject constructor(
         var verificationPromptDismissed by rememberSaveable { mutableStateOf(false) }
         // We combine both values to only display the prompt if the session is not verified and it wasn't dismissed
         val displayVerificationPrompt by remember {
-            derivedStateOf { sessionVerifiedStatus == SessionVerifiedStatus.NotVerified && !verificationPromptDismissed }
+            derivedStateOf { syncState == SyncState.Running && sessionVerifiedStatus == SessionVerifiedStatus.NotVerified && !verificationPromptDismissed }
         }
 
         var displaySearchResults by rememberSaveable { mutableStateOf(false) }

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTests.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTests.kt
@@ -49,6 +49,7 @@ import io.element.android.libraries.matrix.test.A_USER_NAME
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.room.aRoomSummaryFilled
 import io.element.android.libraries.matrix.test.roomlist.FakeRoomListService
+import io.element.android.libraries.matrix.test.sync.FakeSyncService
 import io.element.android.libraries.matrix.test.verification.FakeSessionVerificationService
 import io.element.android.tests.testutils.consumeItemsUntilPredicate
 import io.element.android.tests.testutils.testCoroutineDispatchers
@@ -202,7 +203,8 @@ class RoomListPresenterTests {
     fun `present - handle DismissRequestVerificationPrompt`() = runTest {
         val roomListService = FakeRoomListService()
         val matrixClient = FakeMatrixClient(
-            roomListService = roomListService
+            roomListService = roomListService,
+            syncService = FakeSyncService().apply { startSync() }
         )
         val presenter = createRoomListPresenter(
             client = matrixClient,

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTests.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTests.kt
@@ -49,7 +49,6 @@ import io.element.android.libraries.matrix.test.A_USER_NAME
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.room.aRoomSummaryFilled
 import io.element.android.libraries.matrix.test.roomlist.FakeRoomListService
-import io.element.android.libraries.matrix.test.sync.FakeSyncService
 import io.element.android.libraries.matrix.test.verification.FakeSessionVerificationService
 import io.element.android.tests.testutils.consumeItemsUntilPredicate
 import io.element.android.tests.testutils.testCoroutineDispatchers
@@ -204,7 +203,6 @@ class RoomListPresenterTests {
         val roomListService = FakeRoomListService()
         val matrixClient = FakeMatrixClient(
             roomListService = roomListService,
-            syncService = FakeSyncService().apply { startSync() }
         )
         val presenter = createRoomListPresenter(
             client = matrixClient,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/verification/SessionVerificationService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/verification/SessionVerificationService.kt
@@ -39,7 +39,7 @@ interface SessionVerificationService {
     val sessionVerifiedStatus: StateFlow<SessionVerifiedStatus>
 
     /**
-     * Returns whether the current session needs to be verified.
+     * Returns whether the current session needs to be verified and the SDK is ready to start the verification.
      */
     val canVerifySessionFlow: Flow<Boolean>
 

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/verification/SessionVerificationService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/verification/SessionVerificationService.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.libraries.matrix.api.verification
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 interface SessionVerificationService {
@@ -36,6 +37,11 @@ interface SessionVerificationService {
      * or [SessionVerifiedStatus.Verified].
      */
     val sessionVerifiedStatus: StateFlow<SessionVerifiedStatus>
+
+    /**
+     * Returns whether the current session needs to be verified.
+     */
+    val canVerifySessionFlow: Flow<Boolean>
 
     /**
      * Request verification of the current session.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -35,7 +35,6 @@ import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.roomlist.awaitLoaded
 import io.element.android.libraries.matrix.api.sync.SyncService
-import io.element.android.libraries.matrix.api.sync.SyncState
 import io.element.android.libraries.matrix.api.user.MatrixSearchUserResults
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
@@ -149,13 +148,11 @@ class RustMatrixClient constructor(
 
     init {
         client.setDelegate(clientDelegate)
-        rustSyncService.syncState
-            .onEach { syncState ->
-                if (syncState == SyncState.Running) {
-                    onSlidingSyncUpdate()
-                }
+        roomListService.state.onEach { state ->
+            if (state == RoomListService.State.Running) {
+                onSlidingSyncUpdate()
             }
-            .launchIn(sessionCoroutineScope)
+        }.launchIn(sessionCoroutineScope)
     }
 
     override suspend fun getRoom(roomId: RoomId): MatrixRoom? = withContext(sessionDispatcher) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -150,7 +150,7 @@ class RustMatrixClient constructor(
         client.setDelegate(clientDelegate)
         roomListService.state.onEach { state ->
             if (state == RoomListService.State.Running) {
-                onSlidingSyncUpdate()
+                setupVerificationControllerIfNeeded()
             }
         }.launchIn(sessionCoroutineScope)
     }
@@ -335,8 +335,8 @@ class RustMatrixClient constructor(
         }
     }
 
-    private fun onSlidingSyncUpdate() {
-        if (!verificationService.isReady.value) {
+    private fun setupVerificationControllerIfNeeded() {
+        if (verificationService.verificationController == null) {
             try {
                 verificationService.verificationController = client.getSessionVerificationController()
             } catch (e: Throwable) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -92,8 +92,8 @@ class RustMatrixClient constructor(
     private val innerRoomListService = syncService.roomListService()
     private val sessionDispatcher = dispatchers.io.limitedParallelism(64)
     private val sessionCoroutineScope = appCoroutineScope.childScope(dispatchers.main, "Session-${sessionId}")
-    private val verificationService = RustSessionVerificationService()
     private val rustSyncService = RustSyncService(syncService, sessionCoroutineScope)
+    private val verificationService = RustSessionVerificationService(rustSyncService)
     private val pushersService = RustPushersService(
         client = client,
         dispatchers = dispatchers,

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/verification/FakeSessionVerificationService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/verification/FakeSessionVerificationService.kt
@@ -20,6 +20,7 @@ import io.element.android.libraries.matrix.api.verification.SessionVerificationS
 import io.element.android.libraries.matrix.api.verification.VerificationFlowState
 import io.element.android.libraries.matrix.api.verification.SessionVerifiedStatus
 import io.element.android.libraries.matrix.api.verification.VerificationEmoji
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -27,13 +28,13 @@ class FakeSessionVerificationService : SessionVerificationService {
     private val _isReady = MutableStateFlow(false)
     private val _sessionVerifiedStatus = MutableStateFlow<SessionVerifiedStatus>(SessionVerifiedStatus.Unknown)
     private var _verificationFlowState = MutableStateFlow<VerificationFlowState>(VerificationFlowState.Initial)
+    private var _canVerifySessionFlow = MutableStateFlow(true)
     private var emojiList = emptyList<VerificationEmoji>()
     var shouldFail = false
 
-    override val verificationFlowState: StateFlow<VerificationFlowState>
-        get() = _verificationFlowState
-
+    override val verificationFlowState: StateFlow<VerificationFlowState> =_verificationFlowState
     override val sessionVerifiedStatus: StateFlow<SessionVerifiedStatus> = _sessionVerifiedStatus
+    override val canVerifySessionFlow: Flow<Boolean> = _canVerifySessionFlow
 
     override val isReady: StateFlow<Boolean> = _isReady
 
@@ -75,6 +76,10 @@ class FakeSessionVerificationService : SessionVerificationService {
 
     fun givenVerificationFlowState(state: VerificationFlowState) {
         _verificationFlowState.value = state
+    }
+
+    fun givenCanVerifySession(canVerify: Boolean) {
+        _canVerifySessionFlow.value = canVerify
     }
 
     fun givenIsReady(value: Boolean) {


### PR DESCRIPTION
## Changes

This PR fixes 2 bugs:

1. The verification prompt won't be displayed after logging in: this is kind of a workaround, but I switched from listening to `RustSyncService.state()` to `RoomListService.state()`. For some reason, when RustSyncService emits a `Running` state, the verification controller is not ready to be used yet and the `RustVerificationService` can't be configured. In fact, it won't be retried until it changes sync state (error, stopped, then running again). This doesn't happen with `RoomListService.State`.
2. The 2 options to verify aren't displayed if the sync service isn't running, as they need it to work.

## Why

Fixes #1131 .