### PR TITLE
Allow to seek a voice message before playing it

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessagePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessagePresenter.kt
@@ -126,7 +126,18 @@ class VoiceMessagePresenter @AssistedInject constructor(
                     }
                 }
                 is VoiceMessageEvents.Seek -> {
-                    player.seekTo((event.percentage * content.duration.toMillis()).toLong())
+                    scope.launch {
+                        play.runUpdatingState(
+                            errorTransform = {
+                                analyticsService.trackError(
+                                    VoiceMessageException.PlayMessageError("Error while trying to seek voice message", it)
+                                )
+                                it
+                            },
+                        ) {
+                            player.seekTo((event.percentage * content.duration.toMillis()).toLong())
+                        }
+                    }
                 }
             }
         }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/timeline/DefaultVoiceMessagePlayerTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/timeline/DefaultVoiceMessagePlayerTest.kt
@@ -119,6 +119,39 @@ class DefaultVoiceMessagePlayerTest {
     }
 
     @Test
+    fun `download and seek to works`() = runTest {
+        val player = createDefaultVoiceMessagePlayer()
+        player.state.test {
+            skipItems(1) // skip initial state.
+            Truth.assertThat(player.seekTo(2000).isSuccess).isTrue()
+            player.seekTo(2000)
+            awaitItem().let {
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isMyMedia).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(0)
+            }
+            awaitItem().let {
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isMyMedia).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(2000)
+            }
+        }
+    }
+
+    @Test
+    fun `download and seek to fails`() = runTest {
+        val player = createDefaultVoiceMessagePlayer(
+            voiceMessageMediaRepo = FakeVoiceMessageMediaRepo().apply {
+                shouldFail = true
+            },
+        )
+        player.state.test {
+            skipItems(1) // skip initial state.
+            Truth.assertThat(player.seekTo(2000).isFailure).isTrue()
+        }
+    }
+
+    @Test
     fun `seek to works`() = runTest {
         val player = createDefaultVoiceMessagePlayer()
         player.state.test {


### PR DESCRIPTION
Previously the only way to start interacting with a voice message was to play it. This change makes it possible to start interacting also with a seek.
