### PR TITLE
Include desugaring lib also in library modules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -203,7 +203,6 @@ dependencies {
     implementation(projects.appnav)
     anvil(projects.anvilcodegen)
 
-    coreLibraryDesugaring(libs.android.desugar)
     implementation(libs.appyx.core)
     implementation(libs.androidx.splash)
     implementation(libs.androidx.core)

--- a/libraries/pushstore/impl/build.gradle.kts
+++ b/libraries/pushstore/impl/build.gradle.kts
@@ -55,6 +55,4 @@ dependencies {
     androidTestImplementation(libs.test.truth)
     androidTestImplementation(libs.test.runner)
     androidTestImplementation(projects.libraries.sessionStorage.test)
-
-    coreLibraryDesugaring(libs.android.desugar)
 }

--- a/libraries/session-storage/impl/build.gradle.kts
+++ b/libraries/session-storage/impl/build.gradle.kts
@@ -45,8 +45,6 @@ dependencies {
     testImplementation(libs.test.turbine)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.sqldelight.driver.jvm)
-
-    coreLibraryDesugaring(libs.android.desugar)
 }
 
 sqldelight {

--- a/plugins/src/main/kotlin/extension/CommonExtension.kt
+++ b/plugins/src/main/kotlin/extension/CommonExtension.kt
@@ -31,7 +31,6 @@ fun CommonExtension<*, *, *, *, *>.androidConfig(project: Project) {
     }
 
     compileOptions {
-        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }

--- a/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
@@ -32,9 +32,13 @@ plugins {
 android {
     androidConfig(project)
     composeConfig(libs)
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
     commonDependencies(libs)
     composeDependencies(libs)
+    coreLibraryDesugaring(libs.android.desugar)
 }

--- a/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
@@ -32,9 +32,13 @@ plugins {
 android {
     androidConfig(project)
     composeConfig(libs)
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
     commonDependencies(libs)
     composeDependencies(libs)
+    coreLibraryDesugaring(libs.android.desugar)
 }

--- a/plugins/src/main/kotlin/io.element.android-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-library.gradle.kts
@@ -29,8 +29,12 @@ plugins {
 
 android {
     androidConfig(project)
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
     commonDependencies(libs)
+    coreLibraryDesugaring(libs.android.desugar)
 }

--- a/samples/minimal/build.gradle.kts
+++ b/samples/minimal/build.gradle.kts
@@ -65,5 +65,4 @@ dependencies {
     implementation(projects.services.toolbox.impl)
     implementation(projects.libraries.featureflag.impl)
     implementation(libs.coroutines.core)
-    coreLibraryDesugaring(libs.android.desugar)
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Includes the `coreLibraryDesugaring(libs.android.desugar)` dependency in all modules which use one of our gradle plugins.

## Motivation and context

Right now desugaring is enabled also in library modules but the desugar dependency is not included in those.
This causes some unwanted side effects such as being unable to run compose previews in an emu.

This change will also include the desugar dependency in those libraries.