### PR TITLE
Cleanup `LoggedInAppScopeFlowNode`

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/MainNode.kt
+++ b/app/src/main/kotlin/io/element/android/x/MainNode.kt
@@ -28,8 +28,8 @@ import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.plugin.Plugin
 import io.element.android.appnav.LoggedInAppScopeFlowNode
-import io.element.android.appnav.room.RoomLoadedFlowNode
 import io.element.android.appnav.RootFlowNode
+import io.element.android.appnav.room.RoomLoadedFlowNode
 import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.architecture.createNode
 import io.element.android.libraries.di.DaggerComponentOwner
@@ -45,15 +45,14 @@ class MainNode(
     buildContext: BuildContext,
     private val mainDaggerComponentOwner: MainDaggerComponentsOwner,
     plugins: List<Plugin>,
-) :
-    ParentNode<MainNode.RootNavTarget>(
-        navModel = PermanentNavModel(
-            navTargets = setOf(RootNavTarget),
-            savedStateMap = buildContext.savedStateMap,
-        ),
-        buildContext = buildContext,
-        plugins = plugins,
+) : ParentNode<MainNode.RootNavTarget>(
+    navModel = PermanentNavModel(
+        navTargets = setOf(RootNavTarget),
+        savedStateMap = buildContext.savedStateMap,
     ),
+    buildContext = buildContext,
+    plugins = plugins,
+),
     DaggerComponentOwner by mainDaggerComponentOwner {
 
     private val loggedInFlowNodeCallback = object : LoggedInAppScopeFlowNode.LifecycleCallback {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
`LoggedInAppScopeFlowNode` is just having one permanent child: `LoggedInFlowNode`. So no need to have a `Backstack` here, a `ParentNode` with `PermanentNavModel` is enough.

No need for a changelog entry I think.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Neat codebase, and maybe small perf. improvement.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Run the app, see the room list.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
