### PR TITLE
Improve dialog api

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ErrorDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ErrorDialog.kt
@@ -32,17 +32,17 @@ import io.element.android.libraries.ui.strings.CommonStrings
 @Composable
 fun ErrorDialog(
     content: String,
+    onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     title: String = ErrorDialogDefaults.title,
     submitText: String = ErrorDialogDefaults.submitText,
-    onDismiss: () -> Unit = {},
 ) {
     AlertDialog(modifier = modifier, onDismissRequest = onDismiss) {
         ErrorDialogContent(
             title = title,
             content = content,
             submitText = submitText,
-            onSubmitText = onDismiss,
+            onSubmitClicked = onDismiss,
         )
     }
 }
@@ -50,17 +50,17 @@ fun ErrorDialog(
 @Composable
 private fun ErrorDialogContent(
     content: String,
+    onSubmitClicked: () -> Unit,
     modifier: Modifier = Modifier,
     title: String = ErrorDialogDefaults.title,
     submitText: String = ErrorDialogDefaults.submitText,
-    onSubmitText: () -> Unit = {},
 ) {
     SimpleAlertDialogContent(
         modifier = modifier,
         title = title,
         content = content,
-        cancelText = submitText,
-        onCancelClicked = onSubmitText,
+        submitText = submitText,
+        onSubmitClicked = onSubmitClicked,
     )
 }
 
@@ -76,6 +76,7 @@ internal fun ErrorDialogPreview() {
         DialogPreview {
             ErrorDialogContent(
                 content = "Content",
+                onSubmitClicked = {},
             )
         }
     }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ListDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ListDialog.kt
@@ -38,8 +38,8 @@ import io.element.android.libraries.ui.strings.CommonStrings
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ListDialog(
-    onDismissRequest: () -> Unit,
     onSubmit: () -> Unit,
+    onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     title: String? = null,
     subtitle: String? = null,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/SingleSelectionDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/SingleSelectionDialog.kt
@@ -77,8 +77,8 @@ fun SingleSelectionDialog(
 private fun SingleSelectionDialogContent(
     options: ImmutableList<ListOption>,
     onOptionSelected: (Int) -> Unit,
-    onDismissRequest: () -> Unit,
     dismissButtonTitle: String,
+    onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     title: String? = null,
     initialSelection: Int? = null,
@@ -88,8 +88,8 @@ private fun SingleSelectionDialogContent(
         title = title,
         subtitle = subtitle,
         modifier = modifier,
-        cancelText = dismissButtonTitle,
-        onCancelClicked = onDismissRequest,
+        submitText = dismissButtonTitle,
+        onSubmitClicked = onDismissRequest,
         applyPaddingToContents = false,
     ) {
         LazyColumn {

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
@@ -128,15 +128,24 @@ internal fun SimpleAlertDialogContent(
                         size = ButtonSize.Medium,
                         onClick = onCancelClicked,
                     )
+                    Button(
+                        modifier = Modifier.testTag(TestTags.dialogPositive),
+                        text = submitText,
+                        enabled = enabled,
+                        size = ButtonSize.Medium,
+                        onClick = onSubmitClicked,
+                        destructive = destructiveSubmit,
+                    )
+                } else {
+                    TextButton(
+                        modifier = Modifier.testTag(TestTags.dialogPositive),
+                        text = submitText,
+                        enabled = enabled,
+                        size = ButtonSize.Medium,
+                        onClick = onSubmitClicked,
+                        destructive = destructiveSubmit,
+                    )
                 }
-                Button(
-                    modifier = Modifier.testTag(TestTags.dialogPositive),
-                    text = submitText,
-                    enabled = enabled,
-                    size = ButtonSize.Medium,
-                    onClick = onSubmitClicked,
-                    destructive = destructiveSubmit,
-                )
             }
         },
         modifier = modifier,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
@@ -485,7 +485,6 @@ internal fun DialogWithOnlyMessageAndOkButtonPreview() {
 
 @Preview(group = PreviewGroup.Dialogs, name = "Dialog with destructive button")
 @Composable
-@Suppress("MaxLineLength")
 internal fun DialogWithDestructiveButtonPreview() {
     ElementThemedPreview(showBackground = false) {
         DialogPreview {
@@ -495,6 +494,23 @@ internal fun DialogWithDestructiveButtonPreview() {
                 cancelText = "Cancel",
                 submitText = "Delete",
                 destructiveSubmit = true,
+                onSubmitClicked = {},
+            )
+        }
+    }
+}
+
+@Preview(group = PreviewGroup.Dialogs, name = "Dialog with third button")
+@Composable
+internal fun DialogWithThirdButtonPreview() {
+    ElementThemedPreview(showBackground = false) {
+        DialogPreview {
+            SimpleAlertDialogContent(
+                title = "Dialog Title",
+                content = "A dialog with a third button",
+                cancelText = "Cancel",
+                submitText = "Delete",
+                thirdButtonText = "Other",
                 onSubmitClicked = {},
             )
         }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
@@ -53,14 +53,14 @@ import kotlin.math.max
 @Composable
 internal fun SimpleAlertDialogContent(
     content: String,
-    cancelText: String,
-    onCancelClicked: () -> Unit,
+    submitText: String,
+    onSubmitClicked: () -> Unit,
     modifier: Modifier = Modifier,
     title: String? = null,
     subtitle: @Composable (() -> Unit)? = null,
-    submitText: String? = null,
     destructiveSubmit: Boolean = false,
-    onSubmitClicked: () -> Unit = {},
+    cancelText: String? = null,
+    onCancelClicked: () -> Unit = {},
     thirdButtonText: String? = null,
     onThirdButtonClicked: () -> Unit = {},
     applyPaddingToContents: Boolean = true,
@@ -90,14 +90,14 @@ internal fun SimpleAlertDialogContent(
 
 @Composable
 internal fun SimpleAlertDialogContent(
-    cancelText: String,
-    onCancelClicked: () -> Unit,
+    submitText: String,
+    onSubmitClicked: () -> Unit,
     modifier: Modifier = Modifier,
     title: String? = null,
     subtitle: @Composable (() -> Unit)? = null,
-    submitText: String? = null,
     destructiveSubmit: Boolean = false,
-    onSubmitClicked: () -> Unit = {},
+    cancelText: String? = null,
+    onCancelClicked: () -> Unit = {},
     thirdButtonText: String? = null,
     onThirdButtonClicked: () -> Unit = {},
     applyPaddingToContents: Boolean = true,
@@ -121,24 +121,22 @@ internal fun SimpleAlertDialogContent(
                         onClick = onThirdButtonClicked,
                     )
                 }
-                TextButton(
-                    modifier = Modifier.testTag(
-                        if (submitText == null) TestTags.dialogPositive else TestTags.dialogNegative
-                    ),
-                    text = cancelText,
-                    size = ButtonSize.Medium,
-                    onClick = onCancelClicked,
-                )
-                if (submitText != null) {
-                    Button(
-                        modifier = Modifier.testTag(TestTags.dialogPositive),
-                        text = submitText,
-                        enabled = enabled,
+                if (cancelText != null) {
+                    TextButton(
+                        modifier = Modifier.testTag(TestTags.dialogNegative),
+                        text = cancelText,
                         size = ButtonSize.Medium,
-                        onClick = onSubmitClicked,
-                        destructive = destructiveSubmit,
+                        onClick = onCancelClicked,
                     )
                 }
+                Button(
+                    modifier = Modifier.testTag(TestTags.dialogPositive),
+                    text = submitText,
+                    enabled = enabled,
+                    size = ButtonSize.Medium,
+                    onClick = onSubmitClicked,
+                    destructive = destructiveSubmit,
+                )
             }
         },
         modifier = modifier,
@@ -438,8 +436,8 @@ internal fun DialogWithTitleIconAndOkButtonPreview() {
                 },
                 title = "Dialog Title",
                 content = "A dialog is a type of modal window that appears in front of app content to provide critical information, or prompt for a decision to be made. Learn more",
-                cancelText = "OK",
-                onCancelClicked = {},
+                submitText = "OK",
+                onSubmitClicked = {},
             )
         }
     }
@@ -454,8 +452,8 @@ internal fun DialogWithTitleAndOkButtonPreview() {
             SimpleAlertDialogContent(
                 title = "Dialog Title",
                 content = "A dialog is a type of modal window that appears in front of app content to provide critical information, or prompt for a decision to be made. Learn more",
-                cancelText = "OK",
-                onCancelClicked = {},
+                submitText = "OK",
+                onSubmitClicked = {},
             )
         }
     }
@@ -469,8 +467,8 @@ internal fun DialogWithOnlyMessageAndOkButtonPreview() {
         DialogPreview {
             SimpleAlertDialogContent(
                 content = "A dialog is a type of modal window that appears in front of app content to provide critical information, or prompt for a decision to be made. Learn more",
-                cancelText = "OK",
-                onCancelClicked = {},
+                submitText = "OK",
+                onSubmitClicked = {},
             )
         }
     }
@@ -488,7 +486,7 @@ internal fun DialogWithDestructiveButtonPreview() {
                 cancelText = "Cancel",
                 submitText = "Delete",
                 destructiveSubmit = true,
-                onCancelClicked = {},
+                onSubmitClicked = {},
             )
         }
     }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
@@ -67,23 +67,23 @@ internal fun SimpleAlertDialogContent(
     icon: @Composable (() -> Unit)? = null,
 ) {
     SimpleAlertDialogContent(
+        modifier = modifier,
+        icon = icon,
+        title = title,
+        subtitle = subtitle,
         content = {
             Text(
                 text = content,
                 style = ElementTheme.materialTypography.bodyMedium,
             )
         },
-        cancelText = cancelText,
-        onCancelClicked = onCancelClicked,
-        modifier = modifier,
-        title = title,
-        subtitle = subtitle,
         submitText = submitText,
         destructiveSubmit = destructiveSubmit,
         onSubmitClicked = onSubmitClicked,
+        cancelText = cancelText,
+        onCancelClicked = onCancelClicked,
         thirdButtonText = thirdButtonText,
         onThirdButtonClicked = onThirdButtonClicked,
-        icon = icon,
         applyPaddingToContents = applyPaddingToContents,
     )
 }

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[l.designsystem.theme.components_null_Dialogs_Dialogwiththirdbutton_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[l.designsystem.theme.components_null_Dialogs_Dialogwiththirdbutton_0_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e465788d3307cc42d3f1c322d926e9088994c6b7a5cd338a74dd95a8dfe2977a
+size 31190


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
SimpleAlertDialogContent: enforce button submit instead of button cancel and improve API around dialogs.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Nicer API

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
