### PR TITLE
Check for the correct media id when ensuring the MediaPlayer is ready

### DIFF
--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
@@ -116,7 +116,7 @@ class MediaPlayerImpl @Inject constructor(
         )
         player.prepare()
         // Will throw TimeoutCancellationException if the player is not ready after 1 second.
-        return state.timeout(1.seconds).first { it.isReady }
+        return state.timeout(1.seconds).first { it.isReady && it.mediaId == mediaId }
     }
 
     override fun play() {


### PR DESCRIPTION
Just forgot to add this further condition.
