### PR TITLE
Ensure BackupState and RecoveryState values are set from the SDK only…

### DIFF
--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootView.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootView.kt
@@ -70,6 +70,7 @@ fun SecureBackupRootView(
 
         // Disable / Enable backup
         when (state.backupState) {
+            BackupState.WAITING_FOR_SYNC,
             BackupState.UNKNOWN -> Unit
             BackupState.DISABLED -> {
                 PreferenceText(
@@ -97,6 +98,7 @@ fun SecureBackupRootView(
 
         // Setup recovery
         when (state.recoveryState) {
+            RecoveryState.WAITING_FOR_SYNC -> Unit
             RecoveryState.UNKNOWN,
             RecoveryState.DISABLED -> {
                 PreferenceText(

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/BackupState.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/BackupState.kt
@@ -17,6 +17,14 @@
 package io.element.android.libraries.matrix.api.encryption
 
 enum class BackupState {
+    /**
+     * Special value, when the SDK is waiting for the first sync to be done.
+     */
+    WAITING_FOR_SYNC,
+
+    /**
+     * Values mapped from the SDK.
+     */
     UNKNOWN,
     CREATING,
     ENABLING,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/RecoveryState.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/RecoveryState.kt
@@ -17,6 +17,14 @@
 package io.element.android.libraries.matrix.api.encryption
 
 enum class RecoveryState {
+    /**
+     * Special value, when the SDK is waiting for the first sync to be done.
+     */
+    WAITING_FOR_SYNC,
+
+    /**
+     * Values mapped from the SDK.
+     */
     UNKNOWN,
     ENABLED,
     DISABLED,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -121,7 +121,12 @@ class RustMatrixClient constructor(
     private val notificationService = RustNotificationService(sessionId, notificationClient, dispatchers, clock)
     private val notificationSettingsService = RustNotificationSettingsService(notificationSettings, dispatchers)
     private val roomSyncSubscriber = RoomSyncSubscriber(innerRoomListService, dispatchers)
-    private val encryptionService = RustEncryptionService(client, dispatchers).apply { start() }
+    private val encryptionService = RustEncryptionService(
+        client = client,
+        syncService = rustSyncService,
+        sessionCoroutineScope = sessionCoroutineScope,
+        dispatchers = dispatchers,
+    ).apply { start() }
 
     private val isLoggingOut = AtomicBoolean(false)
 


### PR DESCRIPTION
… when the first sync is finished.

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Add a value for the enums `BackupState` and `RecoveryState` to prevent the application from reacting on `Unknown` value.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #1765 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Log in to a big account
- Once the room list, log out
- Log in again using the same account. So that the OnBoarding screen is not displayed

Before the PR, the recovery key banner was displayed, waiting for the room list to be displayed, and was then replaced by the verify session banner.

With this change, no banner are displayed and when the room list is displayed, we directly see the verification banner.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
