### PR TITLE
Voice message scrubbing improvements

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemVoiceView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemVoiceView.kt
@@ -96,7 +96,7 @@ fun TimelineItemVoiceView(
         Spacer(Modifier.width(8.dp))
         val context = LocalContext.current
         WaveformPlaybackView(
-            showCursor = state.button == VoiceMessageState.Button.Pause,
+            showCursor = state.showCursor,
             playbackProgress = state.progress,
             waveform = content.waveform,
             modifier = Modifier

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessageState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessageState.kt
@@ -20,6 +20,7 @@ data class VoiceMessageState(
     val button: Button,
     val progress: Float,
     val time: String,
+    val showCursor: Boolean,
     val eventSink: (event: VoiceMessageEvents) -> Unit,
 ) {
     enum class Button {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessageStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/VoiceMessageStateProvider.kt
@@ -35,11 +35,13 @@ open class VoiceMessageStateProvider : PreviewParameterProvider<VoiceMessageStat
                 VoiceMessageState.Button.Play,
                 progress = 1f,
                 time = "1:00",
+                showCursor = true,
             ),
             aVoiceMessageState(
                 VoiceMessageState.Button.Pause,
                 progress = 0.2f,
                 time = "10:00",
+                showCursor = true,
             ),
             aVoiceMessageState(
                 VoiceMessageState.Button.Disabled,
@@ -53,9 +55,11 @@ fun aVoiceMessageState(
     button: VoiceMessageState.Button = VoiceMessageState.Button.Play,
     progress: Float = 0f,
     time: String = "1:00",
+    showCursor: Boolean = false,
 ) = VoiceMessageState(
     button = button,
     progress = progress,
     time = time,
+    showCursor = showCursor,
     eventSink = {},
 )

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/timeline/DefaultVoiceMessagePlayerTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/voicemessages/timeline/DefaultVoiceMessagePlayerTest.kt
@@ -16,15 +16,17 @@
 
 package io.element.android.features.messages.voicemessages.timeline
 
+import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.google.common.truth.Truth
-import io.element.android.libraries.mediaplayer.api.MediaPlayer
 import io.element.android.features.messages.impl.voicemessages.timeline.DefaultVoiceMessagePlayer
 import io.element.android.features.messages.impl.voicemessages.timeline.VoiceMessageMediaRepo
-import io.element.android.libraries.mediaplayer.test.FakeMediaPlayer
+import io.element.android.features.messages.impl.voicemessages.timeline.VoiceMessagePlayer
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
+import io.element.android.libraries.mediaplayer.api.MediaPlayer
+import io.element.android.libraries.mediaplayer.test.FakeMediaPlayer
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -33,68 +35,176 @@ class DefaultVoiceMessagePlayerTest {
     @Test
     fun `initial state`() = runTest {
         createDefaultVoiceMessagePlayer().state.test {
-            awaitItem().let {
-                Truth.assertThat(it.isPlaying).isEqualTo(false)
-                Truth.assertThat(it.isMyMedia).isEqualTo(false)
-                Truth.assertThat(it.currentPosition).isEqualTo(0)
-            }
+            matchInitialState()
         }
     }
 
     @Test
-    fun `downloading and play works`() = runTest {
+    fun `prepare succeeds`() = runTest {
         val player = createDefaultVoiceMessagePlayer()
         player.state.test {
-            skipItems(1) // skip initial state.
-            Truth.assertThat(player.play().isSuccess).isTrue()
-            awaitItem().let {
-                Truth.assertThat(it.isPlaying).isEqualTo(false)
-                Truth.assertThat(it.isMyMedia).isEqualTo(true)
-                Truth.assertThat(it.currentPosition).isEqualTo(0)
-            }
-            awaitItem().let {
-                Truth.assertThat(it.isPlaying).isEqualTo(true)
-                Truth.assertThat(it.isMyMedia).isEqualTo(true)
-                Truth.assertThat(it.currentPosition).isEqualTo(1000)
-            }
+            matchInitialState()
+            Truth.assertThat(player.prepare().isSuccess).isTrue()
+            matchReadyState()
         }
     }
 
     @Test
-    fun `downloading and play fails`() = runTest {
+    fun `prepare fails when repo fails`() = runTest {
         val player = createDefaultVoiceMessagePlayer(
             voiceMessageMediaRepo = FakeVoiceMessageMediaRepo().apply {
                 shouldFail = true
             },
         )
         player.state.test {
-            skipItems(1) // skip initial state.
-            Truth.assertThat(player.play().isFailure).isTrue()
+            matchInitialState()
+            Truth.assertThat(player.prepare().isFailure).isTrue()
         }
     }
 
     @Test
-    fun `play fails with no eventId`() = runTest {
+    fun `prepare fails with no eventId`() = runTest {
         val player = createDefaultVoiceMessagePlayer(
             eventId = null
         )
         player.state.test {
-            skipItems(1) // skip initial state.
-            Truth.assertThat(player.play().isFailure).isTrue()
+            matchInitialState()
+            Truth.assertThat(player.prepare().isFailure).isTrue()
         }
     }
 
     @Test
-    fun `pause playing works`() = runTest {
+    fun `play after prepare works`() = runTest {
         val player = createDefaultVoiceMessagePlayer()
         player.state.test {
-            skipItems(1) // skip initial state.
-            Truth.assertThat(player.play().isSuccess).isTrue()
-            skipItems(2) // skip play states
+            matchInitialState()
+            Truth.assertThat(player.prepare().isSuccess).isTrue()
+            matchReadyState()
+            player.play()
+            awaitItem().let {
+                Truth.assertThat(it.isPlaying).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(1000)
+            }
+        }
+    }
+
+    @Test
+    fun `play reaches end of media`() = runTest {
+        val player = createDefaultVoiceMessagePlayer(
+            mediaPlayer = FakeMediaPlayer(
+                fakeTotalDurationMs = 1000,
+                fakePlayedDurationMs = 1000
+            )
+        )
+        player.state.test {
+            matchInitialState()
+            Truth.assertThat(player.prepare().isSuccess).isTrue()
+            matchReadyState(fakeTotalDurationMs = 1000)
+            player.play()
+            awaitItem().let {
+                Truth.assertThat(it.isReady).isEqualTo(false)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(1000)
+                Truth.assertThat(it.duration).isEqualTo(1000)
+            }
+        }
+    }
+
+    @Test
+    fun `player1 plays again after both player1 and player2 are finished`() = runTest {
+        val mediaPlayer = FakeMediaPlayer(
+            fakeTotalDurationMs = 1_000L,
+            fakePlayedDurationMs = 1_000L,
+        )
+        val player1 = createDefaultVoiceMessagePlayer(mediaPlayer = mediaPlayer)
+        val player2 = createDefaultVoiceMessagePlayer(mediaPlayer = mediaPlayer)
+
+        // Play player1 until the end.
+        player1.state.test {
+            matchInitialState()
+            Truth.assertThat(player1.prepare().isSuccess).isTrue()
+            matchReadyState(1_000L)
+            player1.play()
+            awaitItem().let { // it plays until the end.
+                Truth.assertThat(it.isReady).isEqualTo(false)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(1000)
+                Truth.assertThat(it.duration).isEqualTo(1000)
+            }
+        }
+
+        // Play player2 until the end.
+        player2.state.test {
+            matchInitialState()
+            Truth.assertThat(player2.prepare().isSuccess).isTrue()
+            awaitItem().let { // Additional spurious state due to MediaPlayer owner change.
+                Truth.assertThat(it.isReady).isEqualTo(false)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(1000)
+                Truth.assertThat(it.duration).isEqualTo(1000)
+            }
+            awaitItem().let {// Additional spurious state due to MediaPlayer owner change.
+                Truth.assertThat(it.isReady).isEqualTo(false)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(false)
+                Truth.assertThat(it.currentPosition).isEqualTo(0)
+                Truth.assertThat(it.duration).isEqualTo(null)
+            }
+            matchReadyState(1_000L)
+            player2.play()
+            awaitItem().let { // it plays until the end.
+                Truth.assertThat(it.isReady).isEqualTo(false)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(1000)
+                Truth.assertThat(it.duration).isEqualTo(1000)
+            }
+        }
+
+        // Play player1 again.
+        player1.state.test {
+            awaitItem().let {// Last previous state/
+                Truth.assertThat(it.isReady).isEqualTo(false)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(1000)
+                Truth.assertThat(it.duration).isEqualTo(1000)
+            }
+            Truth.assertThat(player1.prepare().isSuccess).isTrue()
+            awaitItem().let {// Additional spurious state due to MediaPlayer owner change.
+                Truth.assertThat(it.isReady).isEqualTo(false)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(false)
+                Truth.assertThat(it.currentPosition).isEqualTo(0)
+                Truth.assertThat(it.duration).isEqualTo(null)
+            }
+            matchReadyState(1_000L)
+            player1.play()
+            awaitItem().let { // it played again until the end.
+                Truth.assertThat(it.isReady).isEqualTo(false)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(true)
+                Truth.assertThat(it.currentPosition).isEqualTo(1000)
+                Truth.assertThat(it.duration).isEqualTo(1000)
+            }
+        }
+    }
+
+    @Test
+    fun `pause after play pauses`() = runTest {
+        val player = createDefaultVoiceMessagePlayer()
+        player.state.test {
+            matchInitialState()
+            Truth.assertThat(player.prepare().isSuccess).isTrue()
+            matchReadyState()
+            player.play()
+            skipItems(1) // skip play state
             player.pause()
             awaitItem().let {
                 Truth.assertThat(it.isPlaying).isEqualTo(false)
-                Truth.assertThat(it.isMyMedia).isEqualTo(true)
                 Truth.assertThat(it.currentPosition).isEqualTo(1000)
             }
         }
@@ -104,72 +214,72 @@ class DefaultVoiceMessagePlayerTest {
     fun `play after pause works`() = runTest {
         val player = createDefaultVoiceMessagePlayer()
         player.state.test {
-            skipItems(1) // skip initial state.
-            Truth.assertThat(player.play().isSuccess).isTrue()
-            skipItems(2) // skip play states
+            matchInitialState()
+            Truth.assertThat(player.prepare().isSuccess).isTrue()
+            matchReadyState()
+            player.play()
+            skipItems(1) // skip play state
             player.pause()
-            skipItems(1)
+            skipItems(1) // skip pause state
             player.play()
             awaitItem().let {
                 Truth.assertThat(it.isPlaying).isEqualTo(true)
-                Truth.assertThat(it.isMyMedia).isEqualTo(true)
                 Truth.assertThat(it.currentPosition).isEqualTo(2000)
             }
         }
     }
 
     @Test
-    fun `download and seek to works`() = runTest {
+    fun `seek before prepare works`() = runTest {
         val player = createDefaultVoiceMessagePlayer()
         player.state.test {
-            skipItems(1) // skip initial state.
-            Truth.assertThat(player.seekTo(2000).isSuccess).isTrue()
+            matchInitialState()
             player.seekTo(2000)
             awaitItem().let {
+                Truth.assertThat(it.isReady).isEqualTo(false)
                 Truth.assertThat(it.isPlaying).isEqualTo(false)
-                Truth.assertThat(it.isMyMedia).isEqualTo(true)
-                Truth.assertThat(it.currentPosition).isEqualTo(0)
-            }
-            awaitItem().let {
-                Truth.assertThat(it.isPlaying).isEqualTo(false)
-                Truth.assertThat(it.isMyMedia).isEqualTo(true)
+                Truth.assertThat(it.isEnded).isEqualTo(false)
                 Truth.assertThat(it.currentPosition).isEqualTo(2000)
+                Truth.assertThat(it.duration).isEqualTo(null)
+            }
+            Truth.assertThat(player.prepare().isSuccess).isTrue()
+            awaitItem().let {
+                Truth.assertThat(it.isReady).isEqualTo(true)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(false)
+                Truth.assertThat(it.currentPosition).isEqualTo(2000)
+                Truth.assertThat(it.duration).isEqualTo(FAKE_TOTAL_DURATION_MS)
             }
         }
     }
 
     @Test
-    fun `download and seek to fails`() = runTest {
-        val player = createDefaultVoiceMessagePlayer(
-            voiceMessageMediaRepo = FakeVoiceMessageMediaRepo().apply {
-                shouldFail = true
-            },
-        )
-        player.state.test {
-            skipItems(1) // skip initial state.
-            Truth.assertThat(player.seekTo(2000).isFailure).isTrue()
-        }
-    }
-
-    @Test
-    fun `seek to works`() = runTest {
+    fun `seek after prepare works`() = runTest {
         val player = createDefaultVoiceMessagePlayer()
         player.state.test {
-            skipItems(1) // skip initial state.
-            Truth.assertThat(player.play().isSuccess).isTrue()
-            skipItems(2) // skip play states
+            matchInitialState()
+            Truth.assertThat(player.prepare().isSuccess).isTrue()
+            matchReadyState()
             player.seekTo(2000)
             awaitItem().let {
-                Truth.assertThat(it.isPlaying).isEqualTo(true)
-                Truth.assertThat(it.isMyMedia).isEqualTo(true)
+                Truth.assertThat(it.isReady).isEqualTo(true)
+                Truth.assertThat(it.isPlaying).isEqualTo(false)
+                Truth.assertThat(it.isEnded).isEqualTo(false)
                 Truth.assertThat(it.currentPosition).isEqualTo(2000)
+                Truth.assertThat(it.duration).isEqualTo(FAKE_TOTAL_DURATION_MS)
             }
         }
     }
 }
 
+private const val FAKE_TOTAL_DURATION_MS = 10_000L
+private const val FAKE_PLAYED_DURATION_MS = 1000L
+
 private fun createDefaultVoiceMessagePlayer(
-    mediaPlayer: MediaPlayer = FakeMediaPlayer(),
+    mediaPlayer: MediaPlayer = FakeMediaPlayer(
+        fakeTotalDurationMs = FAKE_TOTAL_DURATION_MS,
+        fakePlayedDurationMs = FAKE_PLAYED_DURATION_MS
+    ),
     voiceMessageMediaRepo: VoiceMessageMediaRepo = FakeVoiceMessageMediaRepo(),
     eventId: EventId? = AN_EVENT_ID,
 ) = DefaultVoiceMessagePlayer(
@@ -185,3 +295,25 @@ private fun createDefaultVoiceMessagePlayer(
 )
 
 private const val MXC_URI = "mxc://matrix.org/1234567890abcdefg"
+
+private suspend fun TurbineTestContext<VoiceMessagePlayer.State>.matchInitialState() {
+    awaitItem().let {
+        Truth.assertThat(it.isReady).isEqualTo(false)
+        Truth.assertThat(it.isPlaying).isEqualTo(false)
+        Truth.assertThat(it.isEnded).isEqualTo(false)
+        Truth.assertThat(it.currentPosition).isEqualTo(0)
+        Truth.assertThat(it.duration).isEqualTo(null)
+    }
+}
+
+private suspend fun TurbineTestContext<VoiceMessagePlayer.State>.matchReadyState(
+    fakeTotalDurationMs: Long = FAKE_TOTAL_DURATION_MS,
+) {
+    awaitItem().let {
+        Truth.assertThat(it.isReady).isEqualTo(true)
+        Truth.assertThat(it.isPlaying).isEqualTo(false)
+        Truth.assertThat(it.isEnded).isEqualTo(false)
+        Truth.assertThat(it.currentPosition).isEqualTo(0)
+        Truth.assertThat(it.duration).isEqualTo(fakeTotalDurationMs)
+    }
+}

--- a/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
+++ b/libraries/mediaplayer/api/src/main/kotlin/io/element/android/libraries/mediaplayer/api/MediaPlayer.kt
@@ -38,6 +38,7 @@ interface MediaPlayer : AutoCloseable {
         uri: String,
         mediaId: String,
         mimeType: String,
+        startPositionMs: Long = 0,
     ): State
 
     /**
@@ -69,6 +70,10 @@ interface MediaPlayer : AutoCloseable {
          * Whether the player is currently playing.
          */
         val isPlaying: Boolean,
+        /**
+         * Whether the player has reached the end of the current media.
+         */
+        val isEnded: Boolean,
         /**
          * The id of the media which is currently playing.
          *

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/MediaPlayerImpl.kt
@@ -77,6 +77,7 @@ class MediaPlayerImpl @Inject constructor(
             _state.update {
                 it.copy(
                     isReady = playbackState == Player.STATE_READY,
+                    isEnded = playbackState == Player.STATE_ENDED,
                     currentPosition = player.currentPosition,
                     duration = duration,
                 )
@@ -95,16 +96,22 @@ class MediaPlayerImpl @Inject constructor(
         MediaPlayer.State(
             isReady = false,
             isPlaying = false,
+            isEnded = false,
             mediaId = null,
             currentPosition = 0L,
-            duration = 0L
+            duration = null,
         )
     )
 
     override val state: StateFlow<MediaPlayer.State> = _state.asStateFlow()
 
     @OptIn(FlowPreview::class)
-    override suspend fun setMedia(uri: String, mediaId: String, mimeType: String): MediaPlayer.State {
+    override suspend fun setMedia(
+        uri: String,
+        mediaId: String,
+        mimeType: String,
+        startPositionMs: Long,
+    ): MediaPlayer.State {
         player.pause() // Must pause here otherwise if the player was playing it would keep on playing the new media item.
         player.clearMediaItems()
         player.setMediaItem(
@@ -112,7 +119,8 @@ class MediaPlayerImpl @Inject constructor(
                 .setUri(uri)
                 .setMediaId(mediaId)
                 .setMimeType(mimeType)
-                .build()
+                .build(),
+            startPositionMs,
         )
         player.prepare()
         // Will throw TimeoutCancellationException if the player is not ready after 1 second.
@@ -129,7 +137,7 @@ class MediaPlayerImpl @Inject constructor(
             // playing no sound.
             // This is a workaround which will reload the media file.
             player.getCurrentMediaItem()?.let {
-                player.setMediaItem(it)
+                player.setMediaItem(it, 0)
                 player.prepare()
                 player.play()
             }

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
@@ -35,7 +35,7 @@ interface SimplePlayer {
     val playbackState: Int
     val duration: Long
     fun clearMediaItems()
-    fun setMediaItem(mediaItem: MediaItem)
+    fun setMediaItem(mediaItem: MediaItem, startPositionMs: Long)
     fun getCurrentMediaItem(): MediaItem?
     fun prepare()
     fun play()
@@ -81,7 +81,7 @@ class SimplePlayerImpl(
 
     override fun clearMediaItems() = p.clearMediaItems()
 
-    override fun setMediaItem(mediaItem: MediaItem) = p.setMediaItem(mediaItem)
+    override fun setMediaItem(mediaItem: MediaItem, startPositionMs: Long) = p.setMediaItem(mediaItem, startPositionMs)
 
     override fun getCurrentMediaItem(): MediaItem? = p.currentMediaItem
 


### PR DESCRIPTION
- Voice messages can be scrubbed (i.e. seeked to) even when they have not been played yet..
- The progress bar is displayed also when paused.
- Multiple voice messages can keep their state when paused.
- Tries to adhere as much as possible at the detailed "green cursor" behavior in the story (but might not be 100% compliant).

Story: https://github.com/vector-im/element-meta/issues/2113
