### PR TITLE
Enable seeking in voice message preview player

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/VoiceMessageException.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/VoiceMessageException.kt
@@ -17,6 +17,9 @@
 package io.element.android.features.messages.impl.voicemessages
 
 internal sealed class VoiceMessageException : Exception() {
+    data class StateException(
+        override val message: String?, override val cause: Throwable? = null
+    ) : VoiceMessageException()
     data class FileException(
         override val message: String?, override val cause: Throwable? = null
     ) : VoiceMessageException()

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenter.kt
@@ -18,6 +18,7 @@ package io.element.android.features.messages.impl.voicemessages.composer
 
 import android.Manifest
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -69,6 +70,15 @@ class VoiceMessageComposerPresenter @Inject constructor(
         val playerState by player.state.collectAsState(initial = VoiceMessageComposerPlayer.State.NotPlaying)
         val isPlaying by remember(playerState.isPlaying) { derivedStateOf { playerState.isPlaying } }
         val waveform by remember(recorderState) { derivedStateOf { recorderState.finishedWaveform() } }
+
+        LaunchedEffect(recorderState) {
+            val recording = recorderState as? VoiceRecorderState.Finished ?: return@LaunchedEffect
+
+            player.setMedia(
+                mediaPath = recording.file.path,
+                mimeType = recording.mimeType,
+            )
+        }
 
         val onLifecycleEvent = { event: Lifecycle.Event ->
             when (event) {

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/media/FakeWaveformFactory.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/media/FakeWaveformFactory.kt
@@ -20,17 +20,15 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlin.random.Random
 
-object FakeWaveformFactory {
-    /**
-     * Generate a waveform for testing purposes.
-     *
-     * The waveform is a list of floats between 0 and 1.
-     *
-     * @param length The length of the waveform.
-     */
-    fun createFakeWaveform(length: Int = 1000): ImmutableList<Float> {
-        val random = Random(seed = 2)
-        return List(length) { random.nextFloat() }
-            .toPersistentList()
-    }
+/**
+ * Generate a waveform for testing purposes.
+ *
+ * The waveform is a list of floats between 0 and 1.
+ *
+ * @param length The length of the waveform.
+ */
+fun createFakeWaveform(length: Int = 1000): ImmutableList<Float> {
+    val random = Random(seed = 2)
+    return List(length) { random.nextFloat() }
+        .toPersistentList()
 }

--- a/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
+++ b/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
@@ -30,6 +30,15 @@ interface MediaPlayer : AutoCloseable {
     val state: StateFlow<State>
 
     /**
+     * Acquires control of the player with a given media.
+     */
+    fun acquireControl(
+        uri: String,
+        mediaId: String,
+        mimeType: String,
+    )
+
+    /**
      * Acquires control of the player and starts playing the given media.
      */
     fun acquireControlAndPlay(
@@ -74,5 +83,10 @@ interface MediaPlayer : AutoCloseable {
          * The current position of the player.
          */
         val currentPosition: Long,
+
+        /**
+         * The duration of the player content.
+         */
+        val duration: Long,
     )
 }

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
@@ -47,6 +47,7 @@ class MediaPlayerImpl @Inject constructor(
             _state.update {
                 it.copy(
                     currentPosition = player.currentPosition,
+                    duration = player.duration,
                     isPlaying = isPlaying,
                 )
             }
@@ -61,6 +62,7 @@ class MediaPlayerImpl @Inject constructor(
             _state.update {
                 it.copy(
                     currentPosition = player.currentPosition,
+                    duration = player.duration,
                     mediaId = mediaItem?.mediaId,
                 )
             }
@@ -74,11 +76,11 @@ class MediaPlayerImpl @Inject constructor(
     private val scope = CoroutineScope(Job() + Dispatchers.Main)
     private var job: Job? = null
 
-    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L))
+    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L, 0L))
 
     override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
 
-    override fun acquireControlAndPlay(uri: String, mediaId: String, mimeType: String) {
+    override fun acquireControl(uri: String, mediaId: String, mimeType: String) {
         player.clearMediaItems()
         player.setMediaItem(
             MediaItem.Builder()
@@ -88,6 +90,9 @@ class MediaPlayerImpl @Inject constructor(
                 .build()
         )
         player.prepare()
+    }
+    override fun acquireControlAndPlay(uri: String, mediaId: String, mimeType: String) {
+        acquireControl(uri, mediaId, mimeType)
         player.play()
     }
 

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
@@ -18,6 +18,7 @@ package io.element.android.libraries.mediaplayer.impl
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.Tracks
 import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.di.SingleIn
@@ -64,6 +65,15 @@ class MediaPlayerImpl @Inject constructor(
                     currentPosition = player.currentPosition,
                     duration = player.duration,
                     mediaId = mediaItem?.mediaId,
+                )
+            }
+        }
+
+        override fun onTracksChanged(tracks: Tracks) {
+            _state.update {
+                it.copy(
+                    currentPosition = player.currentPosition,
+                    duration = player.duration,
                 )
             }
         }
@@ -135,7 +145,10 @@ class MediaPlayerImpl @Inject constructor(
             if (!_state.value.isPlaying) return
             delay(100)
             _state.update {
-                it.copy(currentPosition = player.currentPosition)
+                it.copy(
+                    currentPosition = player.currentPosition,
+                    duration = player.duration,
+                )
             }
         }
     }

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
@@ -19,6 +19,7 @@ package io.element.android.libraries.mediaplayer.impl
 import android.content.Context
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.Tracks
 import androidx.media3.exoplayer.ExoPlayer
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -45,6 +46,7 @@ interface SimplePlayer {
     interface Listener {
         fun onIsPlayingChanged(isPlaying: Boolean)
         fun onMediaItemTransition(mediaItem: MediaItem?)
+        fun onTracksChanged(tracks: Tracks)
     }
 }
 
@@ -67,6 +69,7 @@ class SimplePlayerImpl(
         p.addListener(object : Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) = listener.onIsPlayingChanged(isPlaying)
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) = listener.onMediaItemTransition(mediaItem)
+            override fun onTracksChanged(tracks: Tracks) = listener.onTracksChanged(tracks)
         })
     }
     override val duration: Long

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.di.RoomScope
  */
 interface SimplePlayer {
     fun addListener(listener: Listener)
+    val duration: Long
     val currentPosition: Long
     val playbackState: Int
     fun clearMediaItems()
@@ -68,12 +69,12 @@ class SimplePlayerImpl(
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) = listener.onMediaItemTransition(mediaItem)
         })
     }
-
+    override val duration: Long
+        get() = p.duration
     override val currentPosition: Long
         get() = p.currentPosition
     override val playbackState: Int
         get() = p.playbackState
-
     override fun clearMediaItems() = p.clearMediaItems()
 
     override fun setMediaItem(mediaItem: MediaItem) = p.setMediaItem(mediaItem)

--- a/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
+++ b/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
@@ -29,6 +29,11 @@ class FakeMediaPlayer : MediaPlayer {
     private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L, 0L))
 
     override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
+    
+    companion object {
+        private const val defaultDurationMs = 10000L
+        private const val staticPlayedMs = 1000L
+    }
 
     override fun acquireControl(uri: String, mediaId: String, mimeType: String) {
         _state.update {
@@ -36,7 +41,7 @@ class FakeMediaPlayer : MediaPlayer {
                 isPlaying = false,
                 mediaId = mediaId,
                 currentPosition = it.currentPosition,
-                duration = 10000L,
+                duration = defaultDurationMs,
             )
         }
     }
@@ -45,8 +50,8 @@ class FakeMediaPlayer : MediaPlayer {
             it.copy(
                 isPlaying = true,
                 mediaId = mediaId,
-                currentPosition = it.currentPosition + 1000L,
-                duration = 10000L,
+                currentPosition = it.currentPosition + staticPlayedMs,
+                duration = defaultDurationMs,
             )
         }
     }
@@ -55,7 +60,7 @@ class FakeMediaPlayer : MediaPlayer {
         _state.update {
             it.copy(
                 isPlaying = true,
-                currentPosition = it.currentPosition + 1000L,
+                currentPosition = it.currentPosition + staticPlayedMs,
             )
         }
     }

--- a/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
+++ b/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
@@ -29,9 +29,9 @@ class FakeMediaPlayer : MediaPlayer {
     private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L, 0L))
 
     override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
-    
+
     companion object {
-        private const val defaultDurationMs = 10000L
+        private const val defaultDurationMs = 10_000L
         private const val staticPlayedMs = 1000L
     }
 

--- a/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
+++ b/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
@@ -26,16 +26,27 @@ import kotlinx.coroutines.flow.update
  * Fake implementation of [MediaPlayer] for testing purposes.
  */
 class FakeMediaPlayer : MediaPlayer {
-    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L))
+    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L, 0L))
 
     override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
 
+    override fun acquireControl(uri: String, mediaId: String, mimeType: String) {
+        _state.update {
+            it.copy(
+                isPlaying = false,
+                mediaId = mediaId,
+                currentPosition = it.currentPosition,
+                duration = 10000L,
+            )
+        }
+    }
     override fun acquireControlAndPlay(uri: String, mediaId: String, mimeType: String) {
         _state.update {
             it.copy(
                 isPlaying = true,
                 mediaId = mediaId,
                 currentPosition = it.currentPosition + 1000L,
+                duration = 10000L,
             )
         }
     }

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -48,7 +48,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import io.element.android.libraries.designsystem.components.media.FakeWaveformFactory.createFakeWaveform
+import io.element.android.libraries.designsystem.components.media.createFakeWaveform
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.text.applyScaleUp
@@ -193,7 +193,7 @@ fun TextComposer(
             when (voiceMessageState) {
                 VoiceMessageState.Idle,
                 is VoiceMessageState.Recording -> recordVoiceButton
-                is VoiceMessageState.Preview -> when(voiceMessageState.isSending) {
+                is VoiceMessageState.Preview -> when (voiceMessageState.isSending) {
                     true -> uploadVoiceProgress
                     false -> sendVoiceButton
                 }
@@ -208,6 +208,7 @@ fun TextComposer(
                 VoiceMessagePreview(
                     isInteractive = !voiceMessageState.isSending,
                     isPlaying = voiceMessageState.isPlaying,
+                    playbackProgress = voiceMessageState.playbackProgress,
                     waveform = voiceMessageState.waveform,
                     onPlayClick = onPlayVoiceMessageClicked,
                     onPauseClick = onPauseVoiceMessageClicked,
@@ -220,7 +221,7 @@ fun TextComposer(
     }
 
     val voiceDeleteButton = @Composable {
-        if(voiceMessageState is VoiceMessageState.Preview) {
+        if (voiceMessageState is VoiceMessageState.Preview) {
             VoiceMessageDeleteButton(enabled = !voiceMessageState.isSending, onClick = onDeleteVoiceMessage)
         }
     }
@@ -816,11 +817,32 @@ internal fun TextComposerVoicePreview() = ElementPreview {
     PreviewColumn(items = persistentListOf({
         VoicePreview(voiceMessageState = VoiceMessageState.Recording(61.seconds, 0.5f))
     }, {
-        VoicePreview(voiceMessageState = VoiceMessageState.Preview(isSending = false, isPlaying = false, waveform = createFakeWaveform()))
+        VoicePreview(
+            voiceMessageState = VoiceMessageState.Preview(
+                isSending = false,
+                isPlaying = false,
+                playbackProgress = 0f,
+                waveform = createFakeWaveform()
+            )
+        )
     }, {
-        VoicePreview(voiceMessageState = VoiceMessageState.Preview(isSending = false, isPlaying = true, waveform = createFakeWaveform()))
+        VoicePreview(
+            voiceMessageState = VoiceMessageState.Preview(
+                isSending = false,
+                isPlaying = true,
+                playbackProgress = 0.2f,
+                waveform = createFakeWaveform()
+            )
+        )
     }, {
-        VoicePreview(voiceMessageState = VoiceMessageState.Preview(isSending = true, isPlaying = false, waveform = createFakeWaveform()))
+        VoicePreview(
+            voiceMessageState = VoiceMessageState.Preview(
+                isSending = true,
+                isPlaying = false,
+                playbackProgress = 0.0f,
+                waveform = createFakeWaveform()
+            )
+        )
     }))
 }
 

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessagePreview.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessagePreview.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import io.element.android.libraries.designsystem.components.media.FakeWaveformFactory.createFakeWaveform
 import io.element.android.libraries.designsystem.components.media.WaveformPlaybackView
+import io.element.android.libraries.designsystem.components.media.createFakeWaveform
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.text.applyScaleUp
@@ -143,7 +143,7 @@ internal fun VoiceMessagePreviewPreview() = ElementPreview {
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        VoiceMessagePreview(isInteractive = true, isPlaying = true, waveform = createFakeWaveform())
+        VoiceMessagePreview(isInteractive = true, isPlaying = true, playbackProgress = 0.2f, waveform = createFakeWaveform())
         VoiceMessagePreview(isInteractive = true, isPlaying = false, waveform = createFakeWaveform())
         VoiceMessagePreview(isInteractive = false, isPlaying = false, waveform = createFakeWaveform())
     }

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/VoiceMessageState.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/VoiceMessageState.kt
@@ -25,6 +25,7 @@ sealed class VoiceMessageState {
     data class Preview(
         val isSending: Boolean,
         val isPlaying: Boolean,
+        val playbackProgress: Float,
         val waveform: ImmutableList<Float>,
     ): VoiceMessageState()
 


### PR DESCRIPTION

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Enable seeking in voice message preview player.

## Motivation and context

- Part of https://github.com/vector-im/element-meta/issues/2104

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

- Record audio
- Seek the audio
- Play the audio
- Seek while playing

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
