### PR TITLE
Fix crash in error tracking

### DIFF
--- a/changelog.d/1248.bugfix
+++ b/changelog.d/1248.bugfix
@@ -1,0 +1,1 @@
+Fix crash in error tracking

--- a/services/analyticsproviders/posthog/src/main/kotlin/io/element/android/services/analyticsproviders/posthog/PosthogAnalyticsProvider.kt
+++ b/services/analyticsproviders/posthog/src/main/kotlin/io/element/android/services/analyticsproviders/posthog/PosthogAnalyticsProvider.kt
@@ -71,7 +71,7 @@ class PosthogAnalyticsProvider @Inject constructor(
     }
 
     override fun trackError(throwable: Throwable) {
-        TODO("Not yet implemented")
+        // Not implemented
     }
 
     private fun createPosthog(): PostHog = postHogFactory.createPosthog()


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Remove unnecessary `TODO()` which causes a crash.

## Motivation and context

Fix crash when calling `DefaultAnalyticsService.trackError()`.

Note that this crash does not currently surface as no components are calling `trackError()` however the Rich Text Editor will do.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
 N/A

## Tests

<!-- Explain how you tested your development -->

N/A

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
