### PR TITLE
Display a single notification for unable to decrypt Event received form push (fallback notification)

### DIFF
--- a/changelog.d/994.bugfix
+++ b/changelog.d/994.bugfix
@@ -1,0 +1,1 @@
+Group fallback notification to avoid having plenty of them displayed.

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotificationDrawerManager.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotificationDrawerManager.kt
@@ -195,9 +195,9 @@ class DefaultNotificationDrawerManager @Inject constructor(
     /**
      * Clear the notifications for a single event.
      */
-    fun clearEvent(eventId: EventId, doRender: Boolean) {
+    fun clearEvent(sessionId: SessionId, eventId: EventId, doRender: Boolean) {
         updateEvents(doRender = doRender) {
-            it.clearEvent(eventId)
+            it.clearEvent(sessionId, eventId)
         }
     }
 

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiver.kt
@@ -56,7 +56,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
                 defaultNotificationDrawerManager.clearMembershipNotificationForRoom(sessionId, roomId, doRender = false)
             }
             actionIds.dismissEvent -> if (eventId != null) {
-                defaultNotificationDrawerManager.clearEvent(eventId, doRender = false)
+                defaultNotificationDrawerManager.clearEvent(sessionId, eventId, doRender = false)
             }
             actionIds.markRoomRead -> if (roomId != null) {
                 defaultNotificationDrawerManager.clearMessagesForRoom(sessionId, roomId, doRender = true)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationEventQueue.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationEventQueue.kt
@@ -135,8 +135,8 @@ data class NotificationEventQueue constructor(
         )
     }
 
-    fun clearEvent(eventId: EventId) {
-        queue.removeAll { it.eventId == eventId }
+    fun clearEvent(sessionId: SessionId, eventId: EventId) {
+        queue.removeAll { it.sessionId == sessionId && it.eventId == eventId }
     }
 
     fun clearMembershipNotificationForSession(sessionId: SessionId) {

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationEventQueue.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationEventQueue.kt
@@ -136,7 +136,13 @@ data class NotificationEventQueue constructor(
     }
 
     fun clearEvent(sessionId: SessionId, eventId: EventId) {
-        queue.removeAll { it.sessionId == sessionId && it.eventId == eventId }
+        val isFallback = queue.firstOrNull { it.sessionId == sessionId && it.eventId == eventId } is FallbackNotifiableEvent
+        if (isFallback) {
+            Timber.d("Removing all the fallbacks")
+            queue.removeAll { it.sessionId == sessionId && it is FallbackNotifiableEvent }
+        } else {
+            queue.removeAll { it.sessionId == sessionId && it.eventId == eventId }
+        }
     }
 
     fun clearMembershipNotificationForSession(sessionId: SessionId) {

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationRenderer.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationRenderer.kt
@@ -124,6 +124,7 @@ class NotificationRenderer @Inject constructor(
                 }
             }
 
+            /*
             fallbackNotifications.forEach { wrapper ->
                 when (wrapper) {
                     is OneShotNotification.Removed -> {
@@ -142,6 +143,23 @@ class NotificationRenderer @Inject constructor(
                         )
                     }
                 }
+            }
+             */
+            val removedFallback = fallbackNotifications.filterIsInstance<OneShotNotification.Removed>()
+            val appendFallback = fallbackNotifications.filterIsInstance<OneShotNotification.Append>()
+            if (appendFallback.isEmpty() && removedFallback.isNotEmpty()) {
+                Timber.tag(loggerTag.value).d("Removing global fallback notification")
+                notificationDisplayer.cancelNotificationMessage(
+                    tag = "FALLBACK",
+                    id = notificationIdProvider.getFallbackNotificationId(currentUser.userId)
+                )
+            } else if (appendFallback.isNotEmpty()) {
+                Timber.tag(loggerTag.value).d("Showing fallback notification")
+                notificationDisplayer.showNotificationMessage(
+                    tag = "FALLBACK",
+                    id = notificationIdProvider.getFallbackNotificationId(currentUser.userId),
+                    notification = appendFallback.first().notification
+                )
             }
 
             // Update summary last to avoid briefly displaying it before other notifications


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
This PR ensure that only a single notification is displayed for all the unable to decrypt Event. Previously there was one fallback notification per event, which can end up to many notification with low added value displayed.

First commit is a fix for better support for multi account.

Note that I prefer to comment out the code, to be able to revert in case we want to have again the previous behavior (for test).

Also the fix looks like a workaround, but we need to keep the existing model, to ensure that the fallback notification is still displayed if several rooms have UTC notification. One Notification is still created per FallbackNotifiableEvent, but we display only the first one (there are identical for now) 

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #994 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
NA

## Tests

<!-- Explain how you tested your development -->

- Set up a room where Push event end up with unable to decrypt Event when fetching from Push (not sure how to do this though...)
- Send a message from another client to this room. Observe that the fallback notification is displayed.
- Send another message. Observe that no new fallback notification is displayed

Then either:
- click on the notification: the app is opened on the room list (this is the current bahavior, there is no change here)
- dismiss the notification: see in the logcat that `Removing all the fallbacks` is printed
- open the app and open the room: the notification is automatically dismissed.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
