### PR TITLE
Always ensure media temp dir exists

### DIFF
--- a/changelog.d/1790.bugfix
+++ b/changelog.d/1790.bugfix
@@ -1,0 +1,1 @@
+Always ensure media temp dir exists

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/logs/VectorFileLogger.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/logs/VectorFileLogger.kt
@@ -37,7 +37,7 @@ import java.util.logging.Logger
  * Will be planted in Timber.
  */
 class VectorFileLogger(
-    context: Context,
+    private val context: Context,
     // private val vectorPreferences: VectorPreferences
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : Timber.Tree() {
@@ -66,7 +66,9 @@ class VectorFileLogger(
     }
 
     private val fileHandler: FileHandler?
-    private val cacheDirectory = File(context.cacheDir, "logs")
+    private val cacheDirectory get() = File(context.cacheDir, "logs").apply {
+        if (!exists()) mkdirs()
+    }
     private var fileNamePrefix = "logs"
 
     private val prioPrefixes = mapOf(
@@ -79,10 +81,6 @@ class VectorFileLogger(
     )
 
     init {
-        if (!cacheDirectory.exists()) {
-            cacheDirectory.mkdirs()
-        }
-
         for (i in 0..15) {
             val file = File(cacheDirectory, "elementLogs.${i}.txt")
             file.safeDelete()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/media/RustMediaLoader.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/media/RustMediaLoader.kt
@@ -30,18 +30,17 @@ import java.io.File
 import org.matrix.rustcomponents.sdk.MediaSource as RustMediaSource
 
 class RustMediaLoader(
-    baseCacheDirectory: File,
+    private val baseCacheDirectory: File,
     dispatchers: CoroutineDispatchers,
     private val innerClient: Client,
 ) : MatrixMediaLoader {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val mediaDispatcher = dispatchers.io.limitedParallelism(32)
-    private val cacheDirectory = File(baseCacheDirectory, "temp/media").apply {
-        if (!exists()) {
-            mkdirs()
+    private val cacheDirectory
+        get() = File(baseCacheDirectory, "temp/media").apply {
+            if (!exists()) mkdirs() // Must always ensure that this directory exists because "Clear cache" does not restart an app's process.
         }
-    }
 
     @OptIn(ExperimentalUnsignedTypes::class)
     override suspend fun loadMediaContent(source: MediaSource): Result<ByteArray> =


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

`RustMediaLoader` creates the "${cacheDir}/temp/media" dir only once at class creation. Unfortunately when clearing an app's cache this directory will be deleted and the app's process won't be killed, so subsequent usages of the same instance of `RustMediaLoader` will not work because `cacheDirectory` does not exists. This fix makes sure that such directory is always checked and created if needed.

## Motivation and context

Fixes https://github.com/vector-im/element-x-android/issues/1788

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
