### PR TITLE
Fix long click on simple formatted messages

### DIFF
--- a/changelog.d/1232.bugfix
+++ b/changelog.d/1232.bugfix
@@ -1,0 +1,1 @@
+Fix long click on simple formatted messages

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/html/HtmlDocument.kt
@@ -126,7 +126,12 @@ private fun HtmlBody(
             when (val node = nodes.next()) {
                 is TextNode -> {
                     if (!node.isBlank) {
-                        ClickableLinkText(text = node.text(), interactionSource = interactionSource)
+                        ClickableLinkText(
+                            text = node.text(),
+                            interactionSource = interactionSource,
+                            onClick = onTextClicked,
+                            onLongClick = onTextLongClicked,
+                        )
                     }
                 }
                 is Element -> {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Forward the right `onClick` and `onLongClick` actions to the default `ClickableLinkText` inside `HtmlDocument`, used for simple formatted messages (formatted as in having a `formatted_body`, that is, HTML content).

## Motivation and context

Should fix #1232.

## Tests

<!-- Explain how you tested your development -->

- Try long pressing different messages: simple text messages, messages written with the rich text editor (HTML content), messages with links...

Previously some of those were working if you long pressed on some places without text, not they should work while long pressing in the middle of some texts.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
