### PR TITLE
Set tracing of `matrix_sdk_ui::timeline` to `trace`

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingFilterConfiguration.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingFilterConfiguration.kt
@@ -28,6 +28,7 @@ data class TracingFilterConfiguration(
         Target.MATRIX_SDK_HTTP_CLIENT to LogLevel.DEBUG,
         Target.MATRIX_SDK_SLIDING_SYNC to LogLevel.TRACE,
         Target.MATRIX_SDK_BASE_SLIDING_SYNC to LogLevel.TRACE,
+        Target.MATRIX_SDK_UI_TIMELINE to LogLevel.TRACE,
     )
 
     fun getLogLevel(target: Target): LogLevel {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
Requested by the Rust team do try to debug the gaps in the timeline reported by some users.
