### PR TITLE
Remove the log, was causing a crash.

### DIFF
--- a/libraries/permissions/impl/src/main/kotlin/io/element/android/libraries/permissions/impl/DefaultPermissionsPresenter.kt
+++ b/libraries/permissions/impl/src/main/kotlin/io/element/android/libraries/permissions/impl/DefaultPermissionsPresenter.kt
@@ -124,9 +124,7 @@ class DefaultPermissionsPresenter @AssistedInject constructor(
             permissionAlreadyAsked = isAlreadyAsked,
             permissionAlreadyDenied = isAlreadyDenied,
             eventSink = ::handleEvents
-        ).also {
-            Timber.tag(loggerTag.value).d("New state: $it")
-        }
+        )
     }
 
     /*


### PR DESCRIPTION
kotlin.reflect.jvm.internal.KotlinReflectionInternalError: Function 'handleEvents' (JVM signature: present$handleEvents(Landroidx/compose/runtime/MutableState;Lkotlin/jvm/internal/Ref$ObjectRef;Lio/element/android/libraries/permissions/api/PermissionsEvents;)V) not resolved in class kotlin.jvm.internal.Intrinsics$Kotlin: no members found
    at kotlin.reflect.jvm.internal.KDeclarationContainerImpl.findFunctionDescriptor(KDeclarationContainerImpl.kt:131)
    at kotlin.reflect.jvm.internal.KFunctionImpl$descriptor$2.invoke(KFunctionImpl.kt:56)
    at kotlin.reflect.jvm.internal.KFunctionImpl$descriptor$2.invoke(KFunctionImpl.kt:55)
    at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:93)
    at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
    at kotlin.reflect.jvm.internal.KFunctionImpl.getDescriptor(KFunctionImpl.kt:55)
    at kotlin.reflect.jvm.internal.KFunctionImpl.toString(KFunctionImpl.kt:185)
    at kotlin.jvm.internal.FunctionReference.toString(FunctionReference.java:130)
    at java.lang.String.valueOf(String.java:4092)
    at java.lang.StringBuilder.append(StringBuilder.java:179)
    at io.element.android.libraries.permissions.api.PermissionsState.toString
    at java.lang.String.valueOf(String.java:4092)
    at java.lang.StringBuilder.append(StringBuilder.java:179)
    at io.element.android.libraries.permissions.impl.DefaultPermissionsPresenter.present(DefaultPermissionsPresenter.kt:128)

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Fix crash https://sentry.tools.element.io/organizations/element/issues/85090

Not sure how the crash is occurring only now, but no need to investigate more I guess.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Stable app.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
