### PR TITLE
Use the right avatar for DMs in DM rooms

### DIFF
--- a/changelog.d/1912.bugfix
+++ b/changelog.d/1912.bugfix
@@ -1,0 +1,1 @@
+Use the right avatar for DMs in DM rooms

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -133,10 +133,10 @@ class MessagesPresenter @AssistedInject constructor(
         val syncUpdateFlow = room.syncUpdateFlow.collectAsState()
         val userHasPermissionToSendMessage by room.canSendMessageAsState(type = MessageEventType.ROOM_MESSAGE, updateKey = syncUpdateFlow.value)
         val userHasPermissionToRedact by room.canRedactAsState(updateKey = syncUpdateFlow.value)
-        val roomName: Async<String> by remember {
+        val roomName: Async<String> by remember(roomInfo?.name) {
             derivedStateOf { roomInfo?.name?.let { Async.Success(it) } ?: Async.Uninitialized }
         }
-        val roomAvatar: Async<AvatarData> by remember {
+        val roomAvatar: Async<AvatarData> by remember(roomInfo?.avatarUrl) {
             derivedStateOf { roomInfo?.avatarData()?.let { Async.Success(it) } ?: Async.Uninitialized }
         }
 
@@ -224,7 +224,7 @@ class MessagesPresenter @AssistedInject constructor(
         return AvatarData(
             id = id,
             name = name,
-            url = avatarUrl,
+            url = avatarUrl ?: room.avatarUrl,
             size = AvatarSize.TimelineRoom
         )
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

When no avatar is found in `RoomInfo`, use the one in `MatrixRoom` instead. This is usually the case for DM rooms.

## Motivation and context

Fixes #1912.

## Screenshots / GIFs

|Before|After|
|-|-|
|![temp (1)](https://github.com/vector-im/element-x-android/assets/480955/7e65481b-b3ac-4e94-ba36-14738ccd3727)|![temp](https://github.com/vector-im/element-x-android/assets/480955/76a7d9de-6f61-4e99-8b99-0d40baa40959)|

## Tests

<!-- Explain how you tested your development -->

- Open a DM.

If it displays the right avatar, it works.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
