### PR TITLE
[Element Call] Keep MatrixClient alive while the call is working

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/di/MatrixClientsHolder.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/di/MatrixClientsHolder.kt
@@ -49,7 +49,7 @@ class MatrixClientsHolder @Inject constructor(private val authenticationService:
         sessionIdsToMatrixClient.remove(sessionId)
     }
 
-    fun getOrNull(sessionId: SessionId): MatrixClient? {
+    override fun getOrNull(sessionId: SessionId): MatrixClient? {
         return sessionIdsToMatrixClient[sessionId]
     }
 

--- a/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenEvents.kt
+++ b/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenEvents.kt
@@ -19,8 +19,6 @@ package io.element.android.features.call.ui
 import io.element.android.features.call.utils.WidgetMessageInterceptor
 
 sealed interface CallScreenEvents {
-    data object StartSync : CallScreenEvents
-    data object StopSync : CallScreenEvents
     data object Hangup : CallScreenEvents
     data class SetupMessageChannels(val widgetMessageInterceptor: WidgetMessageInterceptor) : CallScreenEvents
 }

--- a/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenEvents.kt
+++ b/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenEvents.kt
@@ -18,7 +18,9 @@ package io.element.android.features.call.ui
 
 import io.element.android.features.call.utils.WidgetMessageInterceptor
 
-sealed interface CallScreeEvents {
-    data object Hangup : CallScreeEvents
-    data class SetupMessageChannels(val widgetMessageInterceptor: WidgetMessageInterceptor) : CallScreeEvents
+sealed interface CallScreenEvents {
+    data object StartSync : CallScreenEvents
+    data object StopSync : CallScreenEvents
+    data object Hangup : CallScreenEvents
+    data class SetupMessageChannels(val widgetMessageInterceptor: WidgetMessageInterceptor) : CallScreenEvents
 }

--- a/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenState.kt
+++ b/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenState.kt
@@ -22,5 +22,5 @@ data class CallScreenState(
     val urlState: Async<String>,
     val userAgent: String,
     val isInWidgetMode: Boolean,
-    val eventSink: (CallScreeEvents) -> Unit,
+    val eventSink: (CallScreenEvents) -> Unit,
 )

--- a/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenView.kt
+++ b/features/call/src/main/kotlin/io/element/android/features/call/ui/CallScreenView.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.lifecycle.Lifecycle
 import io.element.android.features.call.R
 import io.element.android.features.call.utils.WebViewWidgetMessageInterceptor
 import io.element.android.libraries.architecture.Async
@@ -44,7 +43,6 @@ import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.theme.components.TopAppBar
 import io.element.android.libraries.designsystem.utils.CommonDrawables
-import io.element.android.libraries.designsystem.utils.OnLifecycleEvent
 
 typealias RequestPermissionCallback = (Array<String>) -> Unit
 
@@ -93,17 +91,6 @@ internal fun CallScreenView(
                 state.eventSink(CallScreenEvents.SetupMessageChannels(interceptor))
             }
         )
-
-        // We need to restart the Matrix client to get the needed call events
-        if (state.isInWidgetMode) {
-            OnLifecycleEvent { _, event ->
-                when (event) {
-                    Lifecycle.Event.ON_START -> state.eventSink(CallScreenEvents.StartSync)
-                    Lifecycle.Event.ON_STOP -> state.eventSink(CallScreenEvents.StopSync)
-                    else -> Unit
-                }
-            }
-        }
     }
 }
 

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClientProvider.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClientProvider.kt
@@ -25,4 +25,11 @@ interface MatrixClientProvider {
      * Most of the time you want to use injected constructor instead of retrieving a MatrixClient with this provider.
      */
     suspend fun getOrRestore(sessionId: SessionId): Result<MatrixClient>
+
+    /**
+     * Can be used to retrieve an existing [MatrixClient] with the given [SessionId].
+     * @param sessionId the [SessionId] of the [MatrixClient] to retrieve.
+     * @return the [MatrixClient] if it exists.
+     */
+    fun getOrNull(sessionId: SessionId): MatrixClient?
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClientProvider.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClientProvider.kt
@@ -24,4 +24,6 @@ class FakeMatrixClientProvider(
     private val getClient: (SessionId) -> Result<MatrixClient> = { Result.success(FakeMatrixClient()) }
 ) : MatrixClientProvider {
     override suspend fun getOrRestore(sessionId: SessionId): Result<MatrixClient> = getClient(sessionId)
+
+    override fun getOrNull(sessionId: SessionId): MatrixClient? = getClient(sessionId).getOrNull()
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- When a call starts in `CallType.RoomCall` mode and is in foreground, we get the `MatrixClient` and start the sync.
- When the call screen is put to background or closed, we stop the sync again.

## Motivation and context

Before this fix we were experiencing a bug that consistently made EC work only 50% of the times it was launched. This happened because the EC Widget needs some data from the Rust SDK that can only be retrieved while the sync is active. 

Since in `LoggedInFlowNode` we stop the sync when it's sent to the background, these events we requested were never received and the call only actually worked if it had some cached membership events from the previous attempt to make a call, working only 50% of the time, after a previous failed attempt to establish a call.

## Tests

<!-- Explain how you tested your development -->

- Join a call several times in a row.

If they all work, this is working.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
