### PR TITLE
Implement a bloom hash store, for faster bloom rendering.

### DIFF
--- a/libraries/designsystem/build.gradle.kts
+++ b/libraries/designsystem/build.gradle.kts
@@ -40,6 +40,7 @@ android {
         implementation(libs.coil.compose)
         implementation(libs.vanniktech.blurhash)
         implementation(projects.libraries.uiStrings)
+        implementation(libs.androidx.datastore.preferences)
 
         ksp(libs.showkase.processor)
         kspTest(libs.showkase.processor)

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/BloomBlurHashStore.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/BloomBlurHashStore.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.designsystem.components
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "bloom_store")
+
+class BloomBlurHashStore(
+    context: Context,
+) {
+    private val store = context.dataStore
+
+    fun get(id: String): Flow<String?> {
+        return store.data.map { prefs ->
+            prefs[getBlurHashPreferenceKey(id)]
+        }
+    }
+
+    suspend fun put(id: String, blurHash: String) {
+        store.edit { prefs ->
+            prefs[getBlurHashPreferenceKey(id)] = blurHash
+        }
+    }
+
+    private fun getBlurHashPreferenceKey(id: String) = stringPreferencesKey("blur_hash_$id")
+}
+
+
+

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl.components_null_DefaultRoomListTopBar-D-4_4_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl.components_null_DefaultRoomListTopBar-D-4_4_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c9708e025f47a0c9ef501b6af19107e7ca1bc0d2d5db20f84a439b1e8f96d30
-size 36809
+oid sha256:14a03c4ed99b4c3ad53a42acbd0efc7bb2bd0676a49f12717de211fe5bd1e435
+size 49375

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl.components_null_DefaultRoomListTopBar-N-4_5_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl.components_null_DefaultRoomListTopBar-N-4_5_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c62a7d690d9138c9a4a6bef79c8191832363f9276cfe30dce81348b0e854b27
-size 43031
+oid sha256:9ac15217dea81f1827d3fc0baf9266f7b7094189545c74e6a3e064f53e3a4418
+size 43126

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_0,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29662089bb7ceefe701078605dad8e81ffc34d2adb26cab4149ab371e06edd09
-size 65468
+oid sha256:c311c128da8e78c91f6b60609221280f5d530de63903e7c1b6fe5651a7026153
+size 77098

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_1,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f499207805737f1c7304b20f43d3c38dd1cd1a1cd4110cc00eb2d1489dd1fe5b
-size 89218
+oid sha256:7b1b509f6067fd1849d3d35910eef30558a0ed80802d2a830e18f8f703d3b3e0
+size 100594

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_2,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29662089bb7ceefe701078605dad8e81ffc34d2adb26cab4149ab371e06edd09
-size 65468
+oid sha256:c311c128da8e78c91f6b60609221280f5d530de63903e7c1b6fe5651a7026153
+size 77098

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_3,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:22eb689307a7809446964bb6b9ef84f2bef7e228daab9ae80bebd0b7e7d58b99
-size 65457
+oid sha256:eb155dfe298ccb402ed8c4437fb3d4f06d43e67ddf8f4345bb78d466088254b2
+size 76056

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_4,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99f520bcea2e71385ab8c10aa5fe1bbe24f01f625b5c44bea43479ba606e28c3
-size 66595
+oid sha256:2b9348b0122afacdb5eb19cfeb6e81aad0eae4d724541508fe1519837bc75c38
+size 78465

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-D-2_2_null_5,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ecaf49554d7c2d5c570dbcc01a922fc0a3b130ede89e69bb0399433b3e0bf808
-size 66978
+oid sha256:d830025722afec4b0b6287304423e6e466ac021d7018ddcf8f34e6097c68ca0c
+size 78719

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_0,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b1a6a75105b643dbef0c18f76e19c23b62634c559ffc9b9073d4626795a53a4
-size 68202
+oid sha256:0ae4dd49977b10287bd5383ccb065ee0fcbe06edcd32f57f98a2f83974dedeb3
+size 69360

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_1,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:006c5af03e2b482373bcb478b988e040e63df53fc95c53035cfb55e2ff672894
-size 91389
+oid sha256:782c2f007c38c78377b316038bd76efd8199cb08ce5fa58ec2a033c947eca08a
+size 92382

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_2,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b1a6a75105b643dbef0c18f76e19c23b62634c559ffc9b9073d4626795a53a4
-size 68202
+oid sha256:0ae4dd49977b10287bd5383ccb065ee0fcbe06edcd32f57f98a2f83974dedeb3
+size 69360

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_3,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c4303a44b5e8b8ae71f101ba1abf6895683137bd668f249e4bbd9f42f10ccc2
-size 68296
+oid sha256:8c7b03ea66469c339c1a42dd5b3943dfec2e248481c9e3d6c8b21fbfdccc4f9f
+size 68975

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_4,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34cb5aa8b8053a0575ed7e8f792a9dc79b522fdfee1bd5810aa8a49c51c46188
-size 69792
+oid sha256:dddf5ad2a21fab422366bd826ab6cbeb4e28a9394f8532cc37be9ba7fc558007
+size 70900

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_null_RoomListView-N-2_3_null_5,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f51f6c4d823e68fe6ba3d39e3c741e75d6ac7bf2fea8e201c321e40a21b6dff8
-size 70126
+oid sha256:fd5176a9d4ac790f5bc09b5e99c1e336fb09672cc8a5b112c99603fed6b00671
+size 71199


### PR DESCRIPTION
Implement a bloom hash store to render the bloom effect a few hundred milliseconds faster.

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Implement a bloom hash store to render the bloom effect a few hundred milliseconds faster.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Visual polish

Logs (extract):
```
12:01:44.755  8635-8635 Bloom render null
12:01:44.786  8635-8635 Bloom render eyKUQG_2D%j[xu~q%MM{ofofIURjs:ofR*M{RjfQazayxut7WBayj[
12:01:45.353  8635-8635 Bloom render eyKUQG_2D%j[xu~q%MM{ofofIURjs:ofR*M{RjfQazayxut7WBayj[
```
First line is first value
Second line of getting the value from store
Third line is when the blur hash is been computed.

Before the PR, it takes 567 ms to display the bloom, with this PR, it takes only 31ms.

Limitation: If the avatar is updated, the previous bloom will be displayed for a few hundred ms, the time to compute the new hash.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
