### PR TITLE
Fix issues with stuck 'loading...' state and hangup

### DIFF
--- a/features/call/src/main/kotlin/io/element/android/features/call/data/WidgetMessage.kt
+++ b/features/call/src/main/kotlin/io/element/android/features/call/data/WidgetMessage.kt
@@ -26,7 +26,7 @@ data class WidgetMessage(
     @SerialName("widgetId") val widgetId: String,
     @SerialName("requestId") val requestId: String,
     @SerialName("action") val action: Action,
-    @SerialName("data") val data: JsonElement?,
+    @SerialName("data") val data: JsonElement? = null,
 ) {
 
     @Serializable

--- a/features/call/src/main/kotlin/io/element/android/features/call/data/WidgetMessage.kt
+++ b/features/call/src/main/kotlin/io/element/android/features/call/data/WidgetMessage.kt
@@ -18,6 +18,7 @@ package io.element.android.features.call.data
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 data class WidgetMessage(
@@ -25,6 +26,7 @@ data class WidgetMessage(
     @SerialName("widgetId") val widgetId: String,
     @SerialName("requestId") val requestId: String,
     @SerialName("action") val action: Action,
+    @SerialName("data") val data: JsonElement?,
 ) {
 
     @Serializable
@@ -38,6 +40,8 @@ data class WidgetMessage(
     @Serializable
     enum class Action {
         @SerialName("im.vector.hangup")
-        HangUp
+        HangUp,
+        @SerialName("send_event")
+        SendEvent,
     }
 }

--- a/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenView.kt
+++ b/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenView.kt
@@ -111,12 +111,8 @@ private fun CallWebView(
             modifier = modifier,
             factory = { context ->
                 WebView(context).apply {
-                    setup(userAgent, onPermissionsRequested)
-                    if (url is Async.Success) {
-                        loadUrl(url.data)
-                    }
-
                     onWebViewCreated(this)
+                    setup(userAgent, onPermissionsRequested)
                 }
             },
             update = { webView ->

--- a/features/call/src/main/kotlin/io/element/android/features/call/utils/WebViewWidgetMessageInterceptor.kt
+++ b/features/call/src/main/kotlin/io/element/android/features/call/utils/WebViewWidgetMessageInterceptor.kt
@@ -36,7 +36,8 @@ class WebViewWidgetMessageInterceptor(
         const val LISTENER_NAME = "elementX"
     }
 
-    override val interceptedMessages = MutableSharedFlow<String>(replay = 1, extraBufferCapacity = 2)
+    // It's important to have extra capacity here to make sure we don't drop any messages
+    override val interceptedMessages = MutableSharedFlow<String>(extraBufferCapacity = 10)
 
     init {
         webView.webViewClient = object : WebViewClient() {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/RustWidgetDriver.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/RustWidgetDriver.kt
@@ -36,7 +36,8 @@ class RustWidgetDriver(
     private val widgetCapabilitiesProvider: WidgetCapabilitiesProvider,
 ): MatrixWidgetDriver {
 
-    override val incomingMessages = MutableSharedFlow<String>()
+    // It's important to have extra capacity here to make sure we don't drop any messages
+    override val incomingMessages = MutableSharedFlow<String>(extraBufferCapacity = 10)
 
     private val driverAndHandle = makeWidgetDriver(widgetSettings.toRustWidgetSettings())
     private var receiveMessageJob: Job? = null


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Add `extraCapacity` to the flows that relay messages between the Widget and the Rust Widget Driver to make sure we don't drop any messages. This was causing a stuck 'Loading...' state to be shown from time to time.
- Add a better mechanism for hanging up with either the close button or the back one.

## Motivation and context

Bugfixes.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
