### PR TITLE
Keep screen on during voice message recording

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -93,6 +93,7 @@ import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.theme.components.TopAppBar
 import io.element.android.libraries.designsystem.utils.CommonDrawables
+import io.element.android.libraries.designsystem.utils.KeepScreenOn
 import io.element.android.libraries.designsystem.utils.LogCompositions
 import io.element.android.libraries.designsystem.utils.OnLifecycleEvent
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarHost
@@ -123,6 +124,8 @@ fun MessagesView(
     OnLifecycleEvent { _, event ->
         state.voiceMessageComposerState.eventSink(VoiceMessageComposerEvents.LifecycleEvent(event))
     }
+
+    KeepScreenOn(state.voiceMessageComposerState.keepScreenOn)
 
     AttachmentStateView(
         state = state.composerState.attachmentsState,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenter.kt
@@ -64,6 +64,7 @@ class VoiceMessageComposerPresenter @Inject constructor(
     override fun present(): VoiceMessageComposerState {
         val localCoroutineScope = rememberCoroutineScope()
         val recorderState by voiceRecorder.state.collectAsState(initial = VoiceRecorderState.Idle)
+        val keepScreenOn by remember { derivedStateOf { recorderState is VoiceRecorderState.Recording } }
 
         val permissionState = permissionsPresenter.present()
         var isSending by remember { mutableStateOf(false) }
@@ -191,6 +192,7 @@ class VoiceMessageComposerPresenter @Inject constructor(
                 else -> VoiceMessageState.Idle
             },
             showPermissionRationaleDialog = permissionState.showDialog,
+            keepScreenOn = keepScreenOn,
             eventSink = handleEvents,
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerState.kt
@@ -23,6 +23,7 @@ import io.element.android.libraries.textcomposer.model.VoiceMessageState
 data class VoiceMessageComposerState(
     val voiceMessageState: VoiceMessageState,
     val showPermissionRationaleDialog: Boolean,
+    val keepScreenOn: Boolean,
     val eventSink: (VoiceMessageComposerEvents) -> Unit,
 )
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerStateProvider.kt
@@ -30,10 +30,12 @@ internal open class VoiceMessageComposerStateProvider : PreviewParameterProvider
 
 internal fun aVoiceMessageComposerState(
     voiceMessageState: VoiceMessageState = VoiceMessageState.Idle,
+    keepScreenOn: Boolean = false,
     showPermissionRationaleDialog: Boolean = false,
 ) = VoiceMessageComposerState(
     voiceMessageState = voiceMessageState,
     showPermissionRationaleDialog = showPermissionRationaleDialog,
+    keepScreenOn = keepScreenOn,
     eventSink = {},
 )
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
@@ -102,6 +102,30 @@ class VoiceMessageComposerPresenterTest {
     }
 
     @Test
+    fun `present - recording keeps screen on`() = runTest {
+        val presenter = createVoiceMessageComposerPresenter()
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            awaitItem().apply {
+                eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.PressStart))
+                assertThat(keepScreenOn).isFalse()
+            }
+
+            awaitItem().apply {
+                assertThat(keepScreenOn).isTrue()
+                eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
+            }
+
+            val finalState = awaitItem().apply {
+                assertThat(keepScreenOn).isFalse()
+            }
+
+            testPauseAndDestroy(finalState)
+        }
+    }
+
+    @Test
     fun `present - abort recording`() = runTest {
         val presenter = createVoiceMessageComposerPresenter()
         moleculeFlow(RecompositionMode.Immediate) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Keep screen on during voice message recording.

## Motivation and context

- https://github.com/vector-im/element-meta/issues/2084

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Change screen time out to 15 seconds
- Recording a voice message that is more than 15 seconds long

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
