### PR TITLE
Make sure Snackbars are only displayed once

### DIFF
--- a/changelog.d/928.bugfix
+++ b/changelog.d/928.bugfix
@@ -1,0 +1,1 @@
+Make sure Snackbars are only displayed once.


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Made `SnackbarDispatcher.snackbarMessage` a shared flow instead of a state one.
- Added `SnackbarMessage.isDisplayed` property to check if the message is already being displayed.
- Clears the `SnackbarDispatcher` queue too when the coroutine displaying the current message is cancelled.

## Motivation and context

Fixes #928.

## Tests

<!-- Explain how you tested your development -->
In an unverified session:
- Go to Settings -> Complete verification.
- Finish the verification.
- See the snackbar being displayed.
- Go back to the room list. No snackbar should be displayed here.

An alternative test is to go to your home screen and then back to the app.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
