### PR TITLE
Run Maestro flow only then `Run-Maestro` label is present in a PR

### DIFF
--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -23,6 +23,11 @@ jobs:
       group: ${{ format('maestro-{0}', github.ref) }}
       cancel-in-progress: true
     steps:
+      - name: Remove Run-Maestro label
+        if: ${{ github.event.label.name == 'Run-Maestro' }}
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: Run-Maestro
       - uses: actions/checkout@v4
         with:
           # Ensure we are building the branch and not the branch after being merged on develop
@@ -52,13 +57,3 @@ jobs:
             INVITEE1_MXID=@maestroelement2:matrix.org
             INVITEE2_MXID=@maestroelement3:matrix.org
             APP_ID=io.element.android.x.debug
-
-  remove_label:
-    if: ${{ github.event.label.name == 'Run-Maestro' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Remove Run-Maestro label
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: Run-Maestro

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -1,11 +1,10 @@
 name: Maestro
 
-# Run this flow only on pull request, and only when the pull request has been approved, to limit our usage of maestro cloud.
-# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-when-a-pull-request-is-approved
+# Run this flow only on pull request, and only when the pull request has the Run-Maestro label, to limit our usage of maestro cloud.
 on:
   workflow_dispatch:
-  pull_request_review:
-    types: [submitted]
+  pull_request:
+    types: [labeled]
 
 # Enrich gradle.properties for CI/CD
 env:
@@ -16,7 +15,7 @@ jobs:
   maestro-cloud:
     name: Maestro test suite
     runs-on: ubuntu-latest
-    if: github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'Run-Maestro'
     strategy:
       fail-fast: false
     # Allow one per PR.
@@ -53,3 +52,13 @@ jobs:
             INVITEE1_MXID=@maestroelement2:matrix.org
             INVITEE2_MXID=@maestroelement3:matrix.org
             APP_ID=io.element.android.x.debug
+
+  remove_label:
+    if: ${{ github.event.label.name == 'Run-Maestro' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Remove Run-Maestro label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: Run-Maestro


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Modified `maestro.yml` workflow so:

- The flow doesn't run anymore on PR approval.
- It will run when `Run-Maestro` label is added.
- Will automatically remove the `Run-Maestro` label when the flow starts.

## Motivation and context

This allows any dev to quickly trigger Maestro tests when they need them.

## Tests

This PR is a good test.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
