### PR TITLE
Fix the orientation of sent images

### DIFF
--- a/changelog.d/1135.bugfix
+++ b/changelog.d/1135.bugfix
@@ -1,0 +1,1 @@
+Fix the orientation of sent images.

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/bitmap/Bitmap.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/bitmap/Bitmap.kt
@@ -22,7 +22,6 @@ import android.graphics.Matrix
 import androidx.core.graphics.scale
 import androidx.exifinterface.media.ExifInterface
 import java.io.File
-import java.io.InputStream
 import kotlin.math.min
 
 fun File.writeBitmap(bitmap: Bitmap, format: Bitmap.CompressFormat, quality: Int) {

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/bitmap/Bitmap.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/bitmap/Bitmap.kt
@@ -33,13 +33,6 @@ fun File.writeBitmap(bitmap: Bitmap, format: Bitmap.CompressFormat, quality: Int
 }
 
 /**
- * Reads the EXIF metadata from the [inputStream] and rotates the current [Bitmap] to match it.
- * @return The resulting [Bitmap] or `null` if no metadata was found.
- */
-fun Bitmap.rotateToMetadataOrientation(inputStream: InputStream): Result<Bitmap> =
-    runCatching { rotateToMetadataOrientation(this, ExifInterface(inputStream)) }
-
-/**
  * Scales the current [Bitmap] to fit the ([maxWidth], [maxHeight]) bounds while keeping aspect ratio.
  * @throws IllegalStateException if [maxWidth] or [maxHeight] <= 0.
  */
@@ -77,8 +70,11 @@ fun BitmapFactory.Options.calculateInSampleSize(desiredWidth: Int, desiredHeight
     return inSampleSize
 }
 
-private fun rotateToMetadataOrientation(bitmap: Bitmap, exifInterface: ExifInterface): Bitmap {
-    val orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+/**
+ * Decodes the [inputStream] into a [Bitmap] and applies the needed rotation based on [orientation].
+ * This orientation value must be one of `ExifInterface.ORIENTATION_*` constants.
+ */
+fun Bitmap.rotateToMetadataOrientation(orientation: Int): Bitmap {
     val matrix = Matrix()
     when (orientation) {
         ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
@@ -94,8 +90,8 @@ private fun rotateToMetadataOrientation(bitmap: Bitmap, exifInterface: ExifInter
             matrix.preRotate(90f)
             matrix.preScale(-1f, 1f)
         }
-        else -> return bitmap
+        else -> return this
     }
 
-    return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+    return Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
 }

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/ImageCompressor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/ImageCompressor.kt
@@ -19,6 +19,7 @@ package io.element.android.libraries.mediaupload
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import androidx.exifinterface.media.ExifInterface
 import io.element.android.libraries.androidutils.bitmap.calculateInSampleSize
 import io.element.android.libraries.androidutils.bitmap.resizeToMax
 import io.element.android.libraries.androidutils.bitmap.rotateToMetadataOrientation
@@ -44,7 +45,7 @@ class ImageCompressor @Inject constructor(
         inputStream: InputStream,
         resizeMode: ResizeMode,
         format: Bitmap.CompressFormat = Bitmap.CompressFormat.JPEG,
-        orientation: Int = 0,
+        orientation: Int = ExifInterface.ORIENTATION_UNDEFINED,
         desiredQuality: Int = 80,
     ): Result<ImageCompressionResult> = withContext(Dispatchers.IO) {
         runCatching {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Read `EXIF` metadata for orientation *before* decoding the bitmap, from another `InputStream`. This gives us a correct orientation value and should rotate the image to send as needed.

## Motivation and context

Fixes #1134 .

## Tests

<!-- Explain how you tested your development -->

On some devices, sending a picture that was just taken from the camera is enough. I couldn't reproduce this in my device, so the alternate solution I found was:

- Download https://github.com/recurser/exif-orientation-examples/blob/master/Landscape_3.jpg or any of the other samples.
- Send it through the 'photo & video library' option.
- Verify the image has the same orientation.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
