### PR TITLE
Hide keyboard when exiting the room screen

### DIFF
--- a/changelog.d/1375.bugfix
+++ b/changelog.d/1375.bugfix
@@ -1,0 +1,1 @@
+Hide keyboard when exiting the chat room screen.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -222,6 +223,14 @@ fun MessagesView(
     ReinviteDialog(
         state = state
     )
+
+    // Since the textfield is now based on an Android view, this is no longer done automatically.
+    // We need to hide the keyboard automatically when navigating out of this screen.
+    DisposableEffect(Unit) {
+        onDispose {
+            localView.hideKeyboard()
+        }
+    }
 }
 
 @Composable


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds a `DisposableEffect` to `MessagesView` so the keyboard is hidden when exiting the chat room screen. It seems to take a bit longer than usual, but at least it's hidden automatically.

## Motivation and context

Fixes #1375.

## Screenshots / GIFs

https://github.com/vector-im/element-x-android/assets/480955/39fd21c5-5d07-49cb-a2ea-c55e68362adf

## Tests

<!-- Explain how you tested your development -->

- Open a room.
- Tap on the message composer.
- Navigate to other screen (back, to the room settings, to some user's profile, to view a media file, etc.).

The keyboard should be hidden automatically.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
