### PR TITLE
Make sure notification permission screen is dismissed

### DIFF
--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInPresenter.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInPresenter.kt
@@ -32,7 +32,6 @@ import io.element.android.libraries.permissions.noop.NoopPermissionsPresenter
 import io.element.android.services.toolbox.api.sdk.BuildVersionSdkIntProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class NotificationsOptInPresenter @AssistedInject constructor(
     private val permissionsPresenterFactory: PermissionsPresenter.Factory,

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInView.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInView.kt
@@ -64,12 +64,6 @@ fun NotificationsOptInView(
 ) {
     BackHandler(onBack = onBack)
 
-    if (state.notificationsPermissionState.permissionAlreadyDenied) {
-        LaunchedEffect(Unit) {
-            state.eventSink(NotificationsOptInEvents.NotNowClicked)
-        }
-    }
-
     HeaderFooterPage(
         modifier = modifier
             .systemBarsPadding()

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInView.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInView.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Listens to the permission granted / denied changes in `NotificationsOptInPresenter`.

## Motivation and context

While testing some other PRs I noticed I sometimes wasn't getting past the notification permission screen after granting the permissions, I had to tap on the 'Ok' button again.

## Tests

Using an Android 13 device/emulator:

1. Clear the app data.
2. Log into any account.
3. Accept the notification permissions when prompted.
4. Make sure the screen is exited at that point, with no further interactions needed.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
