### PR TITLE
Add content description to voice message attachment sheet

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -589,6 +589,7 @@ private fun ReplyToContent(
     }
 }
 
+@Composable
 private fun attachmentThumbnailInfoForInReplyTo(inReplyTo: InReplyTo.Ready): AttachmentThumbnailInfo? {
     val messageContent = inReplyTo.content as? MessageContent ?: return null
     return when (val type = messageContent.type) {
@@ -618,6 +619,7 @@ private fun attachmentThumbnailInfoForInReplyTo(inReplyTo: InReplyTo.Ready): Att
             type = AttachmentThumbnailType.Audio,
         )
         is VoiceMessageType -> AttachmentThumbnailInfo(
+            textContent = stringResource(CommonStrings.common_voice_message),
             type = AttachmentThumbnailType.Voice,
         )
         else -> null


### PR DESCRIPTION
This will add "Voice message" as content description of the voice message icon in the attachment bottom sheet (after long pressing on a voice message).
