### PR TITLE
Remove typo labelled to labeled

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This project is in work in progress. The app does not cover yet all functionalit
 
 ## Contributing
 
-Want to get actively involved in the project? You're more than welcome! A good way to start is to check the issues that are labelled with the [good first issue](https://github.com/vector-im/element-x-android/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) label. Let us know by commenting the issue that you're starting working on it.
+Want to get actively involved in the project? You're more than welcome! A good way to start is to check the issues that are labeled with the [good first issue](https://github.com/vector-im/element-x-android/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) label. Let us know by commenting the issue that you're starting working on it.
 
 But first make sure to read our [contribution guide](CONTRIBUTING.md) first.
 


### PR DESCRIPTION
## Description:
This Pull Request fixes a typographical error in the README.md file.

## Changes Made:
Corrected "labelled" to "labeled" in the README.md file.

## Additional Information:
This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.