### PR TITLE
Maestro test: change server (again) to test server which does not support sliding sync

### DIFF
--- a/.maestro/tests/account/changeServer.yaml
+++ b/.maestro/tests/account/changeServer.yaml
@@ -10,9 +10,9 @@ appId: ${APP_ID}
 - tapOn:
     id: "change_server-server"
 # Test server that does not support sliding sync.
-- inputText: "gnuradio"
+- inputText: "mozilla"
 - hideKeyboard
-- tapOn: "gnuradio.org"
+- tapOn: "mozilla.org"
 - extendedWaitUntil:
     visible: "This server currently doesn’t support sliding sync."
     timeout: 10000


### PR DESCRIPTION
#1066 again, but for gnuradio.org.