### PR TITLE
Remove suppressUnsupportedCompileSdk

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -56,6 +56,3 @@ android.experimental.enableTestFixtures=true
 
 # Create BuildConfig files as bytecode to avoid Java compilation phase
 android.enableBuildConfigAsBytecode=true
-
-# This should be removed after upgrading to AGP 8.1.0
-android.suppressUnsupportedCompileSdk=34


### PR DESCRIPTION
We're now an AGP 8.1.0 so should be safe to remove as per the comment.
