### PR TITLE
Enable seeking a recorded voice message

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPlayer.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPlayer.kt
@@ -17,96 +17,233 @@
 package io.element.android.features.messages.impl.voicemessages.composer
 
 import io.element.android.libraries.mediaplayer.api.MediaPlayer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
  * A media player for the voice message composer.
  *
  * @param mediaPlayer The [MediaPlayer] to use.
+ * @param coroutineScope
  */
 class VoiceMessageComposerPlayer @Inject constructor(
     private val mediaPlayer: MediaPlayer,
+    private val coroutineScope: CoroutineScope,
 ) {
-    private var lastPlayedMediaPath: String? = null
-    private val curPlayingMediaId
-        get() = mediaPlayer.state.value.mediaId
+    companion object {
+        const val MIME_TYPE = "audio/ogg"
+    }
 
-    val state: Flow<State> = mediaPlayer.state.map { state ->
-        if (lastPlayedMediaPath == null || lastPlayedMediaPath != state.mediaId) {
-            return@map State.NotLoaded
+    private var mediaPath: String? = null
+
+    private var seekJob: Job? = null
+    private val seekingTo = MutableStateFlow<Float?>(null)
+
+    val state: Flow<State> = combine(mediaPlayer.state, seekingTo) { state, seekingTo ->
+        state to seekingTo
+    }.scan(InternalState.NotLoaded) { prevState, (state, seekingTo) ->
+        if (mediaPath == null || mediaPath != state.mediaId) {
+            return@scan InternalState.NotLoaded
         }
 
-        State(
-            isPlaying = state.isPlaying,
+        InternalState(
+            playState = calcPlayState(prevState.playState, seekingTo, state),
             currentPosition = state.currentPosition,
-            duration = state.duration ?: 0L,
+            duration = state.duration,
+            seekingTo = seekingTo,
+        )
+    }.map {
+        State(
+            playState = it.playState,
+            currentPosition = it.currentPosition,
+            progress = calcProgress(it),
         )
     }.distinctUntilChanged()
 
     /**
+     * Set the voice message to be played.
+     */
+    suspend fun setMedia(mediaPath: String) {
+        this.mediaPath = mediaPath
+        mediaPlayer.setMedia(
+            uri = mediaPath,
+            mediaId = mediaPath,
+            mimeType = MIME_TYPE,
+        )
+    }
+
+    /**
      * Start playing from the current position.
      *
-     * @param mediaPath The path to the media to be played.
-     * @param mimeType The mime type of the media file.
+     * Call [setMedia] before calling this method.
      */
-    suspend fun play(mediaPath: String, mimeType: String) {
-        if (mediaPath == curPlayingMediaId) {
-            mediaPlayer.play()
-        } else {
-            lastPlayedMediaPath = mediaPath
-            mediaPlayer.setMedia(
-                uri = mediaPath,
-                mediaId = mediaPath,
-                mimeType = mimeType,
-            )
-            mediaPlayer.play()
+    suspend fun play() {
+        val mediaPath = this.mediaPath
+        if (mediaPath == null) {
+            Timber.e("Set media before playing")
+            return
         }
+
+        mediaPlayer.ensureMediaReady(mediaPath)
+
+        mediaPlayer.play()
     }
 
     /**
      * Pause playback.
      */
     fun pause() {
-        if (lastPlayedMediaPath == curPlayingMediaId) {
+        if (mediaPath == mediaPlayer.state.value.mediaId) {
             mediaPlayer.pause()
         }
     }
 
+    /**
+     * Seek to a given position in the current media.
+     *
+     * Call [setMedia] before calling this method.
+     *
+     * @param position The position to seek to between 0 and 1.
+     */
+    suspend fun seek(position: Float) {
+        val mediaPath = this.mediaPath
+        if (mediaPath == null) {
+            Timber.e("Set media before seeking")
+            return
+        }
+
+        seekJob?.cancelAndJoin()
+        seekingTo.value = position
+        seekJob = coroutineScope.launch {
+            val mediaState = mediaPlayer.ensureMediaReady(mediaPath)
+            val duration = mediaState.duration ?: return@launch
+            val positionMs = (duration * position).toLong()
+            mediaPlayer.seekTo(positionMs)
+        }.apply {
+            invokeOnCompletion {
+                seekingTo.value = null
+            }
+        }
+    }
+
+    private suspend fun MediaPlayer.ensureMediaReady(mediaPath: String): MediaPlayer.State {
+        val state = state.value
+        if (state.mediaId == mediaPath && state.isReady) {
+            return state
+        }
+
+        return setMedia(
+            uri = mediaPath,
+            mediaId = mediaPath,
+            mimeType = MIME_TYPE,
+        )
+    }
+
+    private fun calcPlayState(prevPlayState: PlayState, seekingTo: Float?, state: MediaPlayer.State): PlayState {
+        if (state.mediaId == null || state.mediaId != mediaPath) {
+            return PlayState.Stopped
+        }
+
+        // If we were stopped and the player didn't start playing or seeking, we are still stopped.
+        if (prevPlayState == PlayState.Stopped && !state.isPlaying && seekingTo == null) {
+            return PlayState.Stopped
+        }
+
+        return if (state.isPlaying) {
+            PlayState.Playing
+        } else {
+            PlayState.Paused
+        }
+    }
+
+    private fun calcProgress(state: InternalState): Float {
+        if (state.seekingTo != null) {
+            return state.seekingTo
+        }
+
+        if (state.playState == PlayState.Stopped) {
+            return 0f
+        }
+
+        if (state.duration == null) {
+            return 0f
+        }
+
+        return (state.currentPosition.toFloat() / state.duration.toFloat())
+            .coerceAtMost(1f) // Current position may exceed reported duration
+    }
+
+    /**
+     * @property playState Whether this player is currently playing. See [PlayState].
+     * @property currentPosition The elapsed time of this player in milliseconds.
+     * @property progress The progress of this player between 0 and 1.
+     */
     data class State(
+        val playState: PlayState,
+        val currentPosition: Long,
+        val progress: Float,
+    ) {
+
+        companion object {
+            val Initial = State(
+                playState = PlayState.Stopped,
+                currentPosition = 0L,
+                progress = 0f,
+            )
+        }
         /**
          * Whether this player is currently playing.
          */
-        val isPlaying: Boolean,
+        val isPlaying get() = this.playState == PlayState.Playing
+
         /**
-         * The elapsed time of this player in milliseconds.
+         * Whether this player is currently stopped.
          */
+        val isStopped get() = this.playState == PlayState.Stopped
+    }
+
+
+    enum class PlayState {
+        /**
+         * The player is stopped, i.e. it has just been initialised.
+         */
+        Stopped,
+
+        /**
+         * The player is playing.
+         */
+        Playing,
+
+        /**
+         * The player has been paused. The player can also enter the paused state after seeking to a position.
+         */
+        Paused,
+    }
+
+    private data class InternalState(
+        val playState: PlayState,
         val currentPosition: Long,
-        /**
-         * The duration of this player in milliseconds.
-         */
-        val duration: Long,
+        val duration: Long?,
+        val seekingTo: Float?,
     ) {
         companion object {
-            val NotLoaded = State(
-                isPlaying = false,
+            val NotLoaded = InternalState(
+                playState = PlayState.Stopped,
                 currentPosition = 0L,
-                duration = 0L,
+                duration = null,
+                seekingTo = null,
             )
         }
-
-        val isLoaded get() = this != NotLoaded
-
-        /**
-         * The progress of this player between 0 and 1.
-         */
-        val progress: Float =
-            if (duration == 0L)
-                0f
-            else
-                (currentPosition.toFloat() / duration.toFloat())
-                    .coerceAtMost(1f) // Current position may exceed reported duration
     }
 }
+

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessagePlayer.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessagePlayer.kt
@@ -154,7 +154,7 @@ class DefaultVoiceMessagePlayer(
                 mediaPlayer.setMedia(
                     uri = mediaFile.path,
                     mediaId = eventId.value,
-                    mimeType = "audio/ogg" // Files in the voice cache have no extension so we need to set the mime type manually.
+                    mimeType = "audio/ogg", // Files in the voice cache have no extension so we need to set the mime type manually.
                 )
                 mediaPlayer.play()
             }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
@@ -641,7 +641,7 @@ class MessagesPresenterTest {
             FakeVoiceRecorder(),
             analyticsService,
             mediaSender,
-            player = VoiceMessageComposerPlayer(FakeMediaPlayer()),
+            player = VoiceMessageComposerPlayer(FakeMediaPlayer(), this),
             messageComposerContext = FakeMessageComposerContext(),
             permissionsPresenterFactory,
         )

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessagePreview.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessagePreview.kt
@@ -108,7 +108,7 @@ internal fun VoiceMessagePreview(
             playbackProgress = playbackProgress,
             showCursor = showCursor,
             waveform = waveform,
-            seekEnabled = false, // TODO enable seeking
+            seekEnabled = true,
             onSeek = onSeek,
         )
     }

--- a/libraries/voicerecorder/api/build.gradle.kts
+++ b/libraries/voicerecorder/api/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-    id("io.element.android-library")
+    id("io.element.android-compose-library")
     alias(libs.plugins.anvil)
 }
 

--- a/libraries/voicerecorder/api/src/main/kotlin/io/element/android/libraries/voicerecorder/api/VoiceRecorderState.kt
+++ b/libraries/voicerecorder/api/src/main/kotlin/io/element/android/libraries/voicerecorder/api/VoiceRecorderState.kt
@@ -16,9 +16,11 @@
 
 package io.element.android.libraries.voicerecorder.api
 
+import androidx.compose.runtime.Immutable
 import java.io.File
 import kotlin.time.Duration
 
+@Immutable
 sealed interface VoiceRecorderState {
     /**
      * The recorder is idle and not recording.


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Enable seeking the voice message player after recording a voice message.

## Motivation and context

- Part of https://github.com/vector-im/element-meta/issues/2113

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
[Screen_recording_20231107_162647.webm](https://github.com/vector-im/element-x-android/assets/4940864/2742bd61-d162-4533-8336-ac27e2eb5aa4)


## Tests

- Record a voice message
- Seek the preview player by tapping the waveform
- Play a timeline voice message
- Try seeking the preview player again in the same way

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
