### PR TITLE
Bump telephoto to 0.6.0-SNAPSHOT to diagnose crash

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ dependencycheck = "8.4.0"
 dependencyanalysis = "1.21.0"
 stem = "2.3.0"
 sqldelight = "1.5.5"
-telephoto = "0.5.0"
+telephoto = "0.6.0-SNAPSHOT"
 
 # DI
 dagger = "2.47"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = URI("https://oss.sonatype.org/content/repositories/snapshots/") }
         maven {
             url = URI("https://www.jitpack.io")
             content {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : bump library to have logs for [this issue](https://github.com/saket/telephoto/issues/41).

## Content

Bumped telephoto-coil to `v0.6.0-SNAPSHOT`.

## Motivation and context

I tried bumping the library and trying to reproduce the crash locally, but I wasn't able to do it, so maybe it's better to include the library in our beta version and record some logs from the testers.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
