### PR TITLE
Fix composer options bottom sheet position

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -50,6 +50,7 @@ import io.element.android.features.messages.impl.actionlist.ActionListEvents
 import io.element.android.features.messages.impl.actionlist.ActionListView
 import io.element.android.features.messages.impl.actionlist.model.TimelineItemAction
 import io.element.android.features.messages.impl.attachments.Attachment
+import io.element.android.features.messages.impl.messagecomposer.AttachmentsBottomSheet
 import io.element.android.features.messages.impl.messagecomposer.AttachmentsState
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerEvents
 import io.element.android.features.messages.impl.messagecomposer.MessageComposerView
@@ -283,6 +284,13 @@ private fun MessagesViewContent(
             .navigationBarsPadding()
             .imePadding(),
     ) {
+        AttachmentsBottomSheet(
+            state = state.composerState,
+            onSendLocationClicked = onSendLocationClicked,
+            onCreatePollClicked = onCreatePollClicked,
+            enableTextFormatting = state.enableTextFormatting,
+        )
+
         ExpandableBottomSheetScaffold(
             sheetDragHandle = if (state.composerState.showTextFormatting) {
                 @Composable { BottomSheetDragHandle() }
@@ -310,8 +318,6 @@ private fun MessagesViewContent(
                     MessageComposerView(
                         state = state.composerState,
                         subcomposing = subcomposing,
-                        onSendLocationClicked = onSendLocationClicked,
-                        onCreatePollClicked = onCreatePollClicked,
                         enableTextFormatting = state.enableTextFormatting,
                         modifier = Modifier
                             .fillMaxWidth(),

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerView.kt
@@ -16,7 +16,6 @@
 
 package io.element.android.features.messages.impl.messagecomposer
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.height
@@ -35,8 +34,6 @@ import kotlinx.coroutines.launch
 fun MessageComposerView(
     state: MessageComposerState,
     subcomposing: Boolean,
-    onSendLocationClicked: () -> Unit,
-    onCreatePollClicked: () -> Unit,
     enableTextFormatting: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -67,28 +64,20 @@ fun MessageComposerView(
         }
     }
 
-    Box(modifier = modifier) {
-        AttachmentsBottomSheet(
-            state = state,
-            onSendLocationClicked = onSendLocationClicked,
-            onCreatePollClicked = onCreatePollClicked,
-            enableTextFormatting = enableTextFormatting,
-        )
-
-        TextComposer(
-            state = state.richTextEditorState,
-            subcomposing = subcomposing,
-            onRequestFocus = ::onRequestFocus,
-            onSendMessage = ::sendMessage,
-            composerMode = state.mode,
-            showTextFormatting = state.showTextFormatting,
-            onResetComposerMode = ::onCloseSpecialMode,
-            onAddAttachment = ::onAddAttachment,
-            onDismissTextFormatting = ::onDismissTextFormatting,
-            enableTextFormatting = enableTextFormatting,
-            onError = ::onError,
-        )
-    }
+    TextComposer(
+        modifier = modifier,
+        state = state.richTextEditorState,
+        subcomposing = subcomposing,
+        onRequestFocus = ::onRequestFocus,
+        onSendMessage = ::sendMessage,
+        composerMode = state.mode,
+        showTextFormatting = state.showTextFormatting,
+        onResetComposerMode = ::onCloseSpecialMode,
+        onAddAttachment = ::onAddAttachment,
+        onDismissTextFormatting = ::onDismissTextFormatting,
+        enableTextFormatting = enableTextFormatting,
+        onError = ::onError,
+    )
 }
 
 @PreviewsDayNight
@@ -98,16 +87,12 @@ internal fun MessageComposerViewPreview(@PreviewParameter(MessageComposerStatePr
         MessageComposerView(
             modifier = Modifier.height(IntrinsicSize.Min),
             state = state,
-            onSendLocationClicked = {},
-            onCreatePollClicked = {},
             enableTextFormatting = true,
             subcomposing = false,
         )
         MessageComposerView(
             modifier = Modifier.height(200.dp),
             state = state,
-            onSendLocationClicked = {},
-            onCreatePollClicked = {},
             enableTextFormatting = true,
             subcomposing = false,
         )


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Move the composer options / attachments bottom sheet up one level in the UI hierarchy so that it is outside of the composer bottom sheet.

## Motivation and context

Fixes an issue where the attachments dialog is displayed in the wrong position and cannot be swiped to dismiss (see screenshots).

The issue isn't presenting as severely when I test on my physical device as when tested in an emulator (screenshots below).

## Screenshots / GIFs

### Before

[Before.webm](https://github.com/vector-im/element-x-android/assets/4940864/f001fb55-3d56-4a00-bcfd-d013846435f9)

### After

[After.webm](https://github.com/vector-im/element-x-android/assets/4940864/bff29976-f19c-4def-9816-54105daf410e)

## Tests

- Go to composer
- Enter text and ensure keyboard is open
- Open the composer options / attachments menu and dismiss
- Close the keyboard
- Open the composer options / attachments menu and dismiss

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
