### PR TITLE
Change FeatureFlagService.isFeatureEnabled return value from Boolean to Flow<Boolean>

### DIFF
--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenterTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenterTest.kt
@@ -24,6 +24,7 @@ import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.featureflag.test.FakeFeatureFlagService
 import io.element.android.libraries.featureflag.test.InMemoryPreferencesStore
 import io.element.android.tests.testutils.WarmUpRule
+import io.element.android.tests.testutils.awaitLastSequentialItem
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -41,10 +42,10 @@ class AdvancedSettingsPresenterTest {
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
-            val initialState = awaitItem()
+            val initialState = awaitLastSequentialItem()
             assertThat(initialState.isDeveloperModeEnabled).isFalse()
             assertThat(initialState.isRichTextEditorEnabled).isFalse()
-            assertThat(initialState.customElementCallBaseUrlState).isNull()
+            assertThat(initialState.customElementCallBaseUrlState?.baseUrl).isNull()
         }
     }
 
@@ -56,7 +57,7 @@ class AdvancedSettingsPresenterTest {
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
-            val initialState = awaitItem()
+            val initialState = awaitLastSequentialItem()
             assertThat(initialState.isDeveloperModeEnabled).isFalse()
             initialState.eventSink.invoke(AdvancedSettingsEvents.SetDeveloperModeEnabled(true))
             assertThat(awaitItem().isDeveloperModeEnabled).isTrue()
@@ -73,7 +74,7 @@ class AdvancedSettingsPresenterTest {
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
-            val initialState = awaitItem()
+            val initialState = awaitLastSequentialItem()
             assertThat(initialState.isRichTextEditorEnabled).isFalse()
             initialState.eventSink.invoke(AdvancedSettingsEvents.SetRichTextEditorEnabled(true))
             assertThat(awaitItem().isRichTextEditorEnabled).isTrue()
@@ -92,7 +93,7 @@ class AdvancedSettingsPresenterTest {
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
-            val initialState = awaitItem()
+            val initialState = awaitLastSequentialItem()
             assertThat(initialState.customElementCallBaseUrlState).isNull()
         }
     }
@@ -105,10 +106,7 @@ class AdvancedSettingsPresenterTest {
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
-            // Initial state has a default `false` feature flag value, so the state will still be null
-            skipItems(1)
-
-            val initialState = awaitItem()
+            val initialState = awaitLastSequentialItem()
             assertThat(initialState.customElementCallBaseUrlState).isNotNull()
             assertThat(initialState.customElementCallBaseUrlState?.baseUrl).isNull()
 
@@ -128,10 +126,7 @@ class AdvancedSettingsPresenterTest {
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
-            // Initial state has a default `false` feature flag value, so the state will still be null
-            skipItems(1)
-
-            val urlValidator = awaitItem().customElementCallBaseUrlState!!.validator
+            val urlValidator = awaitLastSequentialItem().customElementCallBaseUrlState!!.validator
             assertThat(urlValidator("")).isTrue() // We allow empty string to clear the value and use the default one
             assertThat(urlValidator("test")).isFalse()
             assertThat(urlValidator("http://")).isFalse()

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlagService.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlagService.kt
@@ -16,13 +16,23 @@
 
 package io.element.android.libraries.featureflag.api
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+
 interface FeatureFlagService {
     /**
      * @param feature the feature to check for
      *
      * @return true if the feature is enabled
      */
-    suspend fun isFeatureEnabled(feature: Feature): Boolean
+    suspend fun isFeatureEnabled(feature: Feature): Boolean = isFeatureEnabledFlow(feature).first()
+
+    /**
+     * @param feature the feature to check for
+     *
+     * @return a flow of booleans, true if the feature is enabled, false if it is disabled.
+     */
+    fun isFeatureEnabledFlow(feature: Feature): Flow<Boolean>
 
     /**
      * @param feature the feature to enable or disable

--- a/libraries/featureflag/impl/build.gradle.kts
+++ b/libraries/featureflag/impl/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
     implementation(projects.libraries.di)
     implementation(projects.libraries.core)
+    implementation(libs.coroutines.core)
     testImplementation(libs.test.junit)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.test.truth)

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/DefaultFeatureFlagService.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/DefaultFeatureFlagService.kt
@@ -21,6 +21,8 @@ import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.SingleIn
 import io.element.android.libraries.featureflag.api.Feature
 import io.element.android.libraries.featureflag.api.FeatureFlagService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
@@ -29,12 +31,12 @@ class DefaultFeatureFlagService @Inject constructor(
     private val providers: Set<@JvmSuppressWildcards FeatureFlagProvider>
 ) : FeatureFlagService {
 
-    override suspend fun isFeatureEnabled(feature: Feature): Boolean {
+    override fun isFeatureEnabledFlow(feature: Feature): Flow<Boolean> {
         return providers.filter { it.hasFeature(feature) }
             .sortedByDescending(FeatureFlagProvider::priority)
             .firstOrNull()
-            ?.isFeatureEnabled(feature)
-            ?: feature.defaultValue
+            ?.isFeatureEnabledFlow(feature)
+            ?: flowOf(feature.defaultValue)
     }
 
     override suspend fun setFeatureEnabled(feature: Feature, enabled: Boolean): Boolean {

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/FeatureFlagProvider.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/FeatureFlagProvider.kt
@@ -17,10 +17,11 @@
 package io.element.android.libraries.featureflag.impl
 
 import io.element.android.libraries.featureflag.api.Feature
+import kotlinx.coroutines.flow.Flow
 
 interface FeatureFlagProvider {
     val priority: Int
-    suspend fun isFeatureEnabled(feature: Feature): Boolean
+    fun isFeatureEnabledFlow(feature: Feature): Flow<Boolean>
     fun hasFeature(feature: Feature): Boolean
 }
 

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/PreferencesFeatureFlagProvider.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/PreferencesFeatureFlagProvider.kt
@@ -24,7 +24,8 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.featureflag.api.Feature
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -44,10 +45,10 @@ class PreferencesFeatureFlagProvider @Inject constructor(@ApplicationContext con
         }
     }
 
-    override suspend fun isFeatureEnabled(feature: Feature): Boolean {
+    override fun isFeatureEnabledFlow(feature: Feature): Flow<Boolean> {
         return store.data.map { prefs ->
             prefs[booleanPreferencesKey(feature.key)] ?: feature.defaultValue
-        }.first()
+        }.distinctUntilChanged()
     }
 
     override fun hasFeature(feature: Feature): Boolean {

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
@@ -18,6 +18,8 @@ package io.element.android.libraries.featureflag.impl
 
 import io.element.android.libraries.featureflag.api.Feature
 import io.element.android.libraries.featureflag.api.FeatureFlags
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
 /**
@@ -29,9 +31,9 @@ class StaticFeatureFlagProvider @Inject constructor() :
 
     override val priority = LOW_PRIORITY
 
-    override suspend fun isFeatureEnabled(feature: Feature): Boolean {
-        return if (feature is FeatureFlags) {
-            when(feature) {
+    override fun isFeatureEnabledFlow(feature: Feature): Flow<Boolean> {
+        val isFeatureEnabled = if (feature is FeatureFlags) {
+            when (feature) {
                 FeatureFlags.LocationSharing -> true
                 FeatureFlags.Polls -> true
                 FeatureFlags.NotificationSettings -> true
@@ -43,6 +45,7 @@ class StaticFeatureFlagProvider @Inject constructor() :
         } else {
             false
         }
+        return flowOf(isFeatureEnabled)
     }
 
     override fun hasFeature(feature: Feature) = true

--- a/libraries/featureflag/impl/src/test/kotlin/io/element/android/libraries/featureflag/impl/FakeMutableFeatureFlagProvider.kt
+++ b/libraries/featureflag/impl/src/test/kotlin/io/element/android/libraries/featureflag/impl/FakeMutableFeatureFlagProvider.kt
@@ -17,17 +17,20 @@
 package io.element.android.libraries.featureflag.impl
 
 import io.element.android.libraries.featureflag.api.Feature
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class FakeMutableFeatureFlagProvider(override val priority: Int) : MutableFeatureFlagProvider {
 
-    private val enabledFeatures = HashMap<String, Boolean>()
+    private val enabledFeatures = mutableMapOf<String, MutableStateFlow<Boolean>>()
 
     override suspend fun setFeatureEnabled(feature: Feature, enabled: Boolean) {
-        enabledFeatures[feature.key] = enabled
+        val flow = enabledFeatures.getOrPut(feature.key) { MutableStateFlow(enabled) }
+        flow.emit(enabled)
     }
 
-    override suspend fun isFeatureEnabled(feature: Feature): Boolean {
-        return enabledFeatures[feature.key] ?: feature.defaultValue
+    override fun isFeatureEnabledFlow(feature: Feature): Flow<Boolean> {
+        return enabledFeatures.getOrPut(feature.key) { MutableStateFlow(feature.defaultValue) }
     }
 
     override fun hasFeature(feature: Feature): Boolean = true

--- a/libraries/featureflag/test/build.gradle.kts
+++ b/libraries/featureflag/test/build.gradle.kts
@@ -23,5 +23,6 @@ android {
 
     dependencies {
         api(projects.libraries.featureflag.api)
+        implementation(libs.coroutines.core)
     }
 }

--- a/libraries/featureflag/test/src/main/java/io/element/android/libraries/featureflag/test/FakeFeatureFlagService.kt
+++ b/libraries/featureflag/test/src/main/java/io/element/android/libraries/featureflag/test/FakeFeatureFlagService.kt
@@ -18,19 +18,27 @@ package io.element.android.libraries.featureflag.test
 
 import io.element.android.libraries.featureflag.api.Feature
 import io.element.android.libraries.featureflag.api.FeatureFlagService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class FakeFeatureFlagService(
     initialState: Map<String, Boolean> = emptyMap()
 ) : FeatureFlagService {
 
-    private val enabledFeatures = HashMap(initialState)
+    private val enabledFeatures = initialState
+        .map {
+            it.key to MutableStateFlow(it.value)
+        }
+        .toMap()
+        .toMutableMap()
 
     override suspend fun setFeatureEnabled(feature: Feature, enabled: Boolean): Boolean {
-        enabledFeatures[feature.key] = enabled
+        val flow = enabledFeatures.getOrPut(feature.key) { MutableStateFlow(enabled) }
+        flow.emit(enabled)
         return true
     }
 
-    override suspend fun isFeatureEnabled(feature: Feature): Boolean {
-        return enabledFeatures[feature.key] ?: false
+    override fun isFeatureEnabledFlow(feature: Feature): Flow<Boolean> {
+        return enabledFeatures.getOrPut(feature.key) { MutableStateFlow(feature.defaultValue) }
     }
 }


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Change FeatureFlagService.isFeatureEnabled return value from Boolean to Flow<Boolean>

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Be able to have "live" behavior of feature flag. Until now this was not necessary because when user goes to the settings to switch a flag, the flag is read again when entering the screen where the flag has an effect. Ex: Timeline.

But without this, it would be a bit harder (yet not impossible) to have a flag that have effect on the room list for instance, since the settings screen is a subscreen of the room list.

In particular, we will need this to be able to add a feature flag for the key backup. A banner can be displayed on the room list.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
NA

## Tests

<!-- Explain how you tested your development -->

- Play with the feature flags and check that the effect are still working as expected.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
