### PR TITLE
Add `BackupState` and `BackupStateMapper`

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/BackupState.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/BackupState.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.api.encryption
+
+enum class BackupState {
+    UNKNOWN,
+    CREATING,
+    ENABLING,
+    RESUMING,
+    ENABLED,
+    DOWNLOADING,
+    DISABLING,
+    DISABLED;
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/BackupStateMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/BackupStateMapper.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.encryption
+
+import io.element.android.libraries.matrix.api.encryption.BackupState
+import org.matrix.rustcomponents.sdk.BackupState as RustBackupState
+
+class BackupStateMapper {
+    fun map(backupState: RustBackupState): BackupState {
+        return when (backupState) {
+            RustBackupState.UNKNOWN -> BackupState.UNKNOWN
+            RustBackupState.CREATING -> BackupState.CREATING
+            RustBackupState.ENABLING -> BackupState.ENABLING
+            RustBackupState.RESUMING -> BackupState.RESUMING
+            RustBackupState.ENABLED -> BackupState.ENABLED
+            RustBackupState.DOWNLOADING -> BackupState.DOWNLOADING
+            RustBackupState.DISABLING -> BackupState.DISABLING
+            RustBackupState.DISABLED -> BackupState.DISABLED
+        }
+    }
+}


### PR DESCRIPTION
Add `BackupState` and `BackupStateMapper` from the `feature/bma/secureBackup` branch to ensure that we do not upgrade the SDK with no support of KeyBackup.

This will act as a poison pill to avoid mistake when building new version of the SDK.