### PR TITLE
Add animation on the timeline content, to avoid glitch (#1323)

### DIFF
--- a/changelog.d/1323.bugfix
+++ b/changelog.d/1323.bugfix
@@ -1,0 +1,1 @@
+Add animation when rendering the timeline to avoid glitches.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.pluralStringResource
@@ -63,8 +64,9 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemEventContentProvider
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemStateContent
 import io.element.android.features.messages.impl.timeline.model.event.canBeRepliedTo
-import io.element.android.libraries.designsystem.preview.PreviewsDayNight
+import io.element.android.libraries.designsystem.animation.alphaAnimation
 import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.FloatingActionButton
 import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.utils.CommonDrawables
@@ -105,7 +107,10 @@ fun TimelineView(
         state.eventSink(TimelineEvents.PollAnswerSelected(pollStartId, answerId))
     }
 
-    Box(modifier = modifier) {
+    // Animate alpha when timeline is first displayed, to avoid flashes or glitching when viewing rooms
+    val alpha by alphaAnimation(label = "alpha for timeline")
+
+    Box(modifier = modifier.alpha(alpha)) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             state = lazyListState,
@@ -315,7 +320,9 @@ private fun JumpToBottomButton(
             contentColor = ElementTheme.colors.iconSecondary
         ) {
             Icon(
-                modifier = Modifier.size(24.dp).rotate(90f),
+                modifier = Modifier
+                    .size(24.dp)
+                    .rotate(90f),
                 resourceId = CommonDrawables.ic_compound_arrow_right,
                 contentDescription = "",
             )

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/animation/AlphaAnimation.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/animation/AlphaAnimation.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.designsystem.animation
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalInspectionMode
+
+@Composable
+fun alphaAnimation(
+    fromAlpha: Float = 0f,
+    toAlpha: Float = 1f,
+    delayMillis: Int = 150,
+    durationMillis: Int = 150,
+    label: String = "AlphaAnimation",
+): State<Float> {
+    val firstAlpha = if (LocalInspectionMode.current) 1f else fromAlpha
+    var alpha by remember { mutableFloatStateOf(firstAlpha) }
+    LaunchedEffect(Unit) { alpha = toAlpha }
+    return animateFloatAsState(
+        targetValue = alpha,
+        animationSpec = tween(
+            delayMillis = delayMillis,
+            durationMillis = durationMillis,
+        ),
+        label = label
+    )
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Workaround the load of the timeline by delayed the display to 150ms and passing from 0 to 1 for alpha in 150ms.
This reduce the glitches, and is independant of the loading of the messages behind the scene.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #1323

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

![TimelineAnimation](https://github.com/vector-im/element-x-android/assets/3940906/b35d33db-fea6-460f-910e-5d8737ce7aef)


## Tests

<!-- Explain how you tested your development -->

- Open a timeline and see there is less glitch

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
