### PR TITLE
Take screen density into account when requesting thumbnails

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.libraries.matrix.ui.media
 
+import android.content.Context
 import coil.ImageLoader
 import coil.decode.DataSource
 import coil.decode.ImageSource
@@ -32,8 +33,10 @@ import okio.Buffer
 import okio.Path.Companion.toOkioPath
 import timber.log.Timber
 import java.nio.ByteBuffer
+import kotlin.math.roundToLong
 
 internal class CoilMediaFetcher(
+    private val context: Context,
     private val mediaLoader: MatrixMediaLoader,
     private val mediaData: MediaRequestData?,
     private val options: Options
@@ -78,10 +81,11 @@ internal class CoilMediaFetcher(
     }
 
     private suspend fun fetchThumbnail(mediaSource: MediaSource, kind: MediaRequestData.Kind.Thumbnail, options: Options): FetchResult? {
+        val density = context.resources.displayMetrics.density
         return mediaLoader.loadMediaThumbnail(
             source = mediaSource,
-            width = kind.width,
-            height = kind.height
+            width = (kind.width.toFloat() * density).roundToLong(),
+            height = (kind.height.toFloat() * density).roundToLong(),
         ).map { byteArray ->
             byteArray.asSourceResult(options)
         }.getOrNull()
@@ -102,6 +106,7 @@ internal class CoilMediaFetcher(
     }
 
     class MediaRequestDataFactory(
+        private val context: Context,
         private val client: MatrixClient
     ) :
         Fetcher.Factory<MediaRequestData> {
@@ -111,6 +116,7 @@ internal class CoilMediaFetcher(
             imageLoader: ImageLoader
         ): Fetcher {
             return CoilMediaFetcher(
+                context = context,
                 mediaLoader = client.mediaLoader,
                 mediaData = data,
                 options = options
@@ -119,6 +125,7 @@ internal class CoilMediaFetcher(
     }
 
     class AvatarFactory(
+        private val context: Context,
         private val client: MatrixClient
     ) :
         Fetcher.Factory<AvatarData> {
@@ -129,6 +136,7 @@ internal class CoilMediaFetcher(
             imageLoader: ImageLoader
         ): Fetcher {
             return CoilMediaFetcher(
+                context = context,
                 mediaLoader = client.mediaLoader,
                 mediaData = data.toMediaRequestData(),
                 options = options

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/ImageLoaderFactories.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/ImageLoaderFactories.kt
@@ -46,8 +46,8 @@ class LoggedInImageLoaderFactory @Inject constructor(
                 }
                 add(AvatarDataKeyer())
                 add(MediaRequestDataKeyer())
-                add(CoilMediaFetcher.AvatarFactory(matrixClient))
-                add(CoilMediaFetcher.MediaRequestDataFactory(matrixClient))
+                add(CoilMediaFetcher.AvatarFactory(context, matrixClient))
+                add(CoilMediaFetcher.MediaRequestDataFactory(context, matrixClient))
             }
             .build()
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Have `CoilMediaFetcher` calculate the right size to ask for thumbnails using the screen density.

## Motivation and context

Fixes issues seen with blurry avatars on some homeservers.

## Screenshots / GIFs

|Before|After|
|-|-|
|![image](https://github.com/vector-im/element-x-android/assets/480955/fbe24b1c-9e78-4bc3-bf2b-48429ce3c91d)|![image](https://github.com/vector-im/element-x-android/assets/480955/38ce371e-0b0a-45f9-8455-f88c148647b3)|

## Tests

- Log in to `element.io`.
- Check avatar images.

They should look a lot shaper.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
