### PR TITLE
Fix top padding in room list when app is opened in offline mode

### DIFF
--- a/changelog.d/1297.bugfix
+++ b/changelog.d/1297.bugfix
@@ -1,0 +1,1 @@
+Fix top padding in room list when app is opened in offline mode.

--- a/features/networkmonitor/api/src/main/kotlin/io/element/android/features/networkmonitor/api/ui/ConnectivityIndicatorView.kt
+++ b/features/networkmonitor/api/src/main/kotlin/io/element/android/features/networkmonitor/api/ui/ConnectivityIndicatorView.kt
@@ -109,7 +109,9 @@ fun ConnectivityIndicatorContainer(
     } else {
         WindowInsets.statusBars.asPaddingValues().calculateTopPadding() + 6.dp
     }
-    val target = remember(isOnline) { if (isOnline) 0.dp else statusBarTopPadding }
+    val target = remember(isIndicatorVisible.targetState, statusBarTopPadding) {
+        if (!isIndicatorVisible.targetState) 0.dp else statusBarTopPadding
+    }
     val animationStateOffset by animateDpAsState(
         targetValue = target,
         animationSpec = spring(

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/Bloom.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/Bloom.kt
@@ -363,6 +363,7 @@ fun Modifier.avatarBloom(
             blurSize = blurSize,
             offset = offset,
             clipToSize = clipToSize,
+            bottomSoftEdgeColor = bottomSoftEdgeColor,
             bottomSoftEdgeHeight = bottomSoftEdgeHeight,
             bottomSoftEdgeAlpha = bottomSoftEdgeAlpha,
             alpha = alpha,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Takes into account changing status bar padding values when calculating the animation.

## Motivation and context

Fixes #1297.

## Screenshots / GIFs

https://github.com/vector-im/element-x-android/assets/480955/c0c4dad2-c9e1-4186-8b07-f1c534753d6a

## Tests

<!-- Explain how you tested your development -->

- Set the phone in airplane mode.
- Start the app.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
