### PR TITLE
Enable Element Call integration in rooms by default

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/ElementCallConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/ElementCallConfig.kt
@@ -17,5 +17,5 @@
 package io.element.android.appconfig
 
 object ElementCallConfig {
-    const val DEFAULT_BASE_URL = "https://call.element.io"
+    const val DEFAULT_BASE_URL = "https://call.element.dev"
 }

--- a/changelog.d/+enable-element-call.feature
+++ b/changelog.d/+enable-element-call.feature
@@ -1,0 +1,1 @@
+Enable Element Call integration in rooms by default.

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenter.kt
@@ -82,7 +82,7 @@ class AdvancedSettingsPresenter @Inject constructor(
                     validator = ::customElementCallUrlValidator,
                 )
             } else null,
-            eventSink = ::handleEvents
+            eventSink = { handleEvents(it) }
         )
     }
 

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenterTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenterTest.kt
@@ -44,6 +44,7 @@ class AdvancedSettingsPresenterTest {
             val initialState = awaitItem()
             assertThat(initialState.isDeveloperModeEnabled).isFalse()
             assertThat(initialState.isRichTextEditorEnabled).isFalse()
+            assertThat(initialState.customElementCallBaseUrlState).isNull()
         }
     }
 
@@ -99,9 +100,7 @@ class AdvancedSettingsPresenterTest {
     @Test
     fun `present - custom element call base url`() = runTest {
         val store = InMemoryPreferencesStore()
-        val featureFlagService = FakeFeatureFlagService().apply {
-            setFeatureEnabled(FeatureFlags.InRoomCalls, true)
-        }
+        val featureFlagService = FakeFeatureFlagService(initialState = hashMapOf(FeatureFlags.InRoomCalls.key to true))
         val presenter = AdvancedSettingsPresenter(store, featureFlagService)
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
@@ -113,9 +112,9 @@ class AdvancedSettingsPresenterTest {
             assertThat(initialState.customElementCallBaseUrlState).isNotNull()
             assertThat(initialState.customElementCallBaseUrlState?.baseUrl).isNull()
 
-            initialState.eventSink(AdvancedSettingsEvents.SetCustomElementCallBaseUrl("https://call.element.dev"))
+            initialState.eventSink(AdvancedSettingsEvents.SetCustomElementCallBaseUrl("https://call.element.ahoy"))
             val updatedItem = awaitItem()
-            assertThat(updatedItem.customElementCallBaseUrlState?.baseUrl).isEqualTo("https://call.element.dev")
+            assertThat(updatedItem.customElementCallBaseUrlState?.baseUrl).isEqualTo("https://call.element.ahoy")
         }
     }
 

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -59,7 +59,7 @@ enum class FeatureFlags(
         key = "feature.elementcall",
         title = "Element call in rooms",
         description = "Allow user to start or join a call in a room",
-        defaultValue = false,
+        defaultValue = true,
     ),
     Mentions(
         key = "feature.mentions",

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
@@ -37,7 +37,7 @@ class StaticFeatureFlagProvider @Inject constructor() :
                 FeatureFlags.NotificationSettings -> true
                 FeatureFlags.VoiceMessages -> true
                 FeatureFlags.PinUnlock -> false
-                FeatureFlags.InRoomCalls -> false
+                FeatureFlags.InRoomCalls -> true
                 FeatureFlags.Mentions -> false
             }
         } else {

--- a/libraries/featureflag/test/src/main/java/io/element/android/libraries/featureflag/test/FakeFeatureFlagService.kt
+++ b/libraries/featureflag/test/src/main/java/io/element/android/libraries/featureflag/test/FakeFeatureFlagService.kt
@@ -31,6 +31,6 @@ class FakeFeatureFlagService(
     }
 
     override suspend fun isFeatureEnabled(feature: Feature): Boolean {
-        return enabledFeatures[feature.key] ?: feature.defaultValue
+        return enabledFeatures[feature.key] ?: false
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Enable Element Call integration in rooms by default.
- Also change base url to `call.element.dev`.

Once we've confirmed it's been stable for a while we can probably remove the FF, but we should probably leave the FF there in case we need to release a hotfix disabling the feature.

## Motivation and context

Enable this feature for all users.

## Tests

<!-- Explain how you tested your development -->

- Run the app.
- If you hadn't manually disabled the FF before, you should be able to use the EC integration.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
