### PR TITLE
Feature/bma/notification decryption

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -60,6 +60,7 @@ import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.MAIN_SPACE
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.sync.StartSyncReason
 import io.element.android.libraries.matrix.api.sync.SyncState
 import io.element.android.libraries.push.api.notifications.NotificationDrawerManager
 import io.element.android.services.appnavstate.api.AppNavigationStateService
@@ -124,7 +125,7 @@ class LoggedInFlowNode @AssistedInject constructor(
             onStop = {
                 //Counterpart startSync is done in observeSyncStateAndNetworkStatus method.
                 coroutineScope.launch {
-                    syncService.stopSync()
+                    syncService.stopSync(StartSyncReason.AppInForeground)
                 }
             },
             onDestroy = {
@@ -150,7 +151,7 @@ class LoggedInFlowNode @AssistedInject constructor(
                     .collect { (syncState, networkStatus) ->
                         Timber.d("Sync state: $syncState, network status: $networkStatus")
                         if (syncState != SyncState.Running && networkStatus == NetworkStatus.Online) {
-                            syncService.startSync()
+                            syncService.startSync(StartSyncReason.AppInForeground)
                         }
                     }
             }

--- a/changelog.d/1178.bugfix
+++ b/changelog.d/1178.bugfix
@@ -1,0 +1,1 @@
+Ensure notification for Event from encrypted room get decrypted content.

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/sync/StartSyncReason.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/sync/StartSyncReason.kt
@@ -16,21 +16,10 @@
 
 package io.element.android.libraries.matrix.api.sync
 
-import kotlinx.coroutines.flow.StateFlow
+import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.matrix.api.core.RoomId
 
-interface SyncService {
-    /**
-     * Tries to start the sync. If already syncing it has no effect.
-     */
-    suspend fun startSync(reason: StartSyncReason): Result<Unit>
-
-    /**
-     * Tries to stop the sync. If service is not syncing it has no effect.
-     */
-    suspend fun stopSync(reason: StartSyncReason): Result<Unit>
-
-    /**
-     * Flow of [SyncState]. Will be updated as soon as the current [SyncState] changes.
-     */
-    val syncState: StateFlow<SyncState>
+sealed interface StartSyncReason {
+    data object AppInForeground : StartSyncReason
+    data class Notification(val roomId: RoomId, val eventId: EventId) : StartSyncReason
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/sync/FakeSyncService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/sync/FakeSyncService.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.libraries.matrix.test.sync
 
+import io.element.android.libraries.matrix.api.sync.StartSyncReason
 import io.element.android.libraries.matrix.api.sync.SyncService
 import io.element.android.libraries.matrix.api.sync.SyncState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,12 +30,12 @@ class FakeSyncService : SyncService {
         syncStateFlow.value = SyncState.Error
     }
 
-    override suspend fun startSync(): Result<Unit> {
+    override suspend fun startSync(reason: StartSyncReason): Result<Unit> {
         syncStateFlow.value = SyncState.Running
         return Result.success(Unit)
     }
 
-    override suspend fun stopSync(): Result<Unit> {
+    override suspend fun stopSync(reason: StartSyncReason): Result<Unit> {
         syncStateFlow.value = SyncState.Terminated
         return Result.success(Unit)
     }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
@@ -26,6 +26,7 @@ import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.notification.NotificationContent
 import io.element.android.libraries.matrix.api.notification.NotificationData
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
+import io.element.android.libraries.matrix.api.sync.StartSyncReason
 import io.element.android.libraries.matrix.api.timeline.item.event.AudioMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.EmoteMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.FileMessageType
@@ -44,6 +45,7 @@ import io.element.android.libraries.push.impl.notifications.model.NotifiableMess
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.services.toolbox.api.strings.StringProvider
 import io.element.android.services.toolbox.api.systemclock.SystemClock
+import kotlinx.coroutines.delay
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -65,6 +67,14 @@ class NotifiableEventResolver @Inject constructor(
         // Restore session
         val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: return null
         val notificationService = client.notificationService()
+
+        // Restart the sync service to ensure that the crypto sync handle the toDevice Events.
+        client.syncService().startSync(StartSyncReason.Notification(roomId, eventId))
+        // Wait for toDevice Event to be processed
+        // FIXME This delay can be removed when the Rust SDK will handle internal retry to get
+        //  clear notification content.
+        delay(300)
+
         val notificationData = notificationService.getNotification(
             userId = sessionId,
             roomId = roomId,
@@ -72,6 +82,8 @@ class NotifiableEventResolver @Inject constructor(
         ).onFailure {
             Timber.tag(loggerTag.value).e(it, "Unable to resolve event: $eventId.")
         }.getOrNull()
+
+        client.syncService().stopSync(StartSyncReason.Notification(roomId, eventId))
 
         // TODO this notificationData is not always valid at the moment, sometimes the Rust SDK can't fetch the matching event
         return notificationData?.asNotifiableEvent(sessionId)

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
@@ -39,6 +39,7 @@ import io.element.android.libraries.eventformatter.impl.StateContentFormatter
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
+import io.element.android.libraries.matrix.api.sync.StartSyncReason
 import io.element.android.services.toolbox.impl.strings.AndroidStringProvider
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -109,12 +110,12 @@ class RoomListScreen(
         DisposableEffect(Unit) {
             Timber.w("Start sync!")
             runBlocking {
-                matrixClient.syncService().startSync()
+                matrixClient.syncService().startSync(StartSyncReason.AppInForeground)
             }
             onDispose {
                 Timber.w("Stop sync!")
                 runBlocking {
-                    matrixClient.syncService().stopSync()
+                    matrixClient.syncService().stopSync(StartSyncReason.AppInForeground)
                 }
             }
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Ensure that the sync service is started when handling a Push.

Add to implement a `reason`, to ensure that we call `syncService.stop()` only when no code is using it.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #1178 

## Screenshots / GIFs

NA

## Tests

<!-- Explain how you tested your development -->

From https://github.com/vector-im/element-x-android/issues/1178#issuecomment-1702485220:

- Alice and Bob in room. Bob is using EAX
- bob kills EAX
- Alice rotates their megolm keys by typing '/discardsession' in this room
- Alice sends a message
- Bob should see the notification decrypted on their android device

With this change, Bob can see the message in the notification.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
