### PR TITLE
Remove Element Call feature flag and revert base URL to `call.element.io`

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/ElementCallConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/ElementCallConfig.kt
@@ -17,5 +17,5 @@
 package io.element.android.appconfig
 
 object ElementCallConfig {
-    const val DEFAULT_BASE_URL = "https://call.element.dev"
+    const val DEFAULT_BASE_URL = "https://call.element.io"
 }

--- a/changelog.d/+remove-element-call-flag.misc
+++ b/changelog.d/+remove-element-call-flag.misc
@@ -1,0 +1,4 @@
+Remove Element Call feature flag, it's not always enabled.
+
+- Reverted the EC base URL to `https://call.element.io`.
+- Moved the option to override this URL to developer settings from advanced settings.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -157,10 +157,10 @@ class MessagesPresenter @AssistedInject constructor(
         val enableTextFormatting by preferencesStore.isRichTextEditorEnabledFlow().collectAsState(initial = true)
 
         var enableVoiceMessages by remember { mutableStateOf(false) }
-        var enableInRoomCalls by remember { mutableStateOf(false) }
+        // TODO add min power level to use this feature in the future?
+        val enableInRoomCalls = true
         LaunchedEffect(featureFlagsService) {
             enableVoiceMessages = featureFlagsService.isFeatureEnabled(FeatureFlags.VoiceMessages)
-            enableInRoomCalls = featureFlagsService.isFeatureEnabled(FeatureFlags.InRoomCalls)
         }
 
         fun handleEvents(event: MessagesEvents) {

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsEvents.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsEvents.kt
@@ -19,5 +19,4 @@ package io.element.android.features.preferences.impl.advanced
 sealed interface AdvancedSettingsEvents {
     data class SetRichTextEditorEnabled(val enabled: Boolean) : AdvancedSettingsEvents
     data class SetDeveloperModeEnabled(val enabled: Boolean) : AdvancedSettingsEvents
-    data class SetCustomElementCallBaseUrl(val baseUrl: String?) : AdvancedSettingsEvents
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenter.kt
@@ -17,25 +17,16 @@
 package io.element.android.features.preferences.impl.advanced
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import io.element.android.appconfig.ElementCallConfig
 import io.element.android.features.preferences.api.store.PreferencesStore
 import io.element.android.libraries.architecture.Presenter
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
 import kotlinx.coroutines.launch
-import java.net.URL
 import javax.inject.Inject
 
 class AdvancedSettingsPresenter @Inject constructor(
     private val preferencesStore: PreferencesStore,
-    private val featureFlagService: FeatureFlagService,
 ) : Presenter<AdvancedSettingsState> {
 
     @Composable
@@ -47,14 +38,6 @@ class AdvancedSettingsPresenter @Inject constructor(
         val isDeveloperModeEnabled by preferencesStore
             .isDeveloperModeEnabledFlow()
             .collectAsState(initial = false)
-        val customElementCallBaseUrl by preferencesStore
-            .getCustomElementCallBaseUrlFlow()
-            .collectAsState(initial = null)
-
-        var canDisplayElementCallSettings by remember { mutableStateOf(false) }
-        LaunchedEffect(Unit) {
-            canDisplayElementCallSettings = featureFlagService.isFeatureEnabled(FeatureFlags.InRoomCalls)
-        }
 
         fun handleEvents(event: AdvancedSettingsEvents) {
             when (event) {
@@ -64,34 +47,13 @@ class AdvancedSettingsPresenter @Inject constructor(
                 is AdvancedSettingsEvents.SetDeveloperModeEnabled -> localCoroutineScope.launch {
                     preferencesStore.setDeveloperModeEnabled(event.enabled)
                 }
-                is AdvancedSettingsEvents.SetCustomElementCallBaseUrl -> localCoroutineScope.launch {
-                    // If the URL is either empty or the default one, we want to save 'null' to remove the custom URL
-                    val urlToSave = event.baseUrl.takeIf { !it.isNullOrEmpty() && it != ElementCallConfig.DEFAULT_BASE_URL }
-                    preferencesStore.setCustomElementCallBaseUrl(urlToSave)
-                }
             }
         }
 
         return AdvancedSettingsState(
             isRichTextEditorEnabled = isRichTextEditorEnabled,
             isDeveloperModeEnabled = isDeveloperModeEnabled,
-            customElementCallBaseUrlState = if (canDisplayElementCallSettings) {
-                CustomElementCallBaseUrlState(
-                    baseUrl = customElementCallBaseUrl,
-                    defaultUrl = ElementCallConfig.DEFAULT_BASE_URL,
-                    validator = ::customElementCallUrlValidator,
-                )
-            } else null,
             eventSink = { handleEvents(it) }
         )
-    }
-
-    private fun customElementCallUrlValidator(url: String?): Boolean {
-        return runCatching {
-            if (url.isNullOrEmpty()) return@runCatching
-            val parsedUrl = URL(url)
-            if (parsedUrl.protocol !in listOf("http", "https")) error("Incorrect protocol")
-            if (parsedUrl.host.isNullOrBlank()) error("Missing host")
-        }.isSuccess
     }
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsState.kt
@@ -19,12 +19,5 @@ package io.element.android.features.preferences.impl.advanced
 data class AdvancedSettingsState(
     val isRichTextEditorEnabled: Boolean,
     val isDeveloperModeEnabled: Boolean,
-    val customElementCallBaseUrlState: CustomElementCallBaseUrlState?,
     val eventSink: (AdvancedSettingsEvents) -> Unit
-)
-
-data class CustomElementCallBaseUrlState(
-    val baseUrl: String?,
-    val defaultUrl: String,
-    val validator: (String?) -> Boolean,
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsStateProvider.kt
@@ -24,17 +24,14 @@ open class AdvancedSettingsStateProvider : PreviewParameterProvider<AdvancedSett
             aAdvancedSettingsState(),
             aAdvancedSettingsState(isRichTextEditorEnabled = true),
             aAdvancedSettingsState(isDeveloperModeEnabled = true),
-            aAdvancedSettingsState(customElementCallBaseUrl = "https://call.element.io"),
         )
 }
 
 fun aAdvancedSettingsState(
     isRichTextEditorEnabled: Boolean = false,
     isDeveloperModeEnabled: Boolean = false,
-    customElementCallBaseUrl: String? = null,
 ) = AdvancedSettingsState(
     isRichTextEditorEnabled = isRichTextEditorEnabled,
     isDeveloperModeEnabled = isDeveloperModeEnabled,
-    customElementCallBaseUrlState = customElementCallBaseUrl?.let { CustomElementCallBaseUrlState(it, "https://call.element.io") { true } },
     eventSink = {}
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
@@ -16,16 +16,13 @@
 
 package io.element.android.features.preferences.impl.advanced
 
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import io.element.android.features.preferences.impl.R
 import io.element.android.libraries.designsystem.components.preferences.PreferencePage
 import io.element.android.libraries.designsystem.components.preferences.PreferenceSwitch
-import io.element.android.libraries.designsystem.components.preferences.PreferenceTextField
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.ui.strings.CommonStrings
@@ -36,11 +33,6 @@ fun AdvancedSettingsView(
     onBackPressed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    fun isUsingDefaultUrl(value: String?): Boolean {
-        val defaultUrl = state.customElementCallBaseUrlState?.defaultUrl ?: return false
-        return value.isNullOrEmpty() || value == defaultUrl
-    }
-
     PreferencePage(
         modifier = modifier,
         onBackPressed = onBackPressed,
@@ -58,23 +50,6 @@ fun AdvancedSettingsView(
             isChecked = state.isDeveloperModeEnabled,
             onCheckedChange = { state.eventSink(AdvancedSettingsEvents.SetDeveloperModeEnabled(it)) },
         )
-        state.customElementCallBaseUrlState?.let { callUrlState ->
-            val supportingText = if (isUsingDefaultUrl(callUrlState.baseUrl)) {
-                stringResource(R.string.screen_advanced_settings_element_call_base_url_description)
-            } else {
-                callUrlState.baseUrl
-            }
-            PreferenceTextField(
-                headline = stringResource(R.string.screen_advanced_settings_element_call_base_url),
-                value = callUrlState.baseUrl ?: callUrlState.defaultUrl,
-                supportingText = supportingText,
-                validation = callUrlState.validator,
-                onValidationErrorMessage = stringResource(R.string.screen_advanced_settings_element_call_base_url_validation_error),
-                displayValue = { value -> !isUsingDefaultUrl(value) },
-                keyboardOptions = KeyboardOptions.Default.copy(autoCorrect = false, keyboardType = KeyboardType.Uri),
-                onChange = { state.eventSink(AdvancedSettingsEvents.SetCustomElementCallBaseUrl(it)) }
-            )
-        }
     }
 }
 

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsEvents.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsEvents.kt
@@ -20,5 +20,6 @@ import io.element.android.libraries.featureflag.ui.model.FeatureUiModel
 
 sealed interface DeveloperSettingsEvents {
     data class UpdateEnabledFeature(val feature: FeatureUiModel, val isEnabled: Boolean) : DeveloperSettingsEvents
+    data class SetCustomElementCallBaseUrl(val baseUrl: String?) : DeveloperSettingsEvents
     data object ClearCache: DeveloperSettingsEvents
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsState.kt
@@ -21,10 +21,17 @@ import io.element.android.libraries.architecture.Async
 import io.element.android.libraries.featureflag.ui.model.FeatureUiModel
 import kotlinx.collections.immutable.ImmutableList
 
-data class DeveloperSettingsState constructor(
+data class DeveloperSettingsState(
     val features: ImmutableList<FeatureUiModel>,
     val cacheSize: Async<String>,
     val rageshakeState: RageshakePreferencesState,
     val clearCacheAction: Async<Unit>,
+    val customElementCallBaseUrlState: CustomElementCallBaseUrlState,
     val eventSink: (DeveloperSettingsEvents) -> Unit
+)
+
+data class CustomElementCallBaseUrlState(
+    val baseUrl: String?,
+    val defaultUrl: String,
+    val validator: (String?) -> Boolean,
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsStateProvider.kt
@@ -26,6 +26,13 @@ open class DeveloperSettingsStateProvider : PreviewParameterProvider<DeveloperSe
         get() = sequenceOf(
             aDeveloperSettingsState(),
             aDeveloperSettingsState().copy(clearCacheAction = Async.Loading()),
+            aDeveloperSettingsState().copy(
+                customElementCallBaseUrlState = CustomElementCallBaseUrlState(
+                    baseUrl = "https://call.element.ahoy",
+                    defaultUrl = "https://call.element.io",
+                    validator = { true }
+                )
+            ),
         )
 }
 
@@ -34,5 +41,6 @@ fun aDeveloperSettingsState() = DeveloperSettingsState(
     rageshakeState = aRageshakePreferencesState(),
     cacheSize = Async.Success("1.2 MB"),
     clearCacheAction = Async.Uninitialized,
+    customElementCallBaseUrlState = CustomElementCallBaseUrlState(baseUrl = null, defaultUrl = "https://call.element.io", validator = { true }),
     eventSink = {}
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
@@ -16,16 +16,20 @@
 
 package io.element.android.features.preferences.impl.developer
 
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import io.element.android.features.preferences.impl.R
 import io.element.android.features.rageshake.api.preferences.RageshakePreferencesView
 import io.element.android.libraries.designsystem.components.preferences.PreferenceCategory
-import io.element.android.libraries.designsystem.components.preferences.PreferenceText
 import io.element.android.libraries.designsystem.components.preferences.PreferencePage
-import io.element.android.libraries.designsystem.preview.PreviewsDayNight
+import io.element.android.libraries.designsystem.components.preferences.PreferenceText
+import io.element.android.libraries.designsystem.components.preferences.PreferenceTextField
 import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.featureflag.ui.FeatureListView
 import io.element.android.libraries.featureflag.ui.model.FeatureUiModel
 import io.element.android.libraries.ui.strings.CommonStrings
@@ -47,6 +51,7 @@ fun DeveloperSettingsView(
         PreferenceCategory(title = "Feature flags") {
             FeatureListContent(state)
         }
+        ElementCallCategory(state = state)
         PreferenceCategory(title = "Rust SDK") {
             PreferenceText(
                 title = "Configure tracing",
@@ -81,6 +86,34 @@ fun DeveloperSettingsView(
                 }
             )
         }
+    }
+}
+
+@Composable
+private fun ElementCallCategory(
+    state: DeveloperSettingsState,
+    modifier: Modifier = Modifier,
+) {
+    PreferenceCategory(modifier = modifier, title = "Element Call", showDivider = true) {
+        val callUrlState = state.customElementCallBaseUrlState
+        fun isUsingDefaultUrl(value: String?): Boolean {
+            return value.isNullOrEmpty() || value == callUrlState.defaultUrl
+        }
+        val supportingText = if (isUsingDefaultUrl(callUrlState.baseUrl)) {
+            stringResource(R.string.screen_advanced_settings_element_call_base_url_description)
+        } else {
+            callUrlState.baseUrl
+        }
+        PreferenceTextField(
+            headline = stringResource(R.string.screen_advanced_settings_element_call_base_url),
+            value = callUrlState.baseUrl ?: callUrlState.defaultUrl,
+            supportingText = supportingText,
+            validation = callUrlState.validator,
+            onValidationErrorMessage = stringResource(R.string.screen_advanced_settings_element_call_base_url_validation_error),
+            displayValue = { value -> !isUsingDefaultUrl(value) },
+            keyboardOptions = KeyboardOptions.Default.copy(autoCorrect = false, keyboardType = KeyboardType.Uri),
+            onChange = { state.eventSink(DeveloperSettingsEvents.SetCustomElementCallBaseUrl(it)) }
+        )
     }
 }
 

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -55,12 +55,6 @@ enum class FeatureFlags(
         description = "Allow user to lock/unlock the app with a pin code or biometrics",
         defaultValue = true,
     ),
-    InRoomCalls(
-        key = "feature.elementcall",
-        title = "Element call in rooms",
-        description = "Allow user to start or join a call in a room",
-        defaultValue = true,
-    ),
     Mentions(
         key = "feature.mentions",
         title = "Mentions",

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
@@ -39,7 +39,6 @@ class StaticFeatureFlagProvider @Inject constructor() :
                 FeatureFlags.NotificationSettings -> true
                 FeatureFlags.VoiceMessages -> true
                 FeatureFlags.PinUnlock -> true
-                FeatureFlags.InRoomCalls -> true
                 FeatureFlags.Mentions -> false
                 FeatureFlags.SecureStorage -> false
             }

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.advanced_AdvancedSettingsView_null_AdvancedSettingsView-Day-1_1_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.advanced_AdvancedSettingsView_null_AdvancedSettingsView-Day-1_1_null_3,NEXUS_5,1.0,en].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4e1af15c571d1f087005849b627d79387f8f5557bbc4233768bb3c2d940d628
-size 48510

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.advanced_AdvancedSettingsView_null_AdvancedSettingsView-Night-1_2_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.advanced_AdvancedSettingsView_null_AdvancedSettingsView-Night-1_2_null_3,NEXUS_5,1.0,en].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa25ebf20fe62af56a548c3e962ae2e76e6e8e1b7e685d021306b733613e49eb
-size 45462

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Day-3_3_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Day-3_3_null_0,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c221b092112d787bdc0f9db9e9da3afe75d6b5754b98db119df3c63514da03b4
-size 53808
+oid sha256:b040737c81fb04596312a207e58c75580e48fdd70c1f5ee6abd3c73a846c0337
+size 58489

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Day-3_3_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Day-3_3_null_1,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c221b092112d787bdc0f9db9e9da3afe75d6b5754b98db119df3c63514da03b4
-size 53808
+oid sha256:b040737c81fb04596312a207e58c75580e48fdd70c1f5ee6abd3c73a846c0337
+size 58489

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Day-3_3_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Day-3_3_null_2,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b01d0d26eddb4b6edd900f0f17568d76108e4be97c979d63c5dcca1ca0ed83e
+size 56942

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Night-3_4_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Night-3_4_null_0,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:419ba4098c8b77a6e6ea2af72eeb5a614a9982d04e003fedfcdee92772484eb1
-size 48839
+oid sha256:491beebfede0316e804b818c65794bd0c8f8125fc94f4a89f8e1b3ded5afbf3a
+size 53597

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Night-3_4_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Night-3_4_null_1,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:419ba4098c8b77a6e6ea2af72eeb5a614a9982d04e003fedfcdee92772484eb1
-size 48839
+oid sha256:491beebfede0316e804b818c65794bd0c8f8125fc94f4a89f8e1b3ded5afbf3a
+size 53597

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Night-3_4_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.preferences.impl.developer_DeveloperSettingsView_null_DeveloperSettingsView-Night-3_4_null_2,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16b24b31812e18fbf54568f2bae63c0827dc30e73d7924cdab6387df0c2ad41b
+size 52062


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Removes Element Call feature flag, it's always enabled now.
- Sets base url back to `https://call.element.io`.
- Moves the option to override the url from advanced settings to developer settings to achieve parity with iOS.

## Motivation and context

Parity with iOS.

## Screenshots / GIFs

Inside the PR.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
