### PR TITLE
Voice message MediaPlayer: wait until player is ready

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPlayer.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPlayer.kt
@@ -42,7 +42,7 @@ class VoiceMessageComposerPlayer @Inject constructor(
         State(
             isPlaying = state.isPlaying,
             currentPosition = state.currentPosition,
-            duration = state.duration,
+            duration = state.duration ?: 0L,
         )
     }.distinctUntilChanged()
 
@@ -52,16 +52,17 @@ class VoiceMessageComposerPlayer @Inject constructor(
      * @param mediaPath The path to the media to be played.
      * @param mimeType The mime type of the media file.
      */
-    fun play(mediaPath: String, mimeType: String) {
+    suspend fun play(mediaPath: String, mimeType: String) {
         if (mediaPath == curPlayingMediaId) {
             mediaPlayer.play()
         } else {
             lastPlayedMediaPath = mediaPath
-            mediaPlayer.acquireControlAndPlay(
+            mediaPlayer.setMedia(
                 uri = mediaPath,
                 mediaId = mediaPath,
                 mimeType = mimeType,
             )
+            mediaPlayer.play()
         }
     }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenter.kt
@@ -120,10 +120,12 @@ class VoiceMessageComposerPresenter @Inject constructor(
                 VoiceMessagePlayerEvent.Play ->
                     when (val recording = recorderState) {
                         is VoiceRecorderState.Finished ->
-                            player.play(
-                                mediaPath = recording.file.path,
-                                mimeType = recording.mimeType,
-                            )
+                            localCoroutineScope.launch {
+                                player.play(
+                                    mediaPath = recording.file.path,
+                                    mimeType = recording.mimeType,
+                                )
+                            }
                         else -> Timber.e("Voice message player event received but no file to play")
                     }
                 VoiceMessagePlayerEvent.Pause -> {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessagePlayer.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessagePlayer.kt
@@ -151,11 +151,12 @@ class DefaultVoiceMessagePlayer(
     } else {
         if (eventId != null) {
             repo.getMediaFile().mapCatching { mediaFile ->
-                mediaPlayer.acquireControlAndPlay(
+                mediaPlayer.setMedia(
                     uri = mediaFile.path,
                     mediaId = eventId.value,
                     mimeType = "audio/ogg" // Files in the voice cache have no extension so we need to set the mime type manually.
                 )
+                mediaPlayer.play()
             }
         } else {
             Result.failure(IllegalStateException("Cannot play a voice message with no eventId"))

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
@@ -195,6 +195,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.PressStart))
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
+            skipItems(1)
             val finalState = awaitItem().also {
                 assertThat(it.voiceMessageState).isEqualTo(aPlayingState())
             }
@@ -214,6 +215,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Pause))
+            skipItems(1)
             val finalState = awaitItem().also {
                 assertThat(it.voiceMessageState).isEqualTo(aPausedState())
             }
@@ -251,6 +253,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
             awaitItem().eventSink(VoiceMessageComposerEvents.DeleteVoiceMessage)
+            skipItems(1)
             awaitItem().apply {
                 assertThat(voiceMessageState).isEqualTo(aPausedState())
             }
@@ -322,6 +325,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
             awaitItem().eventSink(VoiceMessageComposerEvents.SendVoiceMessage)
+            skipItems(1)
             assertThat(awaitItem().voiceMessageState).isEqualTo(aPlayingState().toSendingState())
 
             val finalState = awaitItem()

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
@@ -195,7 +195,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.PressStart))
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
-            skipItems(1)
+            awaitItem().apply { assertThat(voiceMessageState).isEqualTo(aLoadedState()) }
             val finalState = awaitItem().also {
                 assertThat(it.voiceMessageState).isEqualTo(aPlayingState())
             }
@@ -214,8 +214,8 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.PressStart))
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
+            skipItems(1) // Loaded state
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Pause))
-            skipItems(1)
             val finalState = awaitItem().also {
                 assertThat(it.voiceMessageState).isEqualTo(aPausedState())
             }
@@ -252,8 +252,8 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.PressStart))
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
+            skipItems(1) // Loaded state
             awaitItem().eventSink(VoiceMessageComposerEvents.DeleteVoiceMessage)
-            skipItems(1)
             awaitItem().apply {
                 assertThat(voiceMessageState).isEqualTo(aPausedState())
             }
@@ -324,8 +324,8 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.PressStart))
             awaitItem().eventSink(VoiceMessageComposerEvents.RecordButtonEvent(PressEvent.LongPressEnd))
             awaitItem().eventSink(VoiceMessageComposerEvents.PlayerEvent(VoiceMessagePlayerEvent.Play))
+            skipItems(1) // Loaded state
             awaitItem().eventSink(VoiceMessageComposerEvents.SendVoiceMessage)
-            skipItems(1)
             assertThat(awaitItem().voiceMessageState).isEqualTo(aPlayingState().toSendingState())
 
             val finalState = awaitItem()
@@ -638,6 +638,14 @@ class VoiceMessageComposerPresenterTest {
         showCursor = showCursor,
         waveform = waveform.toImmutableList(),
     )
