### PR TITLE
Improve timestamp rendering for poll event content

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
@@ -35,6 +35,5 @@ class TimelineItemEventForTimestampViewProvider : PreviewParameterProvider<Timel
                 localSendState = LocalEventSendState.SendingFailed("AN_ERROR"),
                 content = aTimelineItemTextContent().copy(isEdited = true),
             ),
-            //aTimelineItemEvent().copy(content = aTimelineItemPollContent()),
         )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
@@ -35,5 +35,6 @@ class TimelineItemEventForTimestampViewProvider : PreviewParameterProvider<Timel
                 localSendState = LocalEventSendState.SendingFailed("AN_ERROR"),
                 content = aTimelineItemTextContent().copy(isEdited = true),
             ),
+            //aTimelineItemEvent().copy(content = aTimelineItemPollContent()),
         )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -351,6 +351,7 @@ private fun MessageSenderInformation(
     }
 }
 
+@Suppress("")
 @Composable
 private fun MessageEventBubbleContent(
     event: TimelineItem.Event,
@@ -359,7 +360,7 @@ private fun MessageEventBubbleContent(
     onMessageLongClick: () -> Unit,
     inReplyToClick: () -> Unit,
     onTimestampClicked: () -> Unit,
-    modifier: Modifier = Modifier
+    bubbleModifier: Modifier = Modifier
 ) {
     val timestampPosition = when (event.content) {
         is TimelineItemImageContent,
@@ -480,7 +481,7 @@ private fun MessageEventBubbleContent(
         }
     }
 
-    CommonLayout(inReplyToDetails = replyToDetails, modifier = modifier)
+    CommonLayout(inReplyToDetails = replyToDetails, modifier = bubbleModifier)
 }
 
 @Composable

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -366,7 +366,7 @@ private fun MessageEventBubbleContent(
         is TimelineItemVideoContent,
         is TimelineItemLocationContent -> TimestampPosition.Above
         is TimelineItemPollContent -> TimestampPosition.Below
-        else -> TimestampPosition.Aligned
+        else -> TimestampPosition.Default
     }
     val replyToDetails = event.inReplyTo as? InReplyTo.Ready
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -364,7 +364,7 @@ private fun MessageEventBubbleContent(
     val timestampPosition = when (event.content) {
         is TimelineItemImageContent,
         is TimelineItemVideoContent,
-        is TimelineItemLocationContent -> TimestampPosition.Above
+        is TimelineItemLocationContent -> TimestampPosition.Overlay
         is TimelineItemPollContent -> TimestampPosition.Below
         else -> TimestampPosition.Default
     }
@@ -396,7 +396,7 @@ private fun MessageEventBubbleContent(
         timestampModifier: Modifier = Modifier,
     ) {
         when (timestampPosition) {
-            TimestampPosition.Above ->
+            TimestampPosition.Overlay ->
                 Box(modifier) {
                     ContentView(modifier = contentModifier)
                     TimelineEventTimestampView(
@@ -460,14 +460,14 @@ private fun MessageEventBubbleContent(
                             .clip(RoundedCornerShape(6.dp))
                             .clickable(enabled = true, onClick = inReplyToClick),
                     )
-                    if (timestampPosition == TimestampPosition.Above) {
+                    if (timestampPosition == TimestampPosition.Overlay) {
                         modifierWithPadding = Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
                         contentModifier = Modifier.clip(RoundedCornerShape(12.dp))
                     } else {
                         contentModifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 0.dp, bottom = 8.dp)
                     }
                 }
-                timestampPosition != TimestampPosition.Above -> {
+                timestampPosition != TimestampPosition.Overlay -> {
                     contentModifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 8.dp)
                 }
             }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.features.messages.impl.timeline.components
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -351,7 +352,6 @@ private fun MessageSenderInformation(
     }
 }
 
-@Suppress("")
 @Composable
 private fun MessageEventBubbleContent(
     event: TimelineItem.Event,
@@ -360,7 +360,7 @@ private fun MessageEventBubbleContent(
     onMessageLongClick: () -> Unit,
     inReplyToClick: () -> Unit,
     onTimestampClicked: () -> Unit,
-    bubbleModifier: Modifier = Modifier
+    @SuppressLint("ModifierParameter") bubbleModifier: Modifier = Modifier, // need to rename this modifier to distinguish it from the following ones
 ) {
     val timestampPosition = when (event.content) {
         is TimelineItemImageContent,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimestampPosition.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimestampPosition.kt
@@ -30,5 +30,12 @@ enum class TimestampPosition {
     /**
      * Timestamp should always be rendered below the timeline event content (eg. poll).
      */
-    Below,
+    Below;
+
+    companion object {
+        /**
+         * Default timestamp position for timeline event contents.
+         */
+        val Default: TimestampPosition = Aligned
+    }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimestampPosition.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimestampPosition.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.timeline.components
+
+enum class TimestampPosition {
+    /**
+     * Timestamp should be rendered above the timeline event content (eg. image).
+     */
+    Above,
+
+    /**
+     * Timestamp should be aligned with the timeline event content if this is possible (eg. text).
+     */
+    Aligned,
+
+    /**
+     * Timestamp should always be rendered below the timeline event content (eg. poll).
+     */
+    Below,
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimestampPosition.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimestampPosition.kt
@@ -18,9 +18,9 @@ package io.element.android.features.messages.impl.timeline.components
 
 enum class TimestampPosition {
     /**
-     * Timestamp should be rendered above the timeline event content (eg. image).
+     * Timestamp should overlay the timeline event content (eg. image).
      */
-    Above,
+    Overlay,
 
     /**
      * Timestamp should be aligned with the timeline event content if this is possible (eg. text).

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components_null_TimelineItemEventTimestampBelow_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components_null_TimelineItemEventTimestampBelow_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5af81e5f2081b949673c5f08282b5165eb7df4bb970c1db485376c86543e1a96
+size 57313


### PR DESCRIPTION
# Content

Added an enum `TimestampPosition` position to specify where the timestamp should be located for a message event in the timeline. Possible values are `Above`, `Aligned`, `Below`.
`Above` is the current behavior for media or location contents.
`Aligned` is the current behavior for text messages, the timestamp is aligned with the text if this is possible, or below otherwise.
`Below` is a new behavior forcing the timestamp to be placed at the bottom of the content.

I kept `Aligned` as the default position but it would probably make more sense to use `Below` instead.

# Motivation

Fix the overlap issue with poll contents in #1113 

# Screenshots

See screenshot files