### PR TITLE
PoC: Create an example TimelineItemPresenter

### DIFF
--- a/features/messages/api/src/main/kotlin/io/element/android/features/messages/api/TimelineItemPresenter.kt
+++ b/features/messages/api/src/main/kotlin/io/element/android/features/messages/api/TimelineItemPresenter.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.api
+
+import io.element.android.libraries.architecture.Presenter
+
+interface TimelineItemPresenter : Presenter<Any>

--- a/features/messages/api/src/main/kotlin/io/element/android/features/messages/api/TimelineItemPresenterKey.kt
+++ b/features/messages/api/src/main/kotlin/io/element/android/features/messages/api/TimelineItemPresenterKey.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.api
+
+import dagger.MapKey
+
+@MapKey
+annotation class TimelineItemPresenterKey(val eventContentType: String)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -56,7 +56,7 @@ class TimelinePresenter @Inject constructor(
     private val dispatchers: CoroutineDispatchers,
     private val appScope: CoroutineScope,
     private val analyticsService: AnalyticsService,
-    private val contentPresenterFactories: Map<String, Provider<TimelineItemPresenter>>,
+    private val contentPresenterFactories: Map<String, @JvmSuppressWildcards Provider<TimelineItemPresenter>>,
 ) : Presenter<TimelineState> {
 
     private val timeline = room.timeline

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import im.vector.app.features.analytics.plan.PollVote
+import io.element.android.features.messages.api.TimelineItemPresenter
 import io.element.android.features.messages.impl.timeline.factories.TimelineItemsFactory
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.libraries.architecture.Presenter
@@ -44,6 +45,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Provider
 
 private const val BACK_PAGINATION_EVENT_LIMIT = 20
 private const val BACK_PAGINATION_PAGE_SIZE = 50
@@ -54,6 +56,7 @@ class TimelinePresenter @Inject constructor(
     private val dispatchers: CoroutineDispatchers,
     private val appScope: CoroutineScope,
     private val analyticsService: AnalyticsService,
+    private val contentPresenterFactories: Map<String, Provider<TimelineItemPresenter>>,
 ) : Presenter<TimelineState> {
 
     private val timeline = room.timeline

--- a/features/poll/api/src/main/kotlin/io/element/android/features/poll/api/TimelineItemPollContentState.kt
+++ b/features/poll/api/src/main/kotlin/io/element/android/features/poll/api/TimelineItemPollContentState.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.poll.api
+
+data class TimelineItemPollContentState(
+    val a: String,
+)

--- a/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/create/TimelineItemPollContentPresenter.kt
+++ b/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/create/TimelineItemPollContentPresenter.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.poll.impl.create
+
+import androidx.compose.runtime.Composable
+import com.squareup.anvil.annotations.ContributesMultibinding
+import io.element.android.features.messages.api.TimelineItemPresenter
+import io.element.android.features.messages.api.TimelineItemPresenterKey
+import io.element.android.features.poll.api.TimelineItemPollContentState
+import io.element.android.libraries.di.RoomScope
+
+@ContributesMultibinding(RoomScope::class)
+@TimelineItemPresenterKey("TimelineItemPollContent")
+class TimelineItemPollContentPresenter : TimelineItemPresenter {
+    @Composable
+    override fun present(): TimelineItemPollContentState {
+        TODO("Not yet implemented")
+    }
+}

--- a/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/create/TimelineItemPollContentPresenter.kt
+++ b/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/create/TimelineItemPollContentPresenter.kt
@@ -22,10 +22,11 @@ import io.element.android.features.messages.api.TimelineItemPresenter
 import io.element.android.features.messages.api.TimelineItemPresenterKey
 import io.element.android.features.poll.api.TimelineItemPollContentState
 import io.element.android.libraries.di.RoomScope
+import javax.inject.Inject
 
 @ContributesMultibinding(RoomScope::class)
 @TimelineItemPresenterKey("TimelineItemPollContent")
-class TimelineItemPollContentPresenter : TimelineItemPresenter {
+class TimelineItemPollContentPresenter @Inject constructor() : TimelineItemPresenter {
     @Composable
     override fun present(): TimelineItemPollContentState {
         TODO("Not yet implemented")


### PR DESCRIPTION
This tries to create a `TimelineItemPollContentPresenter` and bind it into a map multibinding with anvil. The idea is to retrieve a factory for it in `TimelinePresenter` so that we can properly instantiate presenter for any `TimelineItemEventContent`s that need one in `TimelineItemEventContentView`.

Sadly I couldn't make it work yet.
