### PR TITLE
Render emote

### DIFF
--- a/changelog.d/1497.feature
+++ b/changelog.d/1497.feature
@@ -1,0 +1,1 @@
+Improve rendering of m.emote.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentFactory.kt
@@ -24,6 +24,7 @@ import io.element.android.libraries.matrix.api.timeline.item.event.FailedToParse
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageContent
 import io.element.android.libraries.matrix.api.timeline.item.event.PollContent
 import io.element.android.libraries.matrix.api.timeline.item.event.ProfileChangeContent
+import io.element.android.libraries.matrix.api.timeline.item.event.ProfileTimelineDetails
 import io.element.android.libraries.matrix.api.timeline.item.event.RedactedContent
 import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StateContent
@@ -49,7 +50,10 @@ class TimelineItemContentFactory @Inject constructor(
         return when (val itemContent = eventTimelineItem.content) {
             is FailedToParseMessageLikeContent -> failedToParseMessageFactory.create(itemContent)
             is FailedToParseStateContent -> failedToParseStateFactory.create(itemContent)
-            is MessageContent -> messageFactory.create(itemContent)
+            is MessageContent -> {
+                val senderDisplayName = (eventTimelineItem.senderProfile as? ProfileTimelineDetails.Ready)?.displayName ?: eventTimelineItem.sender.value
+                messageFactory.create(itemContent, senderDisplayName)
+            }
             is ProfileChangeContent -> profileChangeFactory.create(eventTimelineItem)
             is RedactedContent -> redactedMessageFactory.create(itemContent)
             is RoomMembershipContent -> roomMembershipFactory.create(eventTimelineItem)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -39,6 +39,7 @@ import io.element.android.libraries.matrix.api.timeline.item.event.LocationMessa
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageContent
 import io.element.android.libraries.matrix.api.timeline.item.event.NoticeMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.TextMessageType
+import io.element.android.libraries.matrix.api.timeline.item.event.UnknownMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.VideoMessageType
 import javax.inject.Inject
 
@@ -48,7 +49,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
 ) {
 
     fun create(content: MessageContent): TimelineItemEventContent {
-        return when (val messageType = content.type) {
+        return when (val messageType = content.type ?: UnknownMessageType) {
             is EmoteMessageType -> TimelineItemEmoteContent(
                 body = messageType.body,
                 htmlDocument = messageType.formatted?.toHtmlDocument(),
@@ -130,7 +131,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
                 htmlDocument = messageType.formatted?.toHtmlDocument(),
                 isEdited = content.isEdited,
             )
-            else -> TimelineItemUnknownContent
+            UnknownMessageType -> TimelineItemUnknownContent
         }
     }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -52,7 +52,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
         return when (val messageType = content.type ?: UnknownMessageType) {
             is EmoteMessageType -> TimelineItemEmoteContent(
                 body = "* $senderDisplayName ${messageType.body}",
-                htmlDocument = messageType.formatted?.toHtmlDocument(senderDisplayName),
+                htmlDocument = messageType.formatted?.toHtmlDocument(prefix = "* senderDisplayName"),
                 isEdited = content.isEdited,
             )
             is ImageMessageType -> {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -48,11 +48,11 @@ class TimelineItemContentMessageFactory @Inject constructor(
     private val fileExtensionExtractor: FileExtensionExtractor,
 ) {
 
-    fun create(content: MessageContent): TimelineItemEventContent {
+    fun create(content: MessageContent, senderDisplayName: String): TimelineItemEventContent {
         return when (val messageType = content.type ?: UnknownMessageType) {
             is EmoteMessageType -> TimelineItemEmoteContent(
-                body = messageType.body,
-                htmlDocument = messageType.formatted?.toHtmlDocument(),
+                body = "* $senderDisplayName ${messageType.body}",
+                htmlDocument = messageType.formatted?.toHtmlDocument(senderDisplayName),
                 isEdited = content.isEdited,
             )
             is ImageMessageType -> {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/util/toHtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/util/toHtmlDocument.kt
@@ -21,10 +21,10 @@ import io.element.android.libraries.matrix.api.timeline.item.event.MessageFormat
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
-fun FormattedBody.toHtmlDocument(senderDisplayNamePrefix: String? = null): Document? {
+fun FormattedBody.toHtmlDocument(prefix: String? = null): Document? {
     return takeIf { it.format == MessageFormat.HTML }?.body?.let { formattedBody ->
-        if (senderDisplayNamePrefix != null) {
-            Jsoup.parse("* $senderDisplayNamePrefix $formattedBody")
+        if (prefix != null) {
+            Jsoup.parse("$prefix $formattedBody")
         } else {
             Jsoup.parse(formattedBody)
         }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/util/toHtmlDocument.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/util/toHtmlDocument.kt
@@ -21,8 +21,12 @@ import io.element.android.libraries.matrix.api.timeline.item.event.MessageFormat
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
-fun FormattedBody.toHtmlDocument(): Document? {
+fun FormattedBody.toHtmlDocument(senderDisplayNamePrefix: String? = null): Document? {
     return takeIf { it.format == MessageFormat.HTML }?.body?.let { formattedBody ->
-        Jsoup.parse(formattedBody)
+        if (senderDisplayNamePrefix != null) {
+            Jsoup.parse("* $senderDisplayNamePrefix $formattedBody")
+        } else {
+            Jsoup.parse(formattedBody)
+        }
     }
 }

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
@@ -111,7 +111,7 @@ class DefaultRoomLastMessageFormatter @Inject constructor(
         val internalMessage = when (messageType) {
             // Doesn't need a prefix
             is EmoteMessageType -> {
-                return "- $senderDisplayName ${messageType.body}"
+                return "* $senderDisplayName ${messageType.body}"
             }
             is TextMessageType -> {
                 messageType.body

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTests.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTests.kt
@@ -201,7 +201,7 @@ class DefaultRoomLastMessageFormatterTests {
                 is ImageMessageType -> "Image"
                 is FileMessageType -> "File"
                 is LocationMessageType -> "Shared location"
-                is EmoteMessageType -> "- $senderName ${type.body}"
+                is EmoteMessageType -> "* $senderName ${type.body}"
                 is TextMessageType, is NoticeMessageType -> body
                 UnknownMessageType -> "Unsupported event"
             }
@@ -217,7 +217,7 @@ class DefaultRoomLastMessageFormatterTests {
                 is ImageMessageType -> "$senderName: Image"
                 is FileMessageType -> "$senderName: File"
                 is LocationMessageType -> "$senderName: Shared location"
-                is EmoteMessageType -> "- $senderName ${type.body}"
+                is EmoteMessageType -> "* $senderName ${type.body}"
                 is TextMessageType, is NoticeMessageType -> "$senderName: $body"
                 UnknownMessageType -> "$senderName: Unsupported event"
             }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/EventContent.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/EventContent.kt
@@ -63,7 +63,7 @@ sealed interface InReplyTo {
     data object Error : InReplyTo
 }
 
-object RedactedContent : EventContent
+data object RedactedContent : EventContent
 
 data class StickerContent(
     val body: String,
@@ -124,11 +124,11 @@ data class FailedToParseStateContent(
     val error: String
 ) : EventContent
 
-object UnknownContent : EventContent
+data object UnknownContent : EventContent
 
 sealed interface MessageType
 
-object UnknownMessageType : MessageType
+data object UnknownMessageType : MessageType
 
 enum class MessageFormat {
     HTML, UNKNOWN

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
@@ -87,7 +87,7 @@ class NotifiableEventResolver @Inject constructor(
                     noisy = isNoisy,
                     timestamp = this.timestamp,
                     senderName = senderDisplayName,
-                    body = descriptionFromMessageContent(content),
+                    body = descriptionFromMessageContent(content, senderDisplayName ?: content.senderId.value),
                     imageUriString = this.contentUrl,
                     roomName = roomDisplayName,
                     roomIsDirect = isDirect,
@@ -133,7 +133,7 @@ class NotifiableEventResolver @Inject constructor(
             NotificationContent.MessageLike.KeyVerificationStart -> null.also {
                 Timber.tag(loggerTag.value).d("Ignoring notification for verification ${content.javaClass.simpleName}")
             }
-            is NotificationContent.MessageLike.Poll ->  {
+            is NotificationContent.MessageLike.Poll -> {
                 buildNotifiableMessageEvent(
                     sessionId = userId,
                     senderId = content.senderId,
@@ -205,10 +205,11 @@ class NotifiableEventResolver @Inject constructor(
 
     private fun descriptionFromMessageContent(
         content: NotificationContent.MessageLike.RoomMessage,
+        senderDisplayName: String,
     ): String {
         return when (val messageType = content.messageType) {
             is AudioMessageType -> messageType.body
-            is EmoteMessageType -> messageType.body
+            is EmoteMessageType -> "* $senderDisplayName ${messageType.body}"
             is FileMessageType -> messageType.body
             is ImageMessageType -> messageType.body
             is NoticeMessageType -> messageType.body


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Improve rendering of m.emote msgtype.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix #1497 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

<img width="233" alt="image" src="https://github.com/vector-im/element-x-android/assets/3940906/84f07b9a-cea7-4e06-8632-dde1771d5154">

## Tests

<!-- Explain how you tested your development -->

- Send emote (with or without formatted text) and observe the rendering in the room list (last message) and in the timeline.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
