### PR TITLE
Bug reporter crashes when 'send logs' is disabled.

### DIFF
--- a/changelog.d/1168.bugfix
+++ b/changelog.d/1168.bugfix
@@ -1,0 +1,1 @@
+Bug reporter crashes when 'send logs' is disabled.

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
@@ -268,8 +268,9 @@ class DefaultBugReporter @Inject constructor(
                         }
                     }
 
-                    if (!uploadedSomeLogs) {
-                        error("Couldn't upload any logs")
+                    if (gzippedFiles.isNotEmpty() && !uploadedSomeLogs) {
+                        listener?.onUploadFailed("Couldn't upload any logs")
+                        return@withContext
                     }
 
                     mBugReportFiles.addAll(gzippedFiles)

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
@@ -268,12 +268,12 @@ class DefaultBugReporter @Inject constructor(
                         }
                     }
 
+                    mBugReportFiles.addAll(gzippedFiles)
+
                     if (gzippedFiles.isNotEmpty() && !uploadedSomeLogs) {
-                        listener?.onUploadFailed("Couldn't upload any logs")
+                        serverError = "Couldn't upload any logs, please retry."
                         return@withContext
                     }
-
-                    mBugReportFiles.addAll(gzippedFiles)
 
                     if (withScreenshot) {
                         screenshotHolder.getFileUri()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

When sending a but report if no logs are uploaded *and there were logs to upload*, the uploading process will stop with an error instead of crashing.

## Motivation and context

Fixes #1168 .

## Tests

- Open the bug reporter screen from settings.
- Disable 'allow logs'.
- Send the bug report.

If the app doesn't crash, this is fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
