### PR TITLE
Push TimelineEvents further down the UI tree.

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -103,10 +103,6 @@ fun TimelineView(
         // TODO implement this logic once we have support to 'jump to event X' in sliding sync
     }
 
-    fun onPollAnswerSelected(pollStartId: EventId, answerId: String) {
-        state.eventSink(TimelineEvents.PollAnswerSelected(pollStartId, answerId))
-    }
-
     // Animate alpha when timeline is first displayed, to avoid flashes or glitching when viewing rooms
     val alpha by alphaAnimation(label = "alpha for timeline")
 
@@ -134,7 +130,7 @@ fun TimelineView(
                     onReactionLongClick = onReactionLongClicked,
                     onMoreReactionsClick = onMoreReactionsClicked,
                     onTimestampClicked = onTimestampClicked,
-                    onPollAnswerSelected = ::onPollAnswerSelected,
+                    eventSink = state.eventSink,
                     onSwipeToReply = onSwipeToReply,
                 )
             }
@@ -172,7 +168,7 @@ fun TimelineItemRow(
     onMoreReactionsClick: (TimelineItem.Event) -> Unit,
     onTimestampClicked: (TimelineItem.Event) -> Unit,
     onSwipeToReply: (TimelineItem.Event) -> Unit,
-    onPollAnswerSelected: (pollStartId: EventId, answerId: String) -> Unit,
+    eventSink: (TimelineEvents) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (timelineItem) {
@@ -189,6 +185,7 @@ fun TimelineItemRow(
                     isHighlighted = highlightedItem == timelineItem.identifier(),
                     onClick = { onClick(timelineItem) },
                     onLongClick = { onLongClick(timelineItem) },
+                    eventSink = eventSink,
                     modifier = modifier,
                 )
             } else {
@@ -205,7 +202,7 @@ fun TimelineItemRow(
                     onMoreReactionsClick = onMoreReactionsClick,
                     onTimestampClicked = onTimestampClicked,
                     onSwipeToReply = { onSwipeToReply(timelineItem) },
-                    onPollAnswerSelected = onPollAnswerSelected,
+                    eventSink = eventSink,
                     modifier = modifier,
                 )
             }
@@ -243,7 +240,7 @@ fun TimelineItemRow(
                                 onReactionClick = onReactionClick,
                                 onReactionLongClick = onReactionLongClick,
                                 onMoreReactionsClick = onMoreReactionsClick,
-                                onPollAnswerSelected = onPollAnswerSelected,
+                                eventSink = eventSink,
                                 onSwipeToReply = {},
                             )
                         }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.constraintlayout.compose.ConstrainScope
 import androidx.constraintlayout.compose.ConstraintLayout
+import io.element.android.features.messages.impl.timeline.TimelineEvents
 import io.element.android.features.messages.impl.timeline.aTimelineItemEvent
 import io.element.android.features.messages.impl.timeline.aTimelineItemReactions
 import io.element.android.features.messages.impl.timeline.components.event.TimelineItemEventContentView
@@ -80,9 +81,9 @@ import io.element.android.libraries.designsystem.colors.AvatarColorsProvider
 import io.element.android.libraries.designsystem.components.EqualWidthColumn
 import io.element.android.libraries.designsystem.components.avatar.Avatar
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
-import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.ElementPreviewLight
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.swipe.SwipeableActionsState
 import io.element.android.libraries.designsystem.swipe.rememberSwipeableActionsState
 import io.element.android.libraries.designsystem.text.toPx
@@ -123,7 +124,7 @@ fun TimelineItemEventRow(
     onReactionLongClick: (emoji: String, eventId: TimelineItem.Event) -> Unit,
     onMoreReactionsClick: (eventId: TimelineItem.Event) -> Unit,
     onSwipeToReply: () -> Unit,
-    onPollAnswerSelected: (pollStartId: EventId, answerId: String) -> Unit,
+    eventSink: (TimelineEvents) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -181,7 +182,7 @@ fun TimelineItemEventRow(
                         onReactionClicked = { emoji -> onReactionClick(emoji, event) },
                         onReactionLongClicked = { emoji -> onReactionLongClick(emoji, event) },
                         onMoreReactionsClicked = { onMoreReactionsClick(event) },
-                        onPollAnswerSelected = onPollAnswerSelected,
+                        eventSink = eventSink,
                     )
                 }
             }
