### PR TITLE
Send composer analytics when sending a message

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -148,14 +148,6 @@ class MessageComposerPresenter @Inject constructor(
                 )
                 is MessageComposerEvents.SetMode -> {
                     messageComposerContext.composerMode = event.composerMode
-                    analyticsService.capture(
-                        Composer(
-                            inThread = messageComposerContext.composerMode.inThread,
-                            isEditing = messageComposerContext.composerMode.isEditing,
-                            isReply = messageComposerContext.composerMode.isReply,
-                            messageType = Composer.MessageType.Text,
-                        )
-                    )
                 }
                 MessageComposerEvents.AddAttachment -> localCoroutineScope.launch {
                     showAttachmentSourcePicker = true
@@ -238,6 +230,14 @@ class MessageComposerPresenter @Inject constructor(
                 message.html,
             )
         }
+        analyticsService.capture(
+            Composer(
+                inThread = capturedMode.inThread,
+                isEditing = capturedMode.isEditing,
+                isReply = capturedMode.isReply,
+                messageType = Composer.MessageType.Text, // Set proper type when we'll be sending other types of messages.
+            )
+        )
     }
 
     private fun CoroutineScope.sendAttachment(


### PR DESCRIPTION
Composer event are not sent to posthog when sending messages.

After investigation I've found that in `MessageComposerPresenter` the `analyticsService.capture()` call is invoked in the `SetMode` event handler rather than in the `SendMessage` event handler.

This change should result in the desired behavior.