### PR TITLE
Fix: WebP images can't be sent as media.

### DIFF
--- a/changelog.d/1483.bugfix
+++ b/changelog.d/1483.bugfix
@@ -1,0 +1,1 @@
+WebP images can't be sent as media.

--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/mimetype/MimeTypes.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/mimetype/MimeTypes.kt
@@ -31,6 +31,7 @@ object MimeTypes {
     const val BadJpg = "image/jpg"
     const val Jpeg = "image/jpeg"
     const val Gif = "image/gif"
+    const val WebP = "image/webp"
 
     const val Videos = "video/*"
     const val Mp4 = "video/mp4"

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/ImageCompressor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/ImageCompressor.kt
@@ -27,7 +27,6 @@ import io.element.android.libraries.androidutils.file.createTmpFile
 import io.element.android.libraries.di.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.BufferedInputStream
 import java.io.File
 import java.io.InputStream
 import javax.inject.Inject
@@ -42,14 +41,14 @@ class ImageCompressor @Inject constructor(
      * @return a [Result] containing the resulting [ImageCompressionResult] with the temporary [File] and some metadata.
      */
     suspend fun compressToTmpFile(
-        inputStream: InputStream,
+        inputStreamProvider: () -> InputStream,
         resizeMode: ResizeMode,
         format: Bitmap.CompressFormat = Bitmap.CompressFormat.JPEG,
         orientation: Int = ExifInterface.ORIENTATION_UNDEFINED,
         desiredQuality: Int = 80,
     ): Result<ImageCompressionResult> = withContext(Dispatchers.IO) {
         runCatching {
-            val compressedBitmap = compressToBitmap(inputStream, resizeMode, orientation).getOrThrow()
+            val compressedBitmap = compressToBitmap(inputStreamProvider, resizeMode, orientation).getOrThrow()
             // Encode bitmap to the destination temporary file
             val tmpFile = context.createTmpFile(extension = "jpeg")
             tmpFile.outputStream().use {
@@ -65,17 +64,22 @@ class ImageCompressor @Inject constructor(
     }
 
     /**
-     * Decodes the [inputStream] into a [Bitmap] and applies the needed transformations (rotation, scale) based on [resizeMode] and [orientation].
+     * Decodes the inputStream from [inputStreamProvider] into a [Bitmap] and applies the needed transformations (rotation, scale)
+     * based on [resizeMode] and [orientation].
      * @return a [Result] containing the resulting [Bitmap].
      */
     fun compressToBitmap(
-        inputStream: InputStream,
+        inputStreamProvider: () -> InputStream,
         resizeMode: ResizeMode,
         orientation: Int,
     ): Result<Bitmap> = runCatching {
-        BufferedInputStream(inputStream).use { input ->
-            val options = BitmapFactory.Options()
+        val options = BitmapFactory.Options()
+        // Decode bounds
+        inputStreamProvider().use { input ->
             calculateDecodingScale(input, resizeMode, options)
+        }
+        // Decode the actual bitmap
+        inputStreamProvider().use { input ->
             val decodedBitmap = BitmapFactory.decodeStream(input, null, options)
                 ?: error("Decoding Bitmap from InputStream failed")
             val rotatedBitmap = decodedBitmap.rotateToMetadataOrientation(orientation)
@@ -88,7 +92,7 @@ class ImageCompressor @Inject constructor(
     }
 
     private fun calculateDecodingScale(
-        inputStream: BufferedInputStream,
+        inputStream: InputStream,
         resizeMode: ResizeMode,
         options: BitmapFactory.Options
     ) {
@@ -98,13 +102,11 @@ class ImageCompressor @Inject constructor(
             is ResizeMode.None -> return
         }
         // Read bounds only
-        inputStream.mark(inputStream.available())
         options.inJustDecodeBounds = true
         BitmapFactory.decodeStream(inputStream, null, options)
         // Set sample size based on the outWidth and outHeight
         options.inSampleSize = options.calculateInSampleSize(width, height)
         // Now read the actual image and rotate it to match its metadata
-        inputStream.reset()
         options.inJustDecodeBounds = false
     }
 }

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/ImageCompressor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/ImageCompressor.kt
@@ -80,6 +80,8 @@ class ImageCompressor @Inject constructor(
         }
         // Decode the actual bitmap
         inputStreamProvider().use { input ->
+            // Now read the actual image and rotate it to match its metadata
+            options.inJustDecodeBounds = false
             val decodedBitmap = BitmapFactory.decodeStream(input, null, options)
                 ?: error("Decoding Bitmap from InputStream failed")
             val rotatedBitmap = decodedBitmap.rotateToMetadataOrientation(orientation)
@@ -106,8 +108,6 @@ class ImageCompressor @Inject constructor(
         BitmapFactory.decodeStream(inputStream, null, options)
         // Set sample size based on the outWidth and outHeight
         options.inSampleSize = options.calculateInSampleSize(width, height)
-        // Now read the actual image and rotate it to match its metadata
-        options.inJustDecodeBounds = false
     }
 }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Replaces `inputStream` parameter in  `processImage` function with a `inputStreamProvider` parameter so we can create as much input streams as we need to.
- Add WebP files to the mime types that can't be compressed, as some WebP files are animated.

## Motivation and context

To compress images we used a `BufferedInputStream` to read its bounds and then restore its buffer position to 0 so we can read the actual image only. This was failing for WebP types, and it might also fail for very large images, so we need to actually have 2 input streams. Also, WebP files might be animated so compressing them may be a mistake.

Fixes #1483.

## Tests

<!-- Explain how you tested your development -->

- Download some WebP file.
- Try to send it from the gallery picker in a room. If it works, it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
