### PR TITLE
Use eventSink method reference in TimelinePresenter.kt

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -123,7 +123,7 @@ class TimelinePresenter @Inject constructor(
             paginationState = paginationState,
             timelineItems = timelineItems,
             hasNewItems = hasNewItems.value,
-            eventSink = { handleEvents(it) }
+            eventSink = ::handleEvents
         )
     }
 


### PR DESCRIPTION
Has been changed in https://github.com/vector-im/element-x-android/pull/1172 but in general method references should always be preferred to lambdas in composable functions (because they have higher stability guarantees).
