### PR TITLE
Move Konsist tests to their own module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -230,7 +230,6 @@ dependencies {
     testImplementation(libs.test.truth)
     testImplementation(libs.test.turbine)
     testImplementation(projects.libraries.matrix.test)
-    testImplementation(libs.test.konsist)
 
     ksp(libs.showkase.processor)
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/VoiceMessageComposerEvents.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/VoiceMessageComposerEvents.kt
@@ -18,8 +18,8 @@ package io.element.android.features.messages.impl.voicemessages
 
 import io.element.android.libraries.textcomposer.model.PressEvent
 
-sealed class VoiceMessageComposerEvents {
+sealed interface VoiceMessageComposerEvents {
     data class RecordButtonEvent(
         val pressEvent: PressEvent
-    ): VoiceMessageComposerEvents()
+    ): VoiceMessageComposerEvents
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,6 +52,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 rootProject.name = "ElementX"
 include(":app")
 include(":appnav")
+include(":tests:konsist")
 include(":tests:uitests")
 include(":tests:testutils")
 include(":anvilannotations")

--- a/tests/konsist/build.gradle.kts
+++ b/tests/konsist/build.gradle.kts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("io.element.android-compose-library")
+}
+
+android {
+    namespace = "io.element.android.tests.konsist"
+}
+
+dependencies {
+    val composeBom = platform(libs.androidx.compose.bom)
+    testImplementation(composeBom)
+    testImplementation("androidx.compose.ui:ui-tooling-preview")
+    testImplementation(libs.test.junit)
+    testImplementation(libs.test.konsist)
+    testImplementation(libs.test.truth)
+    testImplementation(projects.libraries.architecture)
+    testImplementation(projects.libraries.designsystem)
+}

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistArchitectureTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistArchitectureTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.element.android.app
+package io.element.android.tests.konsist
 
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.constructors

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistClassNameTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistClassNameTest.kt
@@ -46,7 +46,7 @@ class KonsistClassNameTest {
     }
 
     @Test
-    fun `Classes extending 'PreviewParameterProvider' name MUST end with "Provider" and MUST contain provided class name`() {
+    fun `Classes extending 'PreviewParameterProvider' name MUST end with 'Provider' and MUST contain provided class name`() {
         Konsist.scopeFromProject()
             .classes()
             .withAllParentsOf(PreviewParameterProvider::class)

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistClassNameTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistClassNameTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.element.android.app
+package io.element.android.tests.konsist
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.bumble.appyx.core.node.Node

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistComposableTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistComposableTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.element.android.app
+package io.element.android.tests.konsist
 
 import androidx.compose.runtime.Composable
 import com.lemonappdev.konsist.api.KoModifier

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistConfigTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistConfigTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.tests.konsist
+
+import com.google.common.truth.Truth.assertThat
+import com.lemonappdev.konsist.api.Konsist
+import org.junit.Test
+
+class KonsistConfigTest {
+    @Test
+    fun `assert that Konsist detect all the project classes`() {
+        assertThat(
+            Konsist
+                .scopeFromProject()
+                .classes()
+                .size
+        )
+            .isGreaterThan(1_000)
+    }
+
+    @Test
+    fun `assert that Konsist detect all the test classes`() {
+        assertThat(
+            Konsist
+                .scopeFromTest()
+                .classes()
+                .size
+        )
+            .isGreaterThan(100)
+    }
+}

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistFieldTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistFieldTest.kt
@@ -14,25 +14,23 @@
  * limitations under the License.
  */
 
-package io.element.android.app
+package io.element.android.tests.konsist
 
 import com.lemonappdev.konsist.api.Konsist
-import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
-import com.lemonappdev.konsist.api.verify.assertTrue
-import io.element.android.libraries.designsystem.preview.PreviewsDayNight
+import com.lemonappdev.konsist.api.ext.list.properties
+import com.lemonappdev.konsist.api.verify.assertFalse
 import org.junit.Test
 
-class KonsistPreviewTest {
+class KonsistFieldTest {
     @Test
-    fun `Functions with '@PreviewsDayNight' annotation should have 'Preview' suffix`() {
+    fun `no field should have 'm' prefix`() {
         Konsist
             .scopeFromProject()
-            .functions()
-            .withAllAnnotationsOf(PreviewsDayNight::class)
-            .assertTrue {
-                it.hasNameEndingWith("Preview") &&
-                    it.hasNameEndingWith("LightPreview").not() &&
-                    it.hasNameEndingWith("DarkPreview").not()
+            .classes()
+            .properties()
+            .assertFalse {
+                val secondCharacterIsUppercase = it.name.getOrNull(1)?.isUpperCase() ?: false
+                it.name.startsWith('m') && secondCharacterIsUppercase
             }
     }
 }

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistPreviewTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistPreviewTest.kt
@@ -14,23 +14,25 @@
  * limitations under the License.
  */
 
-package io.element.android.app
+package io.element.android.tests.konsist
 
 import com.lemonappdev.konsist.api.Konsist
-import com.lemonappdev.konsist.api.ext.list.properties
-import com.lemonappdev.konsist.api.verify.assertFalse
+import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
+import com.lemonappdev.konsist.api.verify.assertTrue
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import org.junit.Test
 
-class KonsistFieldTest {
+class KonsistPreviewTest {
     @Test
-    fun `no field should have 'm' prefix`() {
+    fun `Functions with '@PreviewsDayNight' annotation should have 'Preview' suffix`() {
         Konsist
             .scopeFromProject()
-            .classes()
-            .properties()
-            .assertFalse {
-                val secondCharacterIsUppercase = it.name.getOrNull(1)?.isUpperCase() ?: false
-                it.name.startsWith('m') && secondCharacterIsUppercase
+            .functions()
+            .withAllAnnotationsOf(PreviewsDayNight::class)
+            .assertTrue {
+                it.hasNameEndingWith("Preview") &&
+                    it.hasNameEndingWith("LightPreview").not() &&
+                    it.hasNameEndingWith("DarkPreview").not()
             }
     }
 }

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistTestTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistTestTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.element.android.app
+package io.element.android.tests.konsist
 
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.modifierprovider.withoutOverrideModifier


### PR DESCRIPTION
- Move Konsist tests to their own module
- Fix issue (merged today on develop, checked by previous version of Konsist tests)

The drawback is that dependencies will have to be added to the `konsist` module on-demand, for instance to check an annotation, a class, etc.