### PR TITLE
Fix maestro test.

### DIFF
--- a/.maestro/tests/account/logout.yaml
+++ b/.maestro/tests/account/logout.yaml
@@ -10,6 +10,7 @@ appId: ${APP_ID}
     id: "sign-out-submit"
 # Ensure cancel cancels
 - tapOn: "Cancel"
+- tapOn:
+    id: "sign-out-submit"
 - tapOn: "Sign out"
-- tapOn: "Sign out anyway"
 - runFlow: ../assertions/assertInitDisplayed.yaml

--- a/.maestro/tests/account/logout.yaml
+++ b/.maestro/tests/account/logout.yaml
@@ -6,7 +6,8 @@ appId: ${APP_ID}
 - takeScreenshot: build/maestro/900-SignOutScreen
 - back
 - tapOn: "Sign out"
-- tapOn: "Sign out"
+- tapOn:
+    id: "sign-out-submit"
 # Ensure cancel cancels
 - tapOn: "Cancel"
 - tapOn: "Sign out"

--- a/.maestro/tests/account/logout.yaml
+++ b/.maestro/tests/account/logout.yaml
@@ -12,5 +12,6 @@ appId: ${APP_ID}
 - tapOn: "Cancel"
 - tapOn:
     id: "sign-out-submit"
-- tapOn: "Sign out"
+- tapOn:
+    id: "dialog-positive"
 - runFlow: ../assertions/assertInitDisplayed.yaml

--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutView.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutView.kt
@@ -46,6 +46,8 @@ import io.element.android.libraries.designsystem.theme.progressIndicatorTrackCol
 import io.element.android.libraries.designsystem.utils.CommonDrawables
 import io.element.android.libraries.matrix.api.encryption.BackupUploadState
 import io.element.android.libraries.matrix.api.encryption.SteadyStateException
+import io.element.android.libraries.testtags.TestTags
+import io.element.android.libraries.testtags.testTag
 import io.element.android.libraries.theme.ElementTheme
 import io.element.android.libraries.ui.strings.CommonStrings
 
@@ -194,7 +196,9 @@ private fun BottomMenu(
             text = stringResource(id = signOutSubmitRes),
             showProgress = logoutAction is Async.Loading,
             destructive = true,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(TestTags.signOut),
             onClick = onLogoutClicked,
         )
     }

--- a/libraries/designsystem/build.gradle.kts
+++ b/libraries/designsystem/build.gradle.kts
@@ -39,6 +39,7 @@ android {
         // Should not be there, but this is a POC
         implementation(libs.coil.compose)
         implementation(libs.vanniktech.blurhash)
+        implementation(projects.libraries.testtags)
         implementation(projects.libraries.uiStrings)
 
         ksp(libs.showkase.processor)

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.unit.dp
 import io.element.android.libraries.designsystem.preview.ElementThemedPreview
 import io.element.android.libraries.designsystem.preview.PreviewGroup
 import io.element.android.libraries.designsystem.utils.CommonDrawables
+import io.element.android.libraries.testtags.TestTags
+import io.element.android.libraries.testtags.testTag
 import io.element.android.libraries.theme.ElementTheme
 import kotlin.math.max
 
@@ -113,18 +115,23 @@ internal fun SimpleAlertDialogContent(
                     // If there is a 3rd item it should be at the end of the dialog
                     // Having this 3rd action is discouraged, see https://m3.material.io/components/dialogs/guidelines#e13b68f5-e367-4275-ad6f-c552ee8e358f
                     TextButton(
+                        modifier = Modifier.testTag(TestTags.dialogNeutral),
                         text = thirdButtonText,
                         size = ButtonSize.Medium,
                         onClick = onThirdButtonClicked,
                     )
                 }
                 TextButton(
+                    modifier = Modifier.testTag(
+                        if (submitText == null) TestTags.dialogPositive else TestTags.dialogNegative
+                    ),
                     text = cancelText,
                     size = ButtonSize.Medium,
                     onClick = onCancelClicked,
                 )
                 if (submitText != null) {
                     Button(
+                        modifier = Modifier.testTag(TestTags.dialogPositive),
                         text = submitText,
                         enabled = enabled,
                         size = ButtonSize.Medium,

--- a/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
+++ b/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
@@ -57,6 +57,13 @@ object TestTags {
      * RichTextEditor.
      */
     val richTextEditor = TestTag("rich_text_editor")
+
+    /**
+     * Dialogs.
+     */
+    val dialogPositive = TestTag("dialog-positive")
+    val dialogNegative = TestTag("dialog-negative")
+    val dialogNeutral = TestTag("dialog-neutral")
 }
 
 

--- a/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
+++ b/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
@@ -34,6 +34,11 @@ object TestTags {
     val loginContinue = TestTag("login-continue")
 
     /**
+     * Sign out screen.
+     */
+    val signOut = TestTag("sign-out-submit")
+
+    /**
      * Change server screen.
      */
     val changeServerServer = TestTag("change_server-server")


### PR DESCRIPTION
Fix Maestro, wording for screen title is now the same than the wording for the button, so Maestro was clicking on the title. Adding an id should fix the test, and is safer, since the button can have other wording.