### PR TITLE
Protect `TimelineItemAspectRatioBox` against `Float.NaN`

### DIFF
--- a/changelog.d/1995.bugfix
+++ b/changelog.d/1995.bugfix
@@ -1,0 +1,1 @@
+Crash with `aspectRatio` modifier when `Float.NaN` was used as input.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemAspectRatioBox.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemAspectRatioBox.kt
@@ -37,8 +37,7 @@ fun TimelineItemAspectRatioBox(
     contentAlignment: Alignment = Alignment.TopStart,
     content: @Composable (BoxScope.() -> Unit),
 ) {
-    val safeAspectRatio = (aspectRatio.takeIf { it?.isFinite() == true } ?: DEFAULT_ASPECT_RATIO)
-        .coerceIn(MIN_ASPECT_RATIO, MAX_ASPECT_RATIO)
+    val safeAspectRatio = (aspectRatio ?: DEFAULT_ASPECT_RATIO).coerceIn(MIN_ASPECT_RATIO, MAX_ASPECT_RATIO)
     Box(
         modifier = modifier
             .heightIn(max = MAX_HEIGHT_IN_DP.dp)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemAspectRatioBox.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemAspectRatioBox.kt
@@ -37,7 +37,8 @@ fun TimelineItemAspectRatioBox(
     contentAlignment: Alignment = Alignment.TopStart,
     content: @Composable (BoxScope.() -> Unit),
 ) {
-    val safeAspectRatio = (aspectRatio ?: DEFAULT_ASPECT_RATIO).coerceIn(MIN_ASPECT_RATIO, MAX_ASPECT_RATIO)
+    val safeAspectRatio = (aspectRatio.takeIf { it?.isFinite() == true } ?: DEFAULT_ASPECT_RATIO)
+        .coerceIn(MIN_ASPECT_RATIO, MAX_ASPECT_RATIO)
     Box(
         modifier = modifier
             .heightIn(max = MAX_HEIGHT_IN_DP.dp)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -132,10 +132,12 @@ class TimelineItemContentMessageFactory @Inject constructor(
     }
 
     private fun aspectRatioOf(width: Long?, height: Long?): Float? {
-        return if (height != null && width != null) {
+        val result = if (height != null && width != null) {
             width.toFloat() / height.toFloat()
         } else {
             null
         }
+
+        return result?.takeIf { it.isFinite() }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Makes sure we don't accept `Float.NaN` or `Float.INFINITE` as input for the `aspectRatio` modifier.

## Motivation and context

Fixes #1195.

## Tests

<!-- Explain how you tested your development -->

It's difficult to test, but you could go to `TimelineItemImageView` and switch the passed `content.aspectRatio` value to `Float.NaN` or `Float.INFINITE`, then take a look at an image in the timeline.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
