### PR TITLE
Add global `context.cacheDir` provider.

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/di/AppModule.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/AppModule.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.core.meta.BuildType
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarDispatcher
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
+import io.element.android.libraries.di.CacheDir
 import io.element.android.libraries.di.DefaultPreferences
 import io.element.android.libraries.di.SingleIn
 import io.element.android.x.BuildConfig
@@ -49,6 +50,12 @@ object AppModule {
     @Provides
     fun providesBaseDirectory(@ApplicationContext context: Context): File {
         return File(context.filesDir, "sessions")
+    }
+
+    @Provides
+    @CacheDir
+    fun providesCacheDirectory(@ApplicationContext context: Context): File {
+        return context.cacheDir
     }
 
     @Provides

--- a/app/src/main/kotlin/io/element/android/x/di/AppModule.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/AppModule.kt
@@ -31,7 +31,7 @@ import io.element.android.libraries.core.meta.BuildType
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarDispatcher
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
-import io.element.android.libraries.di.CacheDir
+import io.element.android.libraries.di.CacheDirectory
 import io.element.android.libraries.di.DefaultPreferences
 import io.element.android.libraries.di.SingleIn
 import io.element.android.x.BuildConfig
@@ -53,7 +53,7 @@ object AppModule {
     }
 
     @Provides
-    @CacheDir
+    @CacheDirectory
     fun providesCacheDirectory(@ApplicationContext context: Context): File {
         return context.cacheDir
     }

--- a/libraries/di/src/main/kotlin/io/element/android/libraries/di/ApplicationContext.kt
+++ b/libraries/di/src/main/kotlin/io/element/android/libraries/di/ApplicationContext.kt
@@ -18,4 +18,10 @@ package io.element.android.libraries.di
 
 import javax.inject.Qualifier
 
-@Qualifier annotation class ApplicationContext
+/**
+ * Qualifies a [Context] object that represents the application context.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Qualifier
+annotation class ApplicationContext

--- a/libraries/di/src/main/kotlin/io/element/android/libraries/di/CacheDir.kt
+++ b/libraries/di/src/main/kotlin/io/element/android/libraries/di/CacheDir.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.di
+
+import javax.inject.Qualifier
+
+@Qualifier annotation class CacheDir

--- a/libraries/di/src/main/kotlin/io/element/android/libraries/di/CacheDirectory.kt
+++ b/libraries/di/src/main/kotlin/io/element/android/libraries/di/CacheDirectory.kt
@@ -18,4 +18,10 @@ package io.element.android.libraries.di
 
 import javax.inject.Qualifier
 
-@Qualifier annotation class CacheDir
+/**
+ * Qualifies a [File] object which represents the application cache directory.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Qualifier
+annotation class CacheDirectory

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -17,7 +17,7 @@
 package io.element.android.libraries.matrix.impl
 
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
-import io.element.android.libraries.di.CacheDir
+import io.element.android.libraries.di.CacheDirectory
 import io.element.android.libraries.network.useragent.UserAgentProvider
 import io.element.android.libraries.sessionstorage.api.SessionData
 import io.element.android.libraries.sessionstorage.api.SessionStore
@@ -32,7 +32,7 @@ import javax.inject.Inject
 
 class RustMatrixClientFactory @Inject constructor(
     private val baseDirectory: File,
-    @CacheDir private val cacheDir: File,
+    @CacheDirectory private val cacheDirectory: File,
     private val appCoroutineScope: CoroutineScope,
     private val coroutineDispatchers: CoroutineDispatchers,
     private val sessionStore: SessionStore,
@@ -62,7 +62,7 @@ class RustMatrixClientFactory @Inject constructor(
             appCoroutineScope = appCoroutineScope,
             dispatchers = coroutineDispatchers,
             baseDirectory = baseDirectory,
-            baseCacheDirectory = cacheDir,
+            baseCacheDirectory = cacheDirectory,
             clock = clock,
         )
     }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -16,9 +16,8 @@
 
 package io.element.android.libraries.matrix.impl
 
-import android.content.Context
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
-import io.element.android.libraries.di.ApplicationContext
+import io.element.android.libraries.di.CacheDir
 import io.element.android.libraries.network.useragent.UserAgentProvider
 import io.element.android.libraries.sessionstorage.api.SessionData
 import io.element.android.libraries.sessionstorage.api.SessionStore
@@ -32,8 +31,8 @@ import java.io.File
 import javax.inject.Inject
 
 class RustMatrixClientFactory @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val baseDirectory: File,
+    @CacheDir private val cacheDir: File,
     private val appCoroutineScope: CoroutineScope,
     private val coroutineDispatchers: CoroutineDispatchers,
     private val sessionStore: SessionStore,
@@ -63,7 +62,7 @@ class RustMatrixClientFactory @Inject constructor(
             appCoroutineScope = appCoroutineScope,
             dispatchers = coroutineDispatchers,
             baseDirectory = baseDirectory,
-            baseCacheDirectory = context.cacheDir,
+            baseCacheDirectory = cacheDir,
             clock = clock,
         )
     }

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/MainActivity.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/MainActivity.kt
@@ -41,6 +41,7 @@ class MainActivity : ComponentActivity() {
 
     private val matrixAuthenticationService: MatrixAuthenticationService by lazy {
         val baseDirectory = File(applicationContext.filesDir, "sessions")
+        val cacheDir = applicationContext.cacheDir
         val userAgentProvider = SimpleUserAgentProvider("MinimalSample")
         val sessionStore = InMemorySessionStore()
         RustMatrixAuthenticationService(
@@ -49,8 +50,8 @@ class MainActivity : ComponentActivity() {
             sessionStore = sessionStore,
             userAgentProvider = userAgentProvider,
             rustMatrixClientFactory = RustMatrixClientFactory(
-                context = applicationContext,
                 baseDirectory = baseDirectory,
+                cacheDir = cacheDir,
                 appCoroutineScope = Singleton.appScope,
                 coroutineDispatchers = Singleton.coroutineDispatchers,
                 sessionStore = sessionStore,

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/MainActivity.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/MainActivity.kt
@@ -41,7 +41,6 @@ class MainActivity : ComponentActivity() {
 
     private val matrixAuthenticationService: MatrixAuthenticationService by lazy {
         val baseDirectory = File(applicationContext.filesDir, "sessions")
-        val cacheDir = applicationContext.cacheDir
         val userAgentProvider = SimpleUserAgentProvider("MinimalSample")
         val sessionStore = InMemorySessionStore()
         RustMatrixAuthenticationService(
@@ -51,7 +50,7 @@ class MainActivity : ComponentActivity() {
             userAgentProvider = userAgentProvider,
             rustMatrixClientFactory = RustMatrixClientFactory(
                 baseDirectory = baseDirectory,
-                cacheDir = cacheDir,
+                cacheDirectory = applicationContext.cacheDir,
                 appCoroutineScope = Singleton.appScope,
                 coroutineDispatchers = Singleton.coroutineDispatchers,
                 sessionStore = sessionStore,


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Dagger now provides the app's `cacheDir` when requesting a `@CacheDirectory File`  type.

## Motivation and context

To support some upcoming code that needs the `cacheDir` to be changed during tests.
