### PR TITLE
Properly format lastMessage when it belongs to a poll.

### DIFF
--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
@@ -96,7 +96,8 @@ class DefaultRoomLastMessageFormatter @Inject constructor(
                 stateContentFormatter.format(content, senderDisplayName, isOutgoing, RenderingMode.RoomList)
             }
             is PollContent -> {
-                prefixIfNeeded(content.question, senderDisplayName, isDmRoom)
+                val message = sp.getString(CommonStrings.common_poll_summary, content.question)
+                prefixIfNeeded(message, senderDisplayName, isDmRoom)
             }
             is FailedToParseMessageLikeContent, is FailedToParseStateContent, is UnknownContent -> {
                 prefixIfNeeded(sp.getString(CommonStrings.common_unsupported_event), senderDisplayName, isDmRoom)

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
@@ -95,7 +95,9 @@ class DefaultRoomLastMessageFormatter @Inject constructor(
             is StateContent -> {
                 stateContentFormatter.format(content, senderDisplayName, isOutgoing, RenderingMode.RoomList)
             }
-            is PollContent, // TODO Polls: handle last message
+            is PollContent -> {
+                prefixIfNeeded(content.question, senderDisplayName, isDmRoom)
+            }
             is FailedToParseMessageLikeContent, is FailedToParseStateContent, is UnknownContent -> {
                 prefixIfNeeded(sp.getString(CommonStrings.common_unsupported_event), senderDisplayName, isDmRoom)
             }

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTests.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTests.kt
@@ -48,6 +48,7 @@ import io.element.android.libraries.matrix.api.timeline.item.event.UnknownMessag
 import io.element.android.libraries.matrix.api.timeline.item.event.VideoMessageType
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.FakeMatrixClient
+import io.element.android.libraries.matrix.test.room.aPollContent
 import io.element.android.libraries.matrix.test.room.aProfileChangeMessageContent
 import io.element.android.libraries.matrix.test.room.anEventTimelineItem
 import io.element.android.services.toolbox.impl.strings.AndroidStringProvider
@@ -153,7 +154,7 @@ class DefaultRoomLastMessageFormatterTests {
     fun `Message contents`() {
         val body = "Shared body"
         fun createMessageContent(type: MessageType): MessageContent {
-            return MessageContent(body, null, false, false,type)
+            return MessageContent(body, null, false, false, type)
         }
 
         val sharedContentMessagesTypes = arrayOf(
@@ -760,6 +761,34 @@ class DefaultRoomLastMessageFormatterTests {
         val sameContentEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = sameContent)
         val sameMessage = formatter.format(sameContentEvent, false)
         Truth.assertThat(sameMessage).isNull()
+    }
+
+    // endregion
+
+    // region Polls
+
+    @Test
+    @Config(qualifiers = "en")
+    fun `Computes last message for poll in DM`() {
+        val pollContent = aPollContent()
+
+        val mineContentEvent = createRoomEvent(sentByYou = true, senderDisplayName = "Alice", content = pollContent)
+        Truth.assertThat(formatter.format(mineContentEvent, true)).isEqualTo("Do you like polls?")
+
+        val contentEvent = createRoomEvent(sentByYou = false, senderDisplayName = "Bob", content = pollContent)
+        Truth.assertThat(formatter.format(contentEvent, true)).isEqualTo("Do you like polls?")
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    fun `Computes last message for poll in room`() {
+        val pollContent = aPollContent()
+
+        val mineContentEvent = createRoomEvent(sentByYou = true, senderDisplayName = "Alice", content = pollContent)
+        Truth.assertThat(formatter.format(mineContentEvent, false).toString()).isEqualTo("Alice: Do you like polls?")
+
+        val contentEvent = createRoomEvent(sentByYou = false, senderDisplayName = "Bob", content = pollContent)
+        Truth.assertThat(formatter.format(contentEvent, false).toString()).isEqualTo("Bob: Do you like polls?")
     }
 
     // endregion

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTests.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTests.kt
@@ -773,10 +773,10 @@ class DefaultRoomLastMessageFormatterTests {
         val pollContent = aPollContent()
 
         val mineContentEvent = createRoomEvent(sentByYou = true, senderDisplayName = "Alice", content = pollContent)
-        Truth.assertThat(formatter.format(mineContentEvent, true)).isEqualTo("Do you like polls?")
+        Truth.assertThat(formatter.format(mineContentEvent, true)).isEqualTo("Poll: Do you like polls?")
 
         val contentEvent = createRoomEvent(sentByYou = false, senderDisplayName = "Bob", content = pollContent)
-        Truth.assertThat(formatter.format(contentEvent, true)).isEqualTo("Do you like polls?")
+        Truth.assertThat(formatter.format(contentEvent, true)).isEqualTo("Poll: Do you like polls?")
     }
 
     @Test
@@ -785,10 +785,10 @@ class DefaultRoomLastMessageFormatterTests {
         val pollContent = aPollContent()
 
         val mineContentEvent = createRoomEvent(sentByYou = true, senderDisplayName = "Alice", content = pollContent)
-        Truth.assertThat(formatter.format(mineContentEvent, false).toString()).isEqualTo("Alice: Do you like polls?")
+        Truth.assertThat(formatter.format(mineContentEvent, false).toString()).isEqualTo("Alice: Poll: Do you like polls?")
 
         val contentEvent = createRoomEvent(sentByYou = false, senderDisplayName = "Bob", content = pollContent)
-        Truth.assertThat(formatter.format(contentEvent, false).toString()).isEqualTo("Bob: Do you like polls?")
+        Truth.assertThat(formatter.format(contentEvent, false).toString()).isEqualTo("Bob: Poll: Do you like polls?")
     }
 
     // endregion

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTests.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTests.kt
@@ -59,6 +59,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
+@Suppress("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 class DefaultRoomLastMessageFormatterTests {
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/RoomSummaryFixture.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/RoomSummaryFixture.kt
@@ -20,10 +20,12 @@ import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.TransactionId
 import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.poll.PollAnswer
+import io.element.android.libraries.matrix.api.poll.PollKind
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
+import io.element.android.libraries.matrix.api.room.message.RoomMessage
 import io.element.android.libraries.matrix.api.roomlist.RoomSummary
 import io.element.android.libraries.matrix.api.roomlist.RoomSummaryDetails
-import io.element.android.libraries.matrix.api.room.message.RoomMessage
 import io.element.android.libraries.matrix.api.timeline.item.TimelineItemDebugInfo
 import io.element.android.libraries.matrix.api.timeline.item.event.EventContent
 import io.element.android.libraries.matrix.api.timeline.item.event.EventReaction
@@ -32,6 +34,7 @@ import io.element.android.libraries.matrix.api.timeline.item.event.InReplyTo
 import io.element.android.libraries.matrix.api.timeline.item.event.LocalEventSendState
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageContent
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageType
+import io.element.android.libraries.matrix.api.timeline.item.event.PollContent
 import io.element.android.libraries.matrix.api.timeline.item.event.ProfileChangeContent
 import io.element.android.libraries.matrix.api.timeline.item.event.ProfileTimelineDetails
 import io.element.android.libraries.matrix.api.timeline.item.event.TextMessageType
@@ -173,3 +176,13 @@ fun aTimelineItemDebugInfo(
     model, originalJson, latestEditedJson
 )
 
+fun aPollContent(
+    question: String = "Do you like polls?",
+) = PollContent(
+    question = question,
+    kind = PollKind.Disclosed,
+    maxSelections = 1u,
+    answers = listOf(PollAnswer("1", "Yes"), PollAnswer("2", "No")),
+    votes = mapOf(),
+    endTime = null
+)

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -146,6 +146,7 @@
   <string name="common_verification_complete">"Verification complete"</string>
   <string name="common_video">"Video"</string>
   <string name="common_waiting">"Waiting…"</string>
+  <string name="common_poll_summary">"Poll: %1$s"</string>
   <string name="dialog_title_confirmation">"Confirmation"</string>
   <string name="dialog_title_warning">"Warning"</string>
   <string name="emoji_picker_category_activity">"Activities"</string>


### PR DESCRIPTION
Takes care of properly formatting a room's last message when it belongs to a poll.

NB: Polls still aren't exposed as a room's `last_message` from the rust SDK, so this code won't actually run yet. This will happen after integrating rust SDK version 0.1.57 which includes: https://github.com/matrix-org/matrix-rust-sdk/pull/2580