### PR TITLE
Switch off `enableOnBackInvokedCallback` due to androidx bug (#1517)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,11 +20,12 @@
     <!-- To be able to install APK from the application -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
+    <!--  Do not enable enableOnBackInvokedCallback until https://issuetracker.google.com/issues/271303558 is fixed -->
     <application
         android:name=".ElementXApplication"
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
-        android:enableOnBackInvokedCallback="true"
+        android:enableOnBackInvokedCallback="false"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/changelog.d/1517.bugfix
+++ b/changelog.d/1517.bugfix
@@ -1,0 +1,1 @@
+Fix back button not working in bottom sheets.


### PR DESCRIPTION
Switch off `enableOnBackInvokedCallback` until https://issuetracker.google.com/issues/271303558 is fixed.


Fixes https://github.com/vector-im/element-x-android/issues/1461