@@ -198,7 +199,7 @@ fun TimelineItemEventRow(
                 onReactionClicked = { emoji -> onReactionClick(emoji, event) },
                 onReactionLongClicked = { emoji -> onReactionLongClick(emoji, event) },
                 onMoreReactionsClicked = { onMoreReactionsClick(event) },
-                onPollAnswerSelected = onPollAnswerSelected,
+                eventSink = eventSink,
             )
         }
     }
@@ -240,7 +241,7 @@ private fun TimelineItemEventRowContent(
     onReactionClicked: (emoji: String) -> Unit,
     onReactionLongClicked: (emoji: String) -> Unit,
     onMoreReactionsClicked: (event: TimelineItem.Event) -> Unit,
-    onPollAnswerSelected: (pollStartId: EventId, answerId: String) -> Unit,
+    eventSink: (TimelineEvents) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     fun ConstrainScope.linkStartOrEnd(event: TimelineItem.Event) = if (event.isMine) {
@@ -299,7 +300,7 @@ private fun TimelineItemEventRowContent(
                 onTimestampClicked = {
                     onTimestampClicked(event)
                 },
-                onPollAnswerSelected = onPollAnswerSelected,
+                eventSink = eventSink,
             )
         }
 
@@ -371,7 +372,7 @@ private fun MessageEventBubbleContent(
     onMessageLongClick: () -> Unit,
     inReplyToClick: () -> Unit,
     onTimestampClicked: () -> Unit,
-    onPollAnswerSelected: (pollStartId: EventId, answerId: String) -> Unit,
+    eventSink: (TimelineEvents) -> Unit,
     @SuppressLint("ModifierParameter") bubbleModifier: Modifier = Modifier, // need to rename this modifier to distinguish it from the following ones
 ) {
 
@@ -389,7 +390,7 @@ private fun MessageEventBubbleContent(
             onClick = onMessageClick,
             onLongClick = onMessageLongClick,
             extraPadding = event.toExtraPadding(),
-            onPollAnswerSelected = onPollAnswerSelected,
+            eventSink = eventSink,
             modifier = modifier,
         )
     }
@@ -652,7 +653,7 @@ internal fun TimelineItemEventRowPreview() = ElementPreview {
                 onMoreReactionsClick = {},
                 onTimestampClicked = {},
                 onSwipeToReply = {},
-                onPollAnswerSelected = { _, _ -> },
+                eventSink = {},
             )
             TimelineItemEventRow(
                 event = aTimelineItemEvent(
@@ -673,7 +674,7 @@ internal fun TimelineItemEventRowPreview() = ElementPreview {
                 onMoreReactionsClick = {},
                 onTimestampClicked = {},
                 onSwipeToReply = {},
-                onPollAnswerSelected = { _, _ -> },
+                eventSink = {},
             )
         }
     }
@@ -712,7 +713,7 @@ internal fun TimelineItemEventRowWithReplyPreview() = ElementPreview {
                 onMoreReactionsClick = {},
                 onTimestampClicked = {},
                 onSwipeToReply = {},
-                onPollAnswerSelected = { _, _ -> },
+                eventSink = {},
             )
             TimelineItemEventRow(
                 event = aTimelineItemEvent(
@@ -735,7 +736,7 @@ internal fun TimelineItemEventRowWithReplyPreview() = ElementPreview {
                 onMoreReactionsClick = {},
                 onTimestampClicked = {},
                 onSwipeToReply = {},
-                onPollAnswerSelected = { _, _ -> },
+                eventSink = {},
             )
         }
     }
@@ -786,7 +787,7 @@ internal fun TimelineItemEventRowTimestampPreview(
                     onMoreReactionsClick = {},
                     onTimestampClicked = {},
                     onSwipeToReply = {},
-                    onPollAnswerSelected = { _, _ -> },
+                    eventSink = {},
                 )
             }
         }
@@ -818,7 +819,7 @@ internal fun TimelineItemEventRowWithManyReactionsPreview() = ElementPreview {
                 onMoreReactionsClick = {},
                 onSwipeToReply = {},
                 onTimestampClicked = {},
-                onPollAnswerSelected = { _, _ -> },
+                eventSink = {},
             )
         }
     }
@@ -843,7 +844,7 @@ internal fun TimelineItemEventRowLongSenderNamePreview() = ElementPreviewLight {
         onMoreReactionsClick = {},
         onSwipeToReply = {},
         onTimestampClicked = {},
-        onPollAnswerSelected = { _, _ -> },
+        eventSink = {},
     )
 }
 
