### PR TITLE
Fix RoomSummary: RoomListEntry.Invalidated 

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessor.kt
@@ -110,7 +110,7 @@ class RoomSummaryListProcessor(
             RoomListEntry.Empty -> buildEmptyRoomSummary()
             is RoomListEntry.Filled -> buildAndCacheRoomSummaryForIdentifier(entry.roomId)
             is RoomListEntry.Invalidated -> {
-                roomSummariesByIdentifier[entry.roomId] ?: buildEmptyRoomSummary()
+                roomSummariesByIdentifier[entry.roomId] ?: buildAndCacheRoomSummaryForIdentifier(entry.roomId)
             }
         }
     }


### PR DESCRIPTION
Currently the Invalidated case was trying to get from memory cache or was defaulting to empty, resulting in slowness when opening the app. 
Now it correctly try to build the RoomSummary and fallback to empty.