### PR TITLE
Make sure Konsist tests always run

### DIFF
--- a/tests/konsist/build.gradle.kts
+++ b/tests/konsist/build.gradle.kts
@@ -32,3 +32,10 @@ dependencies {
     testImplementation(projects.libraries.architecture)
     testImplementation(projects.libraries.designsystem)
 }
+
+// Make sure Konsist tests are always run. This is needed because otherwise we'd have to either:
+// - Add every single module as a dependency of this one.
+// - Move the Konsist tests to a the app module, which was causing issues.
+tasks.withType<Test>().configureEach {
+    outputs.upToDateWhen { false }
+}

--- a/tests/konsist/build.gradle.kts
+++ b/tests/konsist/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
 // Make sure Konsist tests are always run. This is needed because otherwise we'd have to either:
 // - Add every single module as a dependency of this one.
-// - Move the Konsist tests to a the app module, which was causing issues.
+// - Move the Konsist tests to the `app` module, but the `app` module does not need to know about Konsist.
 tasks.withType<Test>().configureEach {
     outputs.upToDateWhen { false }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

This PR adds a workaround so Konsist tests are always run.

## Motivation and context

Konsist tests weren't being run in either the CI or locally using gradle because all the tests were considered up to date. By setting the output as never up to date we make sure they're always run.

## Tests

<!-- Explain how you tested your development -->

- If the tests fail with the broken test commit, it's working.
