### PR TITLE
Show voice message preview player progress

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPlayer.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPlayer.kt
@@ -41,7 +41,8 @@ class VoiceMessageComposerPlayer @Inject constructor(
 
         State(
             isPlaying = state.isPlaying,
-            currentPosition = state.currentPosition
+            currentPosition = state.currentPosition,
+            duration = state.duration,
         )
     }.distinctUntilChanged()
 
@@ -82,12 +83,23 @@ class VoiceMessageComposerPlayer @Inject constructor(
          * The elapsed time of this player in milliseconds.
          */
         val currentPosition: Long,
+        /**
+         * The duration of this player in milliseconds.
+         */
+        val duration: Long,
     ) {
         companion object {
             val NotPlaying = State(
                 isPlaying = false,
                 currentPosition = 0L,
+                duration = 0L,
             )
         }
+
+        /**
+         * The progress of this player between 0 and 1.
+         */
+        val progress: Float =
+            if (duration <= currentPosition) 0f else currentPosition.toFloat() / duration.toFloat()
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenter.kt
@@ -185,6 +185,7 @@ class VoiceMessageComposerPresenter @Inject constructor(
                 is VoiceRecorderState.Finished -> VoiceMessageState.Preview(
                     isSending = isSending,
                     isPlaying = isPlaying,
+                    playbackProgress = playerState.progress,
                     waveform = waveform,
                 )
                 else -> VoiceMessageState.Idle

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
@@ -220,7 +220,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
             awaitItem().eventSink(VoiceMessageComposerEvents.DeleteVoiceMessage)
             awaitItem().apply {
-                assertThat(voiceMessageState).isEqualTo(aPreviewState(isPlaying = false))
+                assertThat(voiceMessageState).isEqualTo(aPreviewState(isPlaying = false, playbackProgress = 0.1f))
             }
 
             val finalState = awaitItem()
@@ -262,7 +262,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
             awaitItem().eventSink(VoiceMessageComposerEvents.SendVoiceMessage)
             assertThat(awaitItem().voiceMessageState).isEqualTo(aPreviewState(
-                isSending = true, isPlaying = false,
+                isSending = true, isPlaying = false, playbackProgress = 0.1f
             ))
 
             val finalState = awaitItem()

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
@@ -164,7 +164,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
             val finalState = awaitItem().also {
-                assertThat(it.voiceMessageState).isEqualTo(aPreviewState(isPlaying = true))
+                assertThat(it.voiceMessageState).isEqualTo(aPreviewState(isPlaying = true, playbackProgress = 0.1f))
             }
             voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 0)
 
@@ -183,7 +183,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Pause))
             val finalState = awaitItem().also {
-                assertThat(it.voiceMessageState).isEqualTo(aPreviewState(isPlaying = false))
+                assertThat(it.voiceMessageState).isEqualTo(aPreviewState(isPlaying = false, playbackProgress = 0.1f))
             }
             voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 0)
 
@@ -510,7 +510,7 @@ class VoiceMessageComposerPresenterTest {
             is VoiceMessageState.Preview -> when (state.isPlaying) {
                 // If the preview was playing, it pauses
                 true -> awaitItem().apply {
-                    assertThat(voiceMessageState).isEqualTo(aPreviewState())
+                    assertThat(voiceMessageState).isEqualTo(aPreviewState(playbackProgress = 0.1f))
                 }
                 false -> mostRecentState
             }
@@ -561,10 +561,12 @@ class VoiceMessageComposerPresenterTest {
 
     private fun aPreviewState(
         isPlaying: Boolean = false,
+        playbackProgress: Float = 0f,
         isSending: Boolean = false,
         waveform: List<Float> = voiceRecorder.waveform,
     ) = VoiceMessageState.Preview(
         isPlaying = isPlaying,
+        playbackProgress = playbackProgress,
         isSending = isSending,
         waveform = waveform.toImmutableList(),
     )

--- a/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
+++ b/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
@@ -75,7 +75,7 @@ interface MediaPlayer : AutoCloseable {
          */
         val currentPosition: Long,
         /**
-         * The duration of the player content, if it exists.
+         * The duration of the current content.
          */
         val duration: Long,
     )

--- a/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
+++ b/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
@@ -74,5 +74,9 @@ interface MediaPlayer : AutoCloseable {
          * The current position of the player.
          */
         val currentPosition: Long,
+        /**
+         * The duration of the player content, if it exists.
+         */
+        val duration: Long,
     )
 }

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
@@ -47,6 +47,7 @@ class MediaPlayerImpl @Inject constructor(
             _state.update {
                 it.copy(
                     currentPosition = player.currentPosition,
+                    duration = duration ?: 0L,
                     isPlaying = isPlaying,
                 )
             }
@@ -61,6 +62,7 @@ class MediaPlayerImpl @Inject constructor(
             _state.update {
                 it.copy(
                     currentPosition = player.currentPosition,
+                    duration = duration ?: 0L,
                     mediaId = mediaItem?.mediaId,
                 )
             }
@@ -74,9 +76,13 @@ class MediaPlayerImpl @Inject constructor(
     private val scope = CoroutineScope(Job() + Dispatchers.Main)
     private var job: Job? = null
 
-    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L))
+    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L, 0L))
 
     override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
+
+    // The underlying player returns negative status codes which we map to null
+    private val duration: Long?
+        get() = player.duration.takeIf { it > 0 }
 
     override fun acquireControlAndPlay(uri: String, mediaId: String, mimeType: String) {
         player.clearMediaItems()

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
@@ -47,7 +47,7 @@ class MediaPlayerImpl @Inject constructor(
             _state.update {
                 it.copy(
                     currentPosition = player.currentPosition,
-                    duration = duration ?: 0L,
+                    duration = player.duration.coerceAtLeast(0),
                     isPlaying = isPlaying,
                 )
             }
@@ -62,7 +62,7 @@ class MediaPlayerImpl @Inject constructor(
             _state.update {
                 it.copy(
                     currentPosition = player.currentPosition,
-                    duration = duration ?: 0L,
+                    duration = player.duration.coerceAtLeast(0),
                     mediaId = mediaItem?.mediaId,
                 )
             }
@@ -79,10 +79,6 @@ class MediaPlayerImpl @Inject constructor(
     private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L, 0L))
 
     override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
-
-    // The underlying player returns negative status codes which we map to null
-    private val duration: Long?
-        get() = player.duration.takeIf { it > 0 }
 
     override fun acquireControlAndPlay(uri: String, mediaId: String, mimeType: String) {
         player.clearMediaItems()

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
@@ -32,6 +32,7 @@ import io.element.android.libraries.di.RoomScope
 interface SimplePlayer {
     fun addListener(listener: Listener)
     val currentPosition: Long
+    val duration: Long
     val playbackState: Int
     fun clearMediaItems()
     fun setMediaItem(mediaItem: MediaItem)
@@ -73,6 +74,8 @@ class SimplePlayerImpl(
         get() = p.currentPosition
     override val playbackState: Int
         get() = p.playbackState
+    override val duration: Long
+        get() = p.duration
 
     override fun clearMediaItems() = p.clearMediaItems()
 

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
@@ -32,8 +32,8 @@ import io.element.android.libraries.di.RoomScope
 interface SimplePlayer {
     fun addListener(listener: Listener)
     val currentPosition: Long
-    val duration: Long
     val playbackState: Int
+    val duration: Long
     fun clearMediaItems()
     fun setMediaItem(mediaItem: MediaItem)
     fun getCurrentMediaItem(): MediaItem?

--- a/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
+++ b/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
@@ -26,14 +26,14 @@ import kotlinx.coroutines.flow.update
  * Fake implementation of [MediaPlayer] for testing purposes.
  */
 class FakeMediaPlayer : MediaPlayer {
-    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L, 0L))
-
-    override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
-
     companion object {
         private const val FAKE_TOTAL_DURATION_MS = 10_000L
         private const val FAKE_PLAYED_DURATION_MS = 1000L
     }
+
+    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L, 0L))
+
+    override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
 
     override fun acquireControlAndPlay(uri: String, mediaId: String, mimeType: String) {
         _state.update {

--- a/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
+++ b/libraries/mediaplayer/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeMediaPlayer.kt
@@ -26,16 +26,22 @@ import kotlinx.coroutines.flow.update
  * Fake implementation of [MediaPlayer] for testing purposes.
  */
 class FakeMediaPlayer : MediaPlayer {
-    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L))
+    private val _state = MutableStateFlow(MediaPlayer.State(false, null, 0L, 0L))
 
     override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
+
+    companion object {
+        private const val FAKE_TOTAL_DURATION_MS = 10_000L
+        private const val FAKE_PLAYED_DURATION_MS = 1000L
+    }
 
     override fun acquireControlAndPlay(uri: String, mediaId: String, mimeType: String) {
         _state.update {
             it.copy(
                 isPlaying = true,
                 mediaId = mediaId,
-                currentPosition = it.currentPosition + 1000L,
+                currentPosition = it.currentPosition + FAKE_PLAYED_DURATION_MS,
+                duration = FAKE_TOTAL_DURATION_MS,
             )
         }
     }
@@ -44,7 +50,8 @@ class FakeMediaPlayer : MediaPlayer {
         _state.update {
             it.copy(
                 isPlaying = true,
-                currentPosition = it.currentPosition + 1000L,
+                currentPosition = it.currentPosition + FAKE_PLAYED_DURATION_MS,
+                duration = FAKE_TOTAL_DURATION_MS,
             )
         }
     }

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -76,8 +76,8 @@ import io.element.android.libraries.textcomposer.components.textInputRoundedCorn
 import io.element.android.libraries.textcomposer.model.Message
 import io.element.android.libraries.textcomposer.model.MessageComposerMode
 import io.element.android.libraries.textcomposer.model.PressEvent
-import io.element.android.libraries.textcomposer.model.VoiceMessagePlayerEvent
 import io.element.android.libraries.textcomposer.model.Suggestion
+import io.element.android.libraries.textcomposer.model.VoiceMessagePlayerEvent
 import io.element.android.libraries.textcomposer.model.VoiceMessageState
 import io.element.android.libraries.theme.ElementTheme
 import io.element.android.libraries.ui.strings.CommonStrings
@@ -86,8 +86,8 @@ import io.element.android.wysiwyg.compose.RichTextEditorState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
-import kotlin.time.Duration.Companion.seconds
 import uniffi.wysiwyg_composer.MenuAction
+import kotlin.time.Duration.Companion.seconds
 
 @Composable
 fun TextComposer(
@@ -194,7 +194,7 @@ fun TextComposer(
             when (voiceMessageState) {
                 VoiceMessageState.Idle,
                 is VoiceMessageState.Recording -> recordVoiceButton
-                is VoiceMessageState.Preview -> when(voiceMessageState.isSending) {
+                is VoiceMessageState.Preview -> when (voiceMessageState.isSending) {
                     true -> uploadVoiceProgress
                     false -> sendVoiceButton
                 }
@@ -210,6 +210,7 @@ fun TextComposer(
                     isInteractive = !voiceMessageState.isSending,
                     isPlaying = voiceMessageState.isPlaying,
                     waveform = voiceMessageState.waveform,
+                    playbackProgress = voiceMessageState.playbackProgress,
                     onPlayClick = onPlayVoiceMessageClicked,
                     onPauseClick = onPauseVoiceMessageClicked,
                     onSeek = onSeekVoiceMessage,
@@ -221,7 +222,7 @@ fun TextComposer(
     }
 
     val voiceDeleteButton = @Composable {
-        if(voiceMessageState is VoiceMessageState.Preview) {
+        if (voiceMessageState is VoiceMessageState.Preview) {
             VoiceMessageDeleteButton(enabled = !voiceMessageState.isSending, onClick = onDeleteVoiceMessage)
         }
     }
@@ -817,11 +818,32 @@ internal fun TextComposerVoicePreview() = ElementPreview {
     PreviewColumn(items = persistentListOf({
         VoicePreview(voiceMessageState = VoiceMessageState.Recording(61.seconds, List(100) { it.toFloat() / 100 }.toPersistentList()))
     }, {
-        VoicePreview(voiceMessageState = VoiceMessageState.Preview(isSending = false, isPlaying = false, waveform = createFakeWaveform()))
+        VoicePreview(
+            voiceMessageState = VoiceMessageState.Preview(
+                isSending = false,
+                isPlaying = false,
+                waveform = createFakeWaveform(),
+                playbackProgress = 0.0f
+            )
+        )
     }, {
-        VoicePreview(voiceMessageState = VoiceMessageState.Preview(isSending = false, isPlaying = true, waveform = createFakeWaveform()))
+        VoicePreview(
+            voiceMessageState = VoiceMessageState.Preview(
+                isSending = false,
+                isPlaying = true,
+                waveform = createFakeWaveform(),
+                playbackProgress = 0.2f
+            )
+        )
     }, {
-        VoicePreview(voiceMessageState = VoiceMessageState.Preview(isSending = true, isPlaying = false, waveform = createFakeWaveform()))
+        VoicePreview(
+            voiceMessageState = VoiceMessageState.Preview(
+                isSending = true,
+                isPlaying = false,
+                waveform = createFakeWaveform(),
+                playbackProgress = 0.0f
+            )
+        )
     }))
 }
 

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessagePreview.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessagePreview.kt
@@ -95,6 +95,7 @@ internal fun VoiceMessagePreview(
             playbackProgress = playbackProgress,
             showCursor = isInteractive,
             waveform = waveform,
+            seekEnabled = false, // TODO enable seeking
             onSeek = onSeek,
         )
     }

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/VoiceMessageState.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/VoiceMessageState.kt
@@ -25,6 +25,7 @@ sealed class VoiceMessageState {
     data class Preview(
         val isSending: Boolean,
         val isPlaying: Boolean,
+        val playbackProgress: Float,
         val waveform: ImmutableList<Float>,
     ): VoiceMessageState()
 

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[l.textcomposer_null_TextComposerVoice-D-4_4_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[l.textcomposer_null_TextComposerVoice-D-4_4_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d93f97e1ae36edc6375b00de4421166f8012ab16cc6629897b6a36b062cbbff6
-size 27255
+oid sha256:e2fe52c3e34e58ab38f7fa0b4b2281bdd8ef269acb3426449faa93fe7b434feb
+size 27393

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[l.textcomposer_null_TextComposerVoice-N-4_5_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[l.textcomposer_null_TextComposerVoice-N-4_5_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b34b9934ea8c06dc98b080d6dcd07c2c12d95c0841c1fd09e2ebc62bb8df2fce
-size 24904
+oid sha256:ffa7daeaf5e27170395307c87c68a7674fb115bb9806cfc0d438a905571ce37f
+size 25100


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Display the progress bar while playing a voice message preview
- Disable seeking the preview player while it is not yet implemented

## Motivation and context

- https://github.com/vector-im/element-meta/issues/2104

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
