### PR TITLE
Remove voice messages feature flag

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -71,8 +71,6 @@ import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarDispatcher
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarMessage
 import io.element.android.libraries.designsystem.utils.snackbar.collectSnackbarMessageAsState
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
@@ -103,7 +101,6 @@ class MessagesPresenter @AssistedInject constructor(
     private val dispatchers: CoroutineDispatchers,
     private val clipboardHelper: ClipboardHelper,
     private val preferencesStore: PreferencesStore,
-    private val featureFlagsService: FeatureFlagService,
     @Assisted private val navigator: MessagesNavigator,
     private val buildMeta: BuildMeta,
 ) : Presenter<MessagesState> {
@@ -156,12 +153,8 @@ class MessagesPresenter @AssistedInject constructor(
 
         val enableTextFormatting by preferencesStore.isRichTextEditorEnabledFlow().collectAsState(initial = true)
 
-        var enableVoiceMessages by remember { mutableStateOf(false) }
         // TODO add min power level to use this feature in the future?
         val enableInRoomCalls = true
-        LaunchedEffect(featureFlagsService) {
-            enableVoiceMessages = featureFlagsService.isFeatureEnabled(FeatureFlags.VoiceMessages)
-        }
 
         fun handleEvents(event: MessagesEvents) {
             when (event) {
@@ -206,7 +199,6 @@ class MessagesPresenter @AssistedInject constructor(
             showReinvitePrompt = showReinvitePrompt,
             inviteProgress = inviteProgress.value,
             enableTextFormatting = enableTextFormatting,
-            enableVoiceMessages = enableVoiceMessages,
             enableInRoomCalls = enableInRoomCalls,
             appName = buildMeta.applicationName,
             isCallOngoing = roomInfo?.hasRoomCall ?: false,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
@@ -48,7 +48,6 @@ data class MessagesState(
     val inviteProgress: Async<Unit>,
     val showReinvitePrompt: Boolean,
     val enableTextFormatting: Boolean,
-    val enableVoiceMessages: Boolean,
     val enableInRoomCalls: Boolean,
     val isCallOngoing: Boolean,
     val appName: String,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
@@ -51,7 +51,6 @@ open class MessagesStateProvider : PreviewParameterProvider<MessagesState> {
             ),
             aMessagesState().copy(composerState = aMessageComposerState().copy(showTextFormatting = true)),
             aMessagesState().copy(
-                enableVoiceMessages = true,
                 voiceMessageComposerState = aVoiceMessageComposerState(showPermissionRationaleDialog = true),
             ),
             aMessagesState().copy(
@@ -68,7 +67,6 @@ open class MessagesStateProvider : PreviewParameterProvider<MessagesState> {
                 isCallOngoing = true,
             ),
             aMessagesState().copy(
-                enableVoiceMessages = true,
                 voiceMessageComposerState = aVoiceMessageComposerState(
                     voiceMessageState = aVoiceMessagePreviewState(),
                     showSendFailureDialog = true
@@ -111,7 +109,6 @@ fun aMessagesState() = MessagesState(
     inviteProgress = Async.Uninitialized,
     showReinvitePrompt = false,
     enableTextFormatting = true,
-    enableVoiceMessages = true,
     enableInRoomCalls = true,
     isCallOngoing = false,
     appName = "Element",

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -330,7 +330,7 @@ private fun MessagesViewContent(
             enableTextFormatting = state.enableTextFormatting,
         )
 
-        if (state.enableVoiceMessages && state.voiceMessageComposerState.showPermissionRationaleDialog) {
+        if (state.voiceMessageComposerState.showPermissionRationaleDialog) {
             VoiceMessagePermissionRationaleDialog(
                 onContinue = {
                     state.voiceMessageComposerState.eventSink(VoiceMessageComposerEvents.AcceptPermissionRationale)
@@ -341,7 +341,7 @@ private fun MessagesViewContent(
                 appName = state.appName
             )
         }
-        if (state.enableVoiceMessages && state.voiceMessageComposerState.showSendFailureDialog) {
+        if (state.voiceMessageComposerState.showSendFailureDialog) {
             VoiceMessageSendingFailedDialog(
                 onDismiss = { state.voiceMessageComposerState.eventSink(VoiceMessageComposerEvents.DismissSendFailureDialog) },
             )
@@ -426,7 +426,6 @@ private fun MessagesViewComposerBottomSheetContents(
                 voiceMessageState = state.voiceMessageComposerState,
                 subcomposing = subcomposing,
                 enableTextFormatting = state.enableTextFormatting,
-                enableVoiceMessages = state.enableVoiceMessages,
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerView.kt
@@ -43,7 +43,6 @@ internal fun MessageComposerView(
     voiceMessageState: VoiceMessageComposerState,
     subcomposing: Boolean,
     enableTextFormatting: Boolean,
-    enableVoiceMessages: Boolean,
     modifier: Modifier = Modifier,
 ) {
     fun sendMessage(message: Message) {
@@ -106,7 +105,6 @@ internal fun MessageComposerView(
         onAddAttachment = ::onAddAttachment,
         onDismissTextFormatting = ::onDismissTextFormatting,
         enableTextFormatting = enableTextFormatting,
-        enableVoiceMessages = enableVoiceMessages,
         onVoiceRecorderEvent = onVoiceRecorderEvent,
         onVoicePlayerEvent = onVoicePlayerEvent,
         onSendVoiceMessage = onSendVoiceMessage,
@@ -127,7 +125,6 @@ internal fun MessageComposerViewPreview(
             state = state,
             voiceMessageState = aVoiceMessageComposerState(),
             enableTextFormatting = true,
-            enableVoiceMessages = true,
             subcomposing = false,
         )
         MessageComposerView(
@@ -135,7 +132,6 @@ internal fun MessageComposerViewPreview(
             state = state,
             voiceMessageState = aVoiceMessageComposerState(),
             enableTextFormatting = true,
-            enableVoiceMessages = true,
             subcomposing = false,
         )
     }
@@ -152,7 +148,6 @@ internal fun MessageComposerViewVoicePreview(
             state = aMessageComposerState(),
             voiceMessageState = state,
             enableTextFormatting = true,
-            enableVoiceMessages = true,
             subcomposing = false,
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -31,8 +31,6 @@ import io.element.android.features.messages.impl.timeline.util.FileExtensionExtr
 import io.element.android.features.messages.impl.timeline.util.toHtmlDocument
 import io.element.android.libraries.androidutils.filesize.FileSizeFormatter
 import io.element.android.libraries.core.mimetype.MimeTypes
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.timeline.item.event.AudioMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.EmoteMessageType
@@ -54,7 +52,6 @@ import javax.inject.Inject
 class TimelineItemContentMessageFactory @Inject constructor(
     private val fileSizeFormatter: FileSizeFormatter,
     private val fileExtensionExtractor: FileExtensionExtractor,
-    private val featureFlagService: FeatureFlagService,
 ) {
 
     suspend fun create(content: MessageContent, senderDisplayName: String, eventId: EventId?): TimelineItemEventContent {
@@ -122,28 +119,14 @@ class TimelineItemContentMessageFactory @Inject constructor(
                 )
             }
             is VoiceMessageType -> {
-                when (featureFlagService.isFeatureEnabled(FeatureFlags.VoiceMessages)) {
-                    true -> {
-                        TimelineItemVoiceContent(
-                            eventId = eventId,
-                            body = messageType.body,
-                            mediaSource = messageType.source,
-                            duration = messageType.info?.duration ?: Duration.ZERO,
-                            mimeType = messageType.info?.mimetype ?: MimeTypes.OctetStream,
-                            waveform = messageType.details?.waveform?.toImmutableList() ?: persistentListOf(),
-                        )
-                    }
-                    false -> {
-                        TimelineItemAudioContent(
-                            body = messageType.body,
-                            mediaSource = messageType.source,
-                            duration = messageType.info?.duration ?: Duration.ZERO,
-                            mimeType = messageType.info?.mimetype ?: MimeTypes.OctetStream,
-                            formattedFileSize = fileSizeFormatter.format(messageType.info?.size ?: 0),
-                            fileExtension = fileExtensionExtractor.extractFromName(messageType.body),
-                        )
-                    }
-                }
+                TimelineItemVoiceContent(
+                    eventId = eventId,
+                    body = messageType.body,
+                    mediaSource = messageType.source,
+                    duration = messageType.info?.duration ?: Duration.ZERO,
+                    mimeType = messageType.info?.mimetype ?: MimeTypes.OctetStream,
+                    waveform = messageType.details?.waveform?.toImmutableList() ?: persistentListOf(),
+                )
             }
             is FileMessageType -> {
                 val fileExtension = fileExtensionExtractor.extractFromName(messageType.body)

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/MessagesPresenterTest.kt
@@ -674,7 +674,6 @@ class MessagesPresenterTest {
             navigator = navigator,
             clipboardHelper = clipboardHelper,
             preferencesStore = preferencesStore,
-            featureFlagsService = FakeFeatureFlagService(),
             buildMeta = aBuildMeta(),
             dispatchers = coroutineDispatchers,
         )

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/fixtures/timelineItemsFactory.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/fixtures/timelineItemsFactory.kt
@@ -52,7 +52,6 @@ internal fun TestScope.aTimelineItemsFactory(): TimelineItemsFactory {
                 messageFactory = TimelineItemContentMessageFactory(
                     fileSizeFormatter = FakeFileSizeFormatter(),
                     fileExtensionExtractor = FileExtensionExtractorWithoutValidation(),
-                    featureFlagService = FakeFeatureFlagService(),
                 ),
                 redactedMessageFactory = TimelineItemContentRedactedFactory(),
                 stickerFactory = TimelineItemContentStickerFactory(),

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -43,12 +43,6 @@ enum class FeatureFlags(
         title = "Show notification settings",
         defaultValue = true,
     ),
-    VoiceMessages(
-        key = "feature.voicemessages",
-        title = "Voice messages",
-        description = "Send and receive voice messages",
-        defaultValue = true,
-    ),
     PinUnlock(
         key = "feature.pinunlock",
         title = "Pin unlock",

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
@@ -37,7 +37,6 @@ class StaticFeatureFlagProvider @Inject constructor() :
                 FeatureFlags.LocationSharing -> true
                 FeatureFlags.Polls -> true
                 FeatureFlags.NotificationSettings -> true
-                FeatureFlags.VoiceMessages -> true
                 FeatureFlags.PinUnlock -> true
                 FeatureFlags.Mentions -> false
                 FeatureFlags.SecureStorage -> false

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -94,7 +94,6 @@ fun TextComposer(
     voiceMessageState: VoiceMessageState,
     composerMode: MessageComposerMode,
     enableTextFormatting: Boolean,
-    enableVoiceMessages: Boolean,
     modifier: Modifier = Modifier,
     showTextFormatting: Boolean = false,
     subcomposing: Boolean = false,
@@ -188,7 +187,7 @@ fun TextComposer(
     val textFormattingOptions = @Composable { TextFormatting(state = state) }
 
     val sendOrRecordButton = when {
-        enableVoiceMessages && !canSendMessage ->
+        !canSendMessage ->
             when (voiceMessageState) {
                 VoiceMessageState.Idle,
                 is VoiceMessageState.Recording -> recordVoiceButton
@@ -244,7 +243,6 @@ fun TextComposer(
     } else {
         StandardLayout(
             voiceMessageState = voiceMessageState,
-            enableVoiceMessages = enableVoiceMessages,
             modifier = layoutModifier,
             composerOptionsButton = composerOptionsButton,
             textInput = textInput,
@@ -276,7 +274,6 @@ fun TextComposer(
 @Composable
 private fun StandardLayout(
     voiceMessageState: VoiceMessageState,
-    enableVoiceMessages: Boolean,
     textInput: @Composable () -> Unit,
     composerOptionsButton: @Composable () -> Unit,
     voiceRecording: @Composable () -> Unit,
@@ -288,7 +285,7 @@ private fun StandardLayout(
         modifier = modifier,
         verticalAlignment = Alignment.Bottom,
     ) {
-        if (enableVoiceMessages && voiceMessageState !is VoiceMessageState.Idle) {
+        if (voiceMessageState !is VoiceMessageState.Idle) {
             if (voiceMessageState is VoiceMessageState.Preview || voiceMessageState is VoiceMessageState.Recording) {
                 Box(
                     modifier = Modifier
@@ -583,7 +580,6 @@ internal fun TextComposerSimplePreview() = ElementPreview {
                 composerMode = MessageComposerMode.Normal,
                 onResetComposerMode = {},
                 enableTextFormatting = true,
-                enableVoiceMessages = true,
             )
         }, {
         TextComposer(
@@ -593,7 +589,6 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             composerMode = MessageComposerMode.Normal,
             onResetComposerMode = {},
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     }, {
         TextComposer(
@@ -606,7 +601,6 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             composerMode = MessageComposerMode.Normal,
             onResetComposerMode = {},
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     }, {
         TextComposer(
@@ -616,7 +610,6 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             composerMode = MessageComposerMode.Normal,
             onResetComposerMode = {},
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     })
     )
@@ -632,7 +625,6 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
             showTextFormatting = true,
             composerMode = MessageComposerMode.Normal,
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     }, {
         TextComposer(
@@ -641,7 +633,6 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
             showTextFormatting = true,
             composerMode = MessageComposerMode.Normal,
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     }, {
         TextComposer(
@@ -650,7 +641,6 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
             showTextFormatting = true,
             composerMode = MessageComposerMode.Normal,
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     }))
 }
@@ -666,7 +656,6 @@ internal fun TextComposerEditPreview() = ElementPreview {
             composerMode = MessageComposerMode.Edit(EventId("$1234"), "Some text", TransactionId("1234")),
             onResetComposerMode = {},
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     }))
 }
@@ -690,7 +679,6 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             ),
             onResetComposerMode = {},
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     },
         {
@@ -709,7 +697,6 @@ internal fun TextComposerReplyPreview() = ElementPreview {
                 ),
                 onResetComposerMode = {},
                 enableTextFormatting = true,
-                enableVoiceMessages = true,
             )
         }, {
         TextComposer(
@@ -730,7 +717,6 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             ),
             onResetComposerMode = {},
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     }, {
         TextComposer(
@@ -751,7 +737,6 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             ),
             onResetComposerMode = {},
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     }, {
         TextComposer(
@@ -772,7 +757,6 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             ),
             onResetComposerMode = {},
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     }, {
         TextComposer(
@@ -793,7 +777,6 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             ),
             onResetComposerMode = {},
             enableTextFormatting = true,
-            enableVoiceMessages = true,
         )
     })
     )
@@ -812,7 +795,6 @@ internal fun TextComposerVoicePreview() = ElementPreview {
         composerMode = MessageComposerMode.Normal,
         onResetComposerMode = {},
         enableTextFormatting = true,
-        enableVoiceMessages = true,
     )
     PreviewColumn(items = persistentListOf({
         VoicePreview(voiceMessageState = VoiceMessageState.Recording(61.seconds, createFakeWaveform()))


### PR DESCRIPTION
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Remove voice messages feature flag.

## Motivation and context

The feature is already enabled by default so this is just cleaning up.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
