### PR TITLE
Remove useless by lazy wrapping

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/addpeople/AddPeoplePresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/addpeople/AddPeoplePresenter.kt
@@ -27,20 +27,18 @@ import io.element.android.libraries.usersearch.api.UserRepository
 import javax.inject.Inject
 
 class AddPeoplePresenter @Inject constructor(
-    private val userListPresenterFactory: UserListPresenter.Factory,
-    private val userRepository: UserRepository,
-    private val dataStore: CreateRoomDataStore,
+    userListPresenterFactory: UserListPresenter.Factory,
+    userRepository: UserRepository,
+    dataStore: CreateRoomDataStore,
 ) : Presenter<UserListState> {
 
-    private val userListPresenter by lazy {
-        userListPresenterFactory.create(
-            UserListPresenterArgs(
-                selectionMode = SelectionMode.Multiple,
-            ),
-            userRepository,
-            dataStore.selectedUserListDataStore,
-        )
-    }
+    private val userListPresenter = userListPresenterFactory.create(
+        UserListPresenterArgs(
+            selectionMode = SelectionMode.Multiple,
+        ),
+        userRepository,
+        dataStore.selectedUserListDataStore,
+    )
 
     @Composable
     override fun present(): UserListState {

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootPresenter.kt
@@ -40,23 +40,21 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class CreateRoomRootPresenter @Inject constructor(
-    private val presenterFactory: UserListPresenter.Factory,
-    private val userRepository: UserRepository,
-    private val userListDataStore: UserListDataStore,
+    presenterFactory: UserListPresenter.Factory,
+    userRepository: UserRepository,
+    userListDataStore: UserListDataStore,
     private val matrixClient: MatrixClient,
     private val analyticsService: AnalyticsService,
     private val buildMeta: BuildMeta,
 ) : Presenter<CreateRoomRootState> {
 
-    private val presenter by lazy {
-        presenterFactory.create(
-            UserListPresenterArgs(
-                selectionMode = SelectionMode.Single,
-            ),
-            userRepository,
-            userListDataStore,
-        )
-    }
+    private val presenter = presenterFactory.create(
+        UserListPresenterArgs(
+            selectionMode = SelectionMode.Single,
+        ),
+        userRepository,
+        userListDataStore,
+    )
 
     @Composable
     override fun present(): CreateRoomRootState {

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInNode.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInNode.kt
@@ -32,18 +32,16 @@ import io.element.android.libraries.di.AppScope
 class NotificationsOptInNode @AssistedInject constructor(
     @Assisted buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,
-    private val presenterFactory: NotificationsOptInPresenter.Factory,
+    presenterFactory: NotificationsOptInPresenter.Factory,
 ) : Node(buildContext, plugins = plugins) {
 
-    interface Callback: NodeInputs {
+    interface Callback : NodeInputs {
         fun onNotificationsOptInFinished()
     }
 
     private val callback = inputs<Callback>()
 
-    private val presenter: NotificationsOptInPresenter by lazy {
-        presenterFactory.create(callback)
-    }
+    private val presenter: NotificationsOptInPresenter = presenterFactory.create(callback)
 
     @Composable
     override fun View(modifier: Modifier) {

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInPresenter.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInPresenter.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 class NotificationsOptInPresenter @AssistedInject constructor(
-    private val permissionsPresenterFactory: PermissionsPresenter.Factory,
+    permissionsPresenterFactory: PermissionsPresenter.Factory,
     @Assisted private val callback: NotificationsOptInNode.Callback,
     private val appCoroutineScope: CoroutineScope,
     private val permissionStateProvider: PermissionStateProvider,
@@ -46,14 +46,13 @@ class NotificationsOptInPresenter @AssistedInject constructor(
         fun create(callback: NotificationsOptInNode.Callback): NotificationsOptInPresenter
     }
 
-    private val postNotificationPermissionsPresenter by lazy {
+    private val postNotificationPermissionsPresenter: PermissionsPresenter =
         // Ask for POST_NOTIFICATION PERMISSION on Android 13+
         if (buildVersionSdkIntProvider.isAtLeast(Build.VERSION_CODES.TIRAMISU)) {
             permissionsPresenterFactory.create(Manifest.permission.POST_NOTIFICATIONS)
         } else {
             NoopPermissionsPresenter()
         }
-    }
 
     @Composable
     override fun present(): NotificationsOptInState {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -40,7 +40,6 @@ import io.element.android.libraries.matrix.api.room.StateEventType
 import io.element.android.libraries.matrix.api.room.location.AssetType
 import io.element.android.libraries.matrix.api.room.roomMembers
 import io.element.android.libraries.matrix.api.room.roomNotificationSettings
-import io.element.android.libraries.matrix.api.timeline.MatrixTimeline
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetDriver
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetSettings
 import io.element.android.libraries.matrix.impl.core.toProgressWatcher
@@ -126,22 +125,18 @@ class RustMatrixRoom(
     private val _roomNotificationSettingsStateFlow = MutableStateFlow<MatrixRoomNotificationSettingsState>(MatrixRoomNotificationSettingsState.Unknown)
     override val roomNotificationSettingsStateFlow: StateFlow<MatrixRoomNotificationSettingsState> = _roomNotificationSettingsStateFlow
 
-    private val _timeline by lazy {
-        RustMatrixTimeline(
-            matrixRoom = this,
-            innerRoom = innerRoom,
-            roomCoroutineScope = roomCoroutineScope,
-            dispatcher = roomDispatcher,
-            lastLoginTimestamp = sessionData.loginTimestamp,
-            onNewSyncedEvent = { _syncUpdateFlow.value = systemClock.epochMillis() }
-        )
-    }
+    override val timeline = RustMatrixTimeline(
+        matrixRoom = this,
+        innerRoom = innerRoom,
+        roomCoroutineScope = roomCoroutineScope,
+        dispatcher = roomDispatcher,
+        lastLoginTimestamp = sessionData.loginTimestamp,
+        onNewSyncedEvent = { _syncUpdateFlow.value = systemClock.epochMillis() }
+    )
 
     override val membersStateFlow: StateFlow<MatrixRoomMembersState> = _membersStateFlow.asStateFlow()
 
     override val syncUpdateFlow: StateFlow<Long> = _syncUpdateFlow.asStateFlow()
-
-    override val timeline: MatrixTimeline = _timeline
 
     override suspend fun subscribeToSync() = roomSyncSubscriber.subscribe(roomId)
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
`by lazy` should only be used when the object it is creating may never be used (so never created), or when the creation can be deferred. Else, it's adding useless overhead computation.

I think in all those case, the wrapping were useless, but I am open to discussion.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Clean and efficient code.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
