### PR TITLE
Improve the logs for `TimelineException.CannotPaginate`

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
@@ -194,8 +194,12 @@ class RustMatrixTimeline(
                 waitForToken = true,
             )
             innerRoom.paginateBackwards(paginationOptions)
-        }.onFailure {
-            Timber.d(it, "Fail to paginate for room ${matrixRoom.roomId}")
+        }.onFailure { error ->
+            if (error is TimelineException.CannotPaginate) {
+                Timber.d("Can't paginate backwards on room ${matrixRoom.roomId}, we're already at the start")
+            } else {
+                Timber.e(error, "Error paginating backwards on room ${matrixRoom.roomId}")
+            }
         }.onSuccess {
             Timber.v("Success back paginating for room ${matrixRoom.roomId}")
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Log `TimelineException.CannotPaginate` exceptions as only debug messages without a stacktrace. 
- Any other exception thrown in `RustMatrixTimeline.paginateBackwards` will print the stacktrace and have a better error message.

## Motivation and context

@jplatte complained these looked like Rust SDK issues and pollute the logs quite a bit.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
