### PR TITLE
Message composer isn't resized when changing the replied to message

### DIFF
--- a/changelog.d/1560.bugfix
+++ b/changelog.d/1560.bugfix
@@ -1,0 +1,1 @@
+Message composer wasn't resized when selecting a several lines message to reply to, then a single line one.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -104,6 +105,7 @@ import io.element.android.libraries.theme.ElementTheme
 import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.collections.immutable.ImmutableList
 import timber.log.Timber
+import kotlin.random.Random
 import androidx.compose.material3.Button as Material3Button
 
 @Composable
@@ -339,6 +341,16 @@ private fun MessagesViewContent(
             )
         }
 
+        // This key is used to force the sheet to be remeasured when the content changes.
+        // Any state change that should trigger a height size should be added to the list of remembered values here.
+        val sheetResizeContentKey = remember(
+            state.composerState.mode.relatedEventId,
+            state.composerState.richTextEditorState.lineCount,
+            state.composerState.memberSuggestions.size
+        ) {
+            Random.nextInt()
+        }
+
         ExpandableBottomSheetScaffold(
             sheetDragHandle = if (state.composerState.showTextFormatting) {
                 @Composable { BottomSheetDragHandle() }
@@ -371,7 +383,7 @@ private fun MessagesViewContent(
                     state = state,
                 )
             },
-            sheetContentKey = state.composerState.richTextEditorState.lineCount + state.composerState.memberSuggestions.size,
+            sheetContentKey = sheetResizeContentKey,
             sheetTonalElevation = 0.dp,
             sheetShadowElevation = if (state.composerState.memberSuggestions.isNotEmpty()) 16.dp else 0.dp,
         )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

`sheetResizeContentKey` now takes into account changes in the related to event to decide when the composer height should be resized.

## Motivation and context

Fixes #1560.

## Tests

- Select a message with several lines to reply to.
- Then select a shorter, single line message.

If the compose resizes properly, it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
