### PR TITLE
Update analytics sdk to v0.8.0

### DIFF
--- a/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/send/SendLocationPresenter.kt
+++ b/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/send/SendLocationPresenter.kt
@@ -26,10 +26,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import im.vector.app.features.analytics.plan.Composer
 import io.element.android.features.location.impl.common.MapDefaults
+import io.element.android.features.location.impl.common.actions.LocationActions
 import io.element.android.features.location.impl.common.permissions.PermissionsEvents
 import io.element.android.features.location.impl.common.permissions.PermissionsPresenter
 import io.element.android.features.location.impl.common.permissions.PermissionsState
-import io.element.android.features.location.impl.common.actions.LocationActions
 import io.element.android.features.messages.api.MessageComposerContext
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.core.meta.BuildMeta
@@ -119,9 +119,8 @@ class SendLocationPresenter @Inject constructor(
                     Composer(
                         inThread = messageComposerContext.composerMode.inThread,
                         isEditing = messageComposerContext.composerMode.isEditing,
-                        isLocation = true,
                         isReply = messageComposerContext.composerMode.isReply,
-                        locationType = Composer.LocationType.PinDrop,
+                        messageType = Composer.MessageType.LocationPin,
                     )
                 )
             }
@@ -138,9 +137,8 @@ class SendLocationPresenter @Inject constructor(
                     Composer(
                         inThread = messageComposerContext.composerMode.inThread,
                         isEditing = messageComposerContext.composerMode.isEditing,
-                        isLocation = true,
                         isReply = messageComposerContext.composerMode.isReply,
-                        locationType = Composer.LocationType.MyLocation,
+                        messageType = Composer.MessageType.LocationUser,
                     )
                 )
             }

--- a/features/location/impl/src/test/kotlin/io/element/android/features/location/impl/send/SendLocationPresenterTest.kt
+++ b/features/location/impl/src/test/kotlin/io/element/android/features/location/impl/send/SendLocationPresenterTest.kt
@@ -308,9 +308,8 @@ class SendLocationPresenterTest {
                 Composer(
                     inThread = false,
                     isEditing = false,
-                    isLocation = true,
                     isReply = false,
-                    locationType = Composer.LocationType.MyLocation,
+                    messageType = Composer.MessageType.LocationUser,
                 )
             )
         }
@@ -365,9 +364,8 @@ class SendLocationPresenterTest {
                 Composer(
                     inThread = false,
                     isEditing = false,
-                    isLocation = true,
                     isReply = false,
-                    locationType = Composer.LocationType.PinDrop,
+                    messageType = Composer.MessageType.LocationPin,
                 )
             )
         }
@@ -412,9 +410,8 @@ class SendLocationPresenterTest {
                 Composer(
                     inThread = false,
                     isEditing = true,
-                    isLocation = true,
                     isReply = false,
-                    locationType = Composer.LocationType.PinDrop,
+                    messageType = Composer.MessageType.LocationPin,
                 )
             )
         }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -153,7 +153,7 @@ class MessageComposerPresenter @Inject constructor(
                             inThread = messageComposerContext.composerMode.inThread,
                             isEditing = messageComposerContext.composerMode.isEditing,
                             isReply = messageComposerContext.composerMode.isReply,
-                            isLocation = false,
+                            messageType = Composer.MessageType.Text,
                         )
                     )
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -169,7 +169,7 @@ maplibre_annotation = "org.maplibre.gl:android-plugin-annotation-v9:2.0.1"
 # Analytics
 posthog = "com.posthog.android:posthog:2.0.3"
 sentry = "io.sentry:sentry-android:6.29.0"
-matrix_analytics_events = "com.github.matrix-org:matrix-analytics-events:42b2faa417c1e95f430bf8f6e379adba25ad5ef8"
+matrix_analytics_events = "com.github.matrix-org:matrix-analytics-events:e9cd9adaf18cec52ed851395eb84358b4f9b8d7f"
 
 # Emojibase
 matrix_emojibase_bindings = "io.element.android:emojibase-bindings:1.1.3"


### PR DESCRIPTION
Integrates a few breaking changes introducing a `messageType` Composer prop:
- Sends `messageType` = Text by default in composer.
- Refactors existing location analytics to send the appropriate `messageType`.
