### PR TITLE
Display poll notifications in the notification drawer

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/notification/NotificationData.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/notification/NotificationData.kt
@@ -61,7 +61,10 @@ sealed interface NotificationContent {
         ) : MessageLike
         data object RoomRedaction : MessageLike
         data object Sticker : MessageLike
-        data class Poll(val question: String) : MessageLike
+        data class Poll(
+            val senderId: UserId,
+            val question: String,
+        ) : MessageLike
     }
 
     sealed interface StateEvent : NotificationContent {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
@@ -94,7 +94,7 @@ private fun MessageLikeEventContent.toContent(senderId: UserId): NotificationCon
             }
             MessageLikeEventContent.RoomRedaction -> NotificationContent.MessageLike.RoomRedaction
             MessageLikeEventContent.Sticker -> NotificationContent.MessageLike.Sticker
-            is MessageLikeEventContent.Poll -> NotificationContent.MessageLike.Poll(question)
+            is MessageLikeEventContent.Poll -> NotificationContent.MessageLike.Poll(senderId, question)
         }
     }
 }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
@@ -143,7 +143,7 @@ class NotifiableEventResolver @Inject constructor(
                     timestamp = this.timestamp,
                     senderName = senderDisplayName,
                     body = stringProvider.getString(CommonStrings.common_poll_summary, content.question),
-                    imageUriString = this.contentUrl,
+                    imageUriString = null,
                     roomName = roomDisplayName,
                     roomIsDirect = isDirect,
                     roomAvatarPath = roomAvatarUrl,

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
@@ -133,9 +133,22 @@ class NotifiableEventResolver @Inject constructor(
             NotificationContent.MessageLike.KeyVerificationStart -> null.also {
                 Timber.tag(loggerTag.value).d("Ignoring notification for verification ${content.javaClass.simpleName}")
             }
-            is NotificationContent.MessageLike.Poll -> null.also {
-                // TODO Polls: handle notification rendering
-                Timber.tag(loggerTag.value).d("Ignoring notification for poll")
+            is NotificationContent.MessageLike.Poll ->  {
+                buildNotifiableMessageEvent(
+                    sessionId = userId,
+                    senderId = content.senderId,
+                    roomId = roomId,
+                    eventId = eventId,
+                    noisy = isNoisy,
+                    timestamp = this.timestamp,
+                    senderName = senderDisplayName,
+                    body = stringProvider.getString(CommonStrings.common_poll_summary, content.question),
+                    imageUriString = this.contentUrl,
+                    roomName = roomDisplayName,
+                    roomIsDirect = isDirect,
+                    roomAvatarPath = roomAvatarUrl,
+                    senderAvatarPath = senderAvatarUrl,
+                )
             }
             is NotificationContent.MessageLike.ReactionContent -> null.also {
                 Timber.tag(loggerTag.value).d("Ignoring notification for reaction")


### PR DESCRIPTION
Display notifications for polls as if they were message events but prepending the poll question with "Poll: " as we do in the room summary.