### PR TITLE
Always register the pusher when application starts

### DIFF
--- a/changelog.d/1481.bugfix
+++ b/changelog.d/1481.bugfix
@@ -1,0 +1,1 @@
+Always register the pusher when application starts

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/PushersManager.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/PushersManager.kt
@@ -63,20 +63,19 @@ class PushersManager @Inject constructor(
     override suspend fun registerPusher(matrixClient: MatrixClient, pushKey: String, gateway: String) {
         val userDataStore = userPushStoreFactory.create(matrixClient.sessionId)
         if (userDataStore.getCurrentRegisteredPushKey() == pushKey) {
-            Timber.tag(loggerTag.value).d("Unnecessary to register again the same pusher")
-        } else {
-            // Register the pusher to the server
-            matrixClient.pushersService().setHttpPusher(
-                createHttpPusher(pushKey, gateway, matrixClient.sessionId)
-            ).fold(
-                {
-                    userDataStore.setCurrentRegisteredPushKey(pushKey)
-                },
-                { throwable ->
-                    Timber.tag(loggerTag.value).e(throwable, "Unable to register the pusher")
-                }
-            )
+            Timber.tag(loggerTag.value)
+                .d("Unnecessary to register again the same pusher, but do it in case the pusher has been removed from the server")
         }
+        matrixClient.pushersService().setHttpPusher(
+            createHttpPusher(pushKey, gateway, matrixClient.sessionId)
+        ).fold(
+            {
+                userDataStore.setCurrentRegisteredPushKey(pushKey)
+            },
+            { throwable ->
+                Timber.tag(loggerTag.value).e(throwable, "Unable to register the pusher")
+            }
+        )
     }
 
     private suspend fun createHttpPusher(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Always register the pusher when application starts, in case the pusher get deleted on the server for some reason...
Also checked: when notification are disabled from the internal settings, the pusher is not unregistered. So there is no risk to enable notification again by registering again the pusher.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix #1481 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
