### PR TITLE
Rename params in NodeFactories for clarity

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/MainNode.kt
+++ b/app/src/main/kotlin/io/element/android/x/MainNode.kt
@@ -52,7 +52,7 @@ class MainNode(
     override val daggerComponent = (context as DaggerComponentOwner).daggerComponent
 
     override fun resolve(navTarget: RootNavTarget, buildContext: BuildContext): Node {
-        return createNode<RootFlowNode>(context = buildContext)
+        return createNode<RootFlowNode>(buildContext = buildContext)
     }
 
     @Composable

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/ConfigureRoomFlowNode.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/ConfigureRoomFlowNode.kt
@@ -77,11 +77,11 @@ class ConfigureRoomFlowNode @AssistedInject constructor(
                         backstack.push(NavTarget.ConfigureRoom)
                     }
                 }
-                createNode<AddPeopleNode>(context = buildContext, plugins = listOf(callback))
+                createNode<AddPeopleNode>(buildContext = buildContext, plugins = listOf(callback))
             }
             NavTarget.ConfigureRoom -> {
                 val callbacks = plugins<ConfigureRoomNode.Callback>()
-                createNode<ConfigureRoomNode>(context = buildContext, plugins = callbacks)
+                createNode<ConfigureRoomNode>(buildContext = buildContext, plugins = callbacks)
             }
         }
     }

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/CreateRoomFlowNode.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/CreateRoomFlowNode.kt
@@ -72,7 +72,7 @@ class CreateRoomFlowNode @AssistedInject constructor(
                         plugins<CreateRoomEntryPoint.Callback>().forEach { it.onSuccess(roomId) }
                     }
                 }
-                createNode<CreateRoomRootNode>(context = buildContext, plugins = listOf(callback))
+                createNode<CreateRoomRootNode>(buildContext = buildContext, plugins = listOf(callback))
             }
             NavTarget.NewRoom -> {
                 val callback = object : ConfigureRoomNode.Callback {
@@ -80,7 +80,7 @@ class CreateRoomFlowNode @AssistedInject constructor(
                         plugins<CreateRoomEntryPoint.Callback>().forEach { it.onSuccess(roomId) }
                     }
                 }
-                createNode<ConfigureRoomFlowNode>(context = buildContext, plugins = listOf(callback))
+                createNode<ConfigureRoomFlowNode>(buildContext = buildContext, plugins = listOf(callback))
             }
         }
     }

--- a/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/NodeFactories.kt
+++ b/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/NodeFactories.kt
@@ -21,27 +21,36 @@ import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.plugin.Plugin
 
-inline fun <reified NODE : Node> Node.createNode(context: BuildContext, plugins: List<Plugin> = emptyList()): NODE {
+inline fun <reified N : Node> Node.createNode(
+    buildContext: BuildContext,
+    plugins: List<Plugin> = emptyList()
+): N {
     val bindings: NodeFactoriesBindings = bindings()
-    return bindings.createNode(context, plugins)
+    return bindings.createNode(buildContext, plugins)
 }
 
-inline fun <reified NODE : Node> Context.createNode(context: BuildContext, plugins: List<Plugin> = emptyList()): NODE {
+inline fun <reified N : Node> Context.createNode(
+    buildContext: BuildContext,
+    plugins: List<Plugin> = emptyList()
+): N {
     val bindings: NodeFactoriesBindings = bindings()
-    return bindings.createNode(context, plugins)
+    return bindings.createNode(buildContext, plugins)
 }
 
-inline fun <reified NODE : Node> NodeFactoriesBindings.createNode(context: BuildContext, plugins: List<Plugin> = emptyList()): NODE {
-    val nodeClass = NODE::class.java
+inline fun <reified N : Node> NodeFactoriesBindings.createNode(
+    buildContext: BuildContext,
+    plugins: List<Plugin> = emptyList()
+): N {
+    val nodeClass = N::class.java
     val nodeFactoryMap = nodeFactories()
     // Note to developers: If you got the error below, make sure to build again after
     // clearing the cache (sometimes several times) to let Dagger generate the NodeFactory.
     val nodeFactory = nodeFactoryMap[nodeClass] ?: error("Cannot find NodeFactory for ${nodeClass.name}.")
 
     @Suppress("UNCHECKED_CAST")
-    val castedNodeFactory = nodeFactory as? AssistedNodeFactory<NODE>
-    val node = castedNodeFactory?.create(context, plugins)
-    return node as NODE
+    val castedNodeFactory = nodeFactory as? AssistedNodeFactory<N>
+    val node = castedNodeFactory?.create(buildContext, plugins)
+    return node as N
 }
 
 interface NodeFactoriesBindings {


### PR DESCRIPTION
- `context` is now `buildContext` to reflect that it's of type `BuildContext` (and not an android `Context`).
- `NODE` generic type param is now `N` to stick with Java convention: https://docs.oracle.com/javase/tutorial/java/generics/types.html.
