### PR TITLE
Feature/bma/lint

### DIFF
--- a/appconfig/build.gradle.kts
+++ b/appconfig/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 plugins {
     id("java-library")
+    id("com.android.lint")
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.anvil)
     alias(libs.plugins.ksp)

--- a/features/location/api/src/main/kotlin/io/element/android/features/location/api/Location.kt
+++ b/features/location/api/src/main/kotlin/io/element/android/features/location/api/Location.kt
@@ -16,11 +16,13 @@
 
 package io.element.android.features.location.api
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 private const val GEO_URI_REGEX = """geo:(?<latitude>-?\d+(?:\.\d+)?),(?<longitude>-?\d+(?:\.\d+)?)(?:;u=(?<uncertainty>\d+(?:\.\d+)?))?"""
 
+@SuppressLint("NewApi")
 @Parcelize
 data class Location(
     val lat: Double,

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ signing.element.nightly.keyPassword=Secret
 
 # Customise the Lint version to use a more recent version than the one bundled with AGP
 # https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
-android.experimental.lint.version=8.2.0-alpha02
+android.experimental.lint.version=8.3.0-alpha11
 
 # Enable test fixture for all modules by default
 android.experimental.enableTestFixtures=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,6 @@ junit = "4.13.2"
 androidx-test-ext-junit = "1.1.5"
 espresso-core = "3.5.1"
 appcompat = "1.6.1"
-material = "1.9.0"
 
 [libraries]
 # Project
@@ -196,7 +195,6 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 [bundles]
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Upgrade lint, and do other small cleanup (see commit message for the details).

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #1744 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