+
+    private fun aLoadedState() =
+        aPreviewState(
+            isPlaying = false,
+            playbackProgress = 0.0f,
+            showCursor = true,
+            time = 0.seconds,
+        )
 
     private fun aPlayingState() =
         aPreviewState(

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/timeline/DefaultVoiceMessagePlayerTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/timeline/DefaultVoiceMessagePlayerTest.kt
@@ -48,6 +48,11 @@ class DefaultVoiceMessagePlayerTest {
             skipItems(1) // skip initial state.
             Truth.assertThat(player.play().isSuccess).isTrue()
             awaitItem().let {
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isMyMedia).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(0)
+            }
+            awaitItem().let {
                 Truth.assertThat(it.isPlaying).isEqualTo(true)
                 Truth.assertThat(it.isMyMedia).isEqualTo(true)
                 Truth.assertThat(it.currentPosition).isEqualTo(1000)
@@ -85,7 +90,7 @@ class DefaultVoiceMessagePlayerTest {
         player.state.test {
             skipItems(1) // skip initial state.
             Truth.assertThat(player.play().isSuccess).isTrue()
-            skipItems(1) // skip play state
+            skipItems(2) // skip play states
             player.pause()
             awaitItem().let {
                 Truth.assertThat(it.isPlaying).isEqualTo(false)
@@ -101,7 +106,7 @@ class DefaultVoiceMessagePlayerTest {
         player.state.test {
             skipItems(1) // skip initial state.
             Truth.assertThat(player.play().isSuccess).isTrue()
-            skipItems(1) // skip play state
+            skipItems(2) // skip play states
             player.pause()
             skipItems(1)
             player.play()
@@ -119,7 +124,7 @@ class DefaultVoiceMessagePlayerTest {
         player.state.test {
             skipItems(1) // skip initial state.
             Truth.assertThat(player.play().isSuccess).isTrue()
-            skipItems(1) // skip play state
+            skipItems(2) // skip play states
             player.seekTo(2000)
             awaitItem().let {
                 Truth.assertThat(it.isPlaying).isEqualTo(true)

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/timeline/VoiceMessagePresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/timeline/VoiceMessagePresenterTest.kt
@@ -71,6 +71,11 @@ class VoiceMessagePresenterTest {
                 Truth.assertThat(it.time).isEqualTo("0:02")
             }
             awaitItem().also {
+                Truth.assertThat(it.button).isEqualTo(VoiceMessageState.Button.Downloading)
+                Truth.assertThat(it.progress).isEqualTo(0f)
+                Truth.assertThat(it.time).isEqualTo("0:00")
+            }
+            awaitItem().also {
                 Truth.assertThat(it.button).isEqualTo(VoiceMessageState.Button.Pause)
                 Truth.assertThat(it.progress).isEqualTo(0.5f)
                 Truth.assertThat(it.time).isEqualTo("0:01")
@@ -128,7 +133,7 @@ class VoiceMessagePresenterTest {
             }
 
             initialState.eventSink(VoiceMessageEvents.PlayPause)
-            skipItems(1) // skip downloading state
+            skipItems(2) // skip downloading states
 
             val playingState = awaitItem().also {
                 Truth.assertThat(it.button).isEqualTo(VoiceMessageState.Button.Pause)
@@ -177,7 +182,7 @@ class VoiceMessagePresenterTest {
 
             initialState.eventSink(VoiceMessageEvents.PlayPause)
 
-            skipItems(1) // skip downloading state
+            skipItems(2) // skip downloading states
 
             awaitItem().also {
                 Truth.assertThat(it.button).isEqualTo(VoiceMessageState.Button.Pause)

--- a/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
+++ b/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
@@ -30,13 +30,15 @@ interface MediaPlayer : AutoCloseable {
     val state: StateFlow<State>
 
     /**
-     * Acquires control of the player and starts playing the given media.
+     * Initialises the player with a new media item, will suspend until the player is ready.
+     *
+     * @return the ready state of the player.
      */
-    fun acquireControlAndPlay(
+    suspend fun setMedia(
         uri: String,
         mediaId: String,
         mimeType: String,
-    )
+    ): State
 
     /**
      * Plays the current media.
@@ -60,6 +62,10 @@ interface MediaPlayer : AutoCloseable {
 
     data class State(
         /**
+         * Whether the player is ready to play.
+         */
+        val isReady: Boolean,
+        /**
          * Whether the player is currently playing.
          */
         val isPlaying: Boolean,
@@ -75,8 +81,8 @@ interface MediaPlayer : AutoCloseable {
          */
         val currentPosition: Long,
         /**
-         * The duration of the current content.
+         * The duration of the current content, if available.
          */
-        val duration: Long,
+        val duration: Long?,
     )
 }

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
@@ -45,6 +45,7 @@ interface SimplePlayer {
     interface Listener {
         fun onIsPlayingChanged(isPlaying: Boolean)
         fun onMediaItemTransition(mediaItem: MediaItem?)
+        fun onPlaybackStateChanged(playbackState: Int)
     }
 }
 
@@ -67,6 +68,7 @@ class SimplePlayerImpl(
         p.addListener(object : Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) = listener.onIsPlayingChanged(isPlaying)
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) = listener.onMediaItemTransition(mediaItem)
+            override fun onPlaybackStateChanged(playbackState: Int) = listener.onPlaybackStateChanged(playbackState)
         })
     }
 


### PR DESCRIPTION
Change to `MediaPlayer` API to allow waiting for the player to be in a ready state.
This is needed in order to perform some tasks (e.g. read the media duration, seek) after changing the media file.