### PR TITLE
Fix system bar color after login on light theme.

### DIFF
--- a/changelog.d/1222.bugfix
+++ b/changelog.d/1222.bugfix
@@ -1,0 +1,1 @@
+Fix system bar color after login on light theme.

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/SunsetPage.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/SunsetPage.kt
@@ -44,6 +44,7 @@ import io.element.android.libraries.designsystem.text.withColoredPeriod
 import io.element.android.libraries.designsystem.theme.components.CircularProgressIndicator
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.theme.ElementTheme
+import io.element.android.libraries.theme.ForcedDarkElementTheme
 
 @Composable
 fun SunsetPage(
@@ -53,9 +54,7 @@ fun SunsetPage(
     modifier: Modifier = Modifier,
     overallContent: @Composable () -> Unit,
 ) {
-    ElementTheme(
-        darkTheme = true
-    ) {
+    ForcedDarkElementTheme(lightStatusBar = true) {
         Box(
             modifier = modifier.fillMaxSize()
         ) {

--- a/libraries/theme/src/main/kotlin/io/element/android/libraries/theme/ElementTheme.kt
+++ b/libraries/theme/src/main/kotlin/io/element/android/libraries/theme/ElementTheme.kt
@@ -92,6 +92,7 @@ internal val LocalCompoundColors = staticCompositionLocalOf { compoundColorsLigh
 @Composable
 fun ElementTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    lightStatusBar: Boolean = !darkTheme,
     dynamicColor: Boolean = false, /* true to enable MaterialYou */
     compoundColors: SemanticColors = if (darkTheme) compoundColorsDark else compoundColorsLight,
     materialLightColors: ColorScheme = materialColorSchemeLight,
@@ -111,8 +112,19 @@ fun ElementTheme(
         darkTheme -> materialDarkColors
         else -> materialLightColors
     }
+    val statusBarColorScheme = if (lightStatusBar) {
+        when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                dynamicLightColorScheme(context)
+            }
+            else -> materialLightColors
+        }
+    } else {
+        colorScheme
+    }
     SideEffect {
-        systemUiController.applyTheme(colorScheme = colorScheme, darkTheme = darkTheme)
+        systemUiController.applyTheme(colorScheme = statusBarColorScheme, darkTheme = darkTheme && !lightStatusBar)
     }
     CompositionLocalProvider(
         LocalCompoundColors provides currentCompoundColor,
@@ -132,6 +144,7 @@ fun ElementTheme(
  */
 @Composable
 fun ForcedDarkElementTheme(
+    lightStatusBar: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val systemUiController = rememberSystemUiController()
@@ -142,7 +155,7 @@ fun ForcedDarkElementTheme(
             systemUiController.applyTheme(colorScheme, wasDarkTheme)
         }
     }
-    ElementTheme(darkTheme = true, content = content)
+    ElementTheme(darkTheme = true, lightStatusBar = lightStatusBar, content = content)
 }
 
 private fun SystemUiController.applyTheme(


### PR DESCRIPTION
Actually for the SunsetPage, we need a light status bar.

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Ensure the status bar is displayed with a SunsetPage in dark theme. This page is a bit special because the top of the screen is white, and the bottom is Black.

Also ensure that in Light theme, the status bar is correctly reset for the following screens.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #1222 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

1. Connect to an account
2. Set the phone to light mode
3. Play with the clear cache developer option to see the FTUE sequence, watching the status bar colors.
4. Set the phone to dark mode
5. repeat 3 

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