@@ -864,6 +865,6 @@ internal fun TimelineItemEventTimestampBelowPreview() = ElementPreviewLight {
         onMoreReactionsClick = {},
         onSwipeToReply = {},
         onTimestampClicked = {},
-        onPollAnswerSelected = { _, _ -> },
+        eventSink = {},
     )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemStateEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemStateEventRow.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import io.element.android.features.messages.impl.timeline.TimelineEvents
 import io.element.android.features.messages.impl.timeline.aTimelineItemEvent
 import io.element.android.features.messages.impl.timeline.components.event.TimelineItemEventContentView
 import io.element.android.features.messages.impl.timeline.components.event.noExtraPadding
@@ -35,8 +36,8 @@ import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.messages.impl.timeline.model.TimelineItemGroupPosition
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemStateEventContent
 import io.element.android.features.messages.impl.timeline.util.defaultTimelineContentPadding
-import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 
 @Composable
 fun TimelineItemStateEventRow(
@@ -44,6 +45,7 @@ fun TimelineItemStateEventRow(
     isHighlighted: Boolean,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
+    eventSink: (TimelineEvents) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -69,7 +71,7 @@ fun TimelineItemStateEventRow(
                 onClick = onClick,
                 onLongClick = onLongClick,
                 extraPadding = noExtraPadding,
-                onPollAnswerSelected = { _, _ -> error("Polls are not supported in state events") },
+                eventSink = eventSink,
                 modifier = Modifier.defaultTimelineContentPadding()
             )
         }
@@ -88,5 +90,6 @@ internal fun TimelineItemStateEventRowPreview() = ElementPreview {
         isHighlighted = false,
         onClick = {},
         onLongClick = {},
+        eventSink = {}
     )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemContentView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemContentView.kt
@@ -19,6 +19,7 @@ package io.element.android.features.messages.impl.timeline.components.event
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import io.element.android.features.messages.impl.timeline.TimelineEvents
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemAudioContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemEncryptedContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemEventContent
@@ -31,7 +32,6 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemTextBasedContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemUnknownContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContent
-import io.element.android.libraries.matrix.api.core.EventId
 
 @Composable
 fun TimelineItemEventContentView(
@@ -40,7 +40,7 @@ fun TimelineItemEventContentView(
     extraPadding: ExtraPadding,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
-    onPollAnswerSelected: (pollStartId: EventId, answerId: String) -> Unit,
+    eventSink: (TimelineEvents) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (content) {
@@ -95,7 +95,7 @@ fun TimelineItemEventContentView(
         )
         is TimelineItemPollContent -> TimelineItemPollView(
             content = content,
-            onAnswerSelected = onPollAnswerSelected,
+            eventSink = eventSink,
             modifier = modifier,
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemPollView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemPollView.kt
@@ -19,27 +19,32 @@ package io.element.android.features.messages.impl.timeline.components.event
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import io.element.android.features.messages.impl.timeline.TimelineEvents
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemPollContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemPollContentProvider
 import io.element.android.features.poll.api.PollContentView
-import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.matrix.api.core.EventId
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun TimelineItemPollView(
     content: TimelineItemPollContent,
-    onAnswerSelected: (pollStartId: EventId, answerId: String) -> Unit,
+    eventSink: (TimelineEvents) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    fun onAnswerSelected(pollStartId: EventId, answerId: String) {
+        eventSink(TimelineEvents.PollAnswerSelected(pollStartId, answerId))
+    }
+
     PollContentView(
         eventId = content.eventId,
         question = content.question,
         answerItems = content.answerItems.toImmutableList(),
         pollKind = content.pollKind,
         isPollEnded = content.isEnded,
-        onAnswerSelected = onAnswerSelected,
+        onAnswerSelected = ::onAnswerSelected,
         modifier = modifier,
     )
 }
@@ -50,6 +55,6 @@ internal fun TimelineItemPollViewPreview(@PreviewParameter(TimelineItemPollConte
     ElementPreview {
         TimelineItemPollView(
             content = content,
-            onAnswerSelected = { _, _ -> },
+            eventSink = {},
         )
     }

--- a/features/poll/api/src/main/kotlin/io/element/android/features/poll/api/PollContentView.kt
+++ b/features/poll/api/src/main/kotlin/io/element/android/features/poll/api/PollContentView.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.utils.CommonDrawables


### PR DESCRIPTION
So that timeline items don't have to route their callback all the way down to TimelinePresenter.
