### PR TITLE
Set a default power level to join calls in room

### DIFF
--- a/changelog.d/+set-default-power-level-to-join-calls.bugfix
+++ b/changelog.d/+set-default-power-level-to-join-calls.bugfix
@@ -1,0 +1,1 @@
+Set a default power level to join calls. Also, create new rooms taking this power level into account.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -79,6 +79,7 @@ import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
 import io.element.android.libraries.matrix.api.room.MessageEventType
+import io.element.android.libraries.matrix.api.user.CurrentSessionIdHolder
 import io.element.android.libraries.matrix.ui.components.AttachmentThumbnailInfo
 import io.element.android.libraries.matrix.ui.components.AttachmentThumbnailType
 import io.element.android.libraries.matrix.ui.room.canRedactAsState
@@ -108,6 +109,7 @@ class MessagesPresenter @AssistedInject constructor(
     private val featureFlagsService: FeatureFlagService,
     @Assisted private val navigator: MessagesNavigator,
     private val buildMeta: BuildMeta,
+    private val currentSessionIdHolder: CurrentSessionIdHolder,
 ) : Presenter<MessagesState> {
 
     private val timelinePresenter = timelinePresenterFactory.create(navigator = navigator)
@@ -144,6 +146,16 @@ class MessagesPresenter @AssistedInject constructor(
             mutableStateOf(false)
         }
 
+        var canJoinCall by rememberSaveable {
+            mutableStateOf(false)
+        }
+
+        LaunchedEffect(currentSessionIdHolder.current) {
+            withContext(dispatchers.io) {
+                canJoinCall = room.canUserJoinCall(userId = currentSessionIdHolder.current).getOrDefault(false)
+            }
+        }
+
         val inviteProgress = remember { mutableStateOf<Async<Unit>>(Async.Uninitialized) }
         var showReinvitePrompt by remember { mutableStateOf(false) }
         LaunchedEffect(hasDismissedInviteDialog, composerState.hasFocus, syncUpdateFlow) {
@@ -162,8 +174,6 @@ class MessagesPresenter @AssistedInject constructor(
         val enableTextFormatting by preferencesStore.isRichTextEditorEnabledFlow().collectAsState(initial = true)
 
         var enableVoiceMessages by remember { mutableStateOf(false) }
-        // TODO add min power level to use this feature in the future?
-        val enableInRoomCalls = true
         LaunchedEffect(featureFlagsService) {
             enableVoiceMessages = featureFlagsService.isFeatureEnabled(FeatureFlags.VoiceMessages)
         }
@@ -193,6 +203,12 @@ class MessagesPresenter @AssistedInject constructor(
             }
         }
 
+        val callState = when {
+            !canJoinCall -> RoomCallState.DISABLED
+            roomInfo?.hasRoomCall == true -> RoomCallState.ONGOING
+            else -> RoomCallState.ENABLED
+        }
+
         return MessagesState(
             roomId = room.roomId,
             roomName = roomName,
@@ -213,9 +229,8 @@ class MessagesPresenter @AssistedInject constructor(
             inviteProgress = inviteProgress.value,
             enableTextFormatting = enableTextFormatting,
             enableVoiceMessages = enableVoiceMessages,
-            enableInRoomCalls = enableInRoomCalls,
             appName = buildMeta.applicationName,
-            isCallOngoing = roomInfo?.hasRoomCall ?: false,
+            callState = callState,
             eventSink = { handleEvents(it) }
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
@@ -51,8 +51,13 @@ data class MessagesState(
     val showReinvitePrompt: Boolean,
     val enableTextFormatting: Boolean,
     val enableVoiceMessages: Boolean,
-    val enableInRoomCalls: Boolean,
-    val isCallOngoing: Boolean,
+    val callState: RoomCallState,
     val appName: String,
     val eventSink: (MessagesEvents) -> Unit
 )
+
+enum class RoomCallState {
+    ENABLED,
+    ONGOING,
+    DISABLED
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
@@ -66,7 +66,7 @@ open class MessagesStateProvider : PreviewParameterProvider<MessagesState> {
                 ),
             ),
             aMessagesState().copy(
-                isCallOngoing = true,
+                callState = RoomCallState.ONGOING,
             ),
             aMessagesState().copy(
                 enableVoiceMessages = true,
@@ -74,6 +74,9 @@ open class MessagesStateProvider : PreviewParameterProvider<MessagesState> {
                     voiceMessageState = aVoiceMessagePreviewState(),
                     showSendFailureDialog = true
                 ),
+            ),
+            aMessagesState().copy(
+                callState = RoomCallState.DISABLED,
             ),
         )
 }
@@ -117,8 +120,7 @@ fun aMessagesState() = MessagesState(
     showReinvitePrompt = false,
     enableTextFormatting = true,
     enableVoiceMessages = true,
-    enableInRoomCalls = true,
-    isCallOngoing = false,
+    callState = RoomCallState.ENABLED,
     appName = "Element",
     eventSink = {}
 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -191,10 +191,9 @@ fun MessagesView(
                 MessagesViewTopBar(
                     roomName = state.roomName.dataOrNull(),
                     roomAvatar = state.roomAvatar.dataOrNull(),
-                    inRoomCallsEnabled = state.enableInRoomCalls,
+                    callState = state.callState,
                     onBackPressed = onBackPressed,
                     onRoomDetailsClicked = onRoomDetailsClicked,
-                    isCallOngoing = state.isCallOngoing,
                     onJoinCallClicked = onJoinCallClicked,
                 )
             }
@@ -449,8 +448,7 @@ private fun MessagesViewComposerBottomSheetContents(
 private fun MessagesViewTopBar(
     roomName: String?,
     roomAvatar: AvatarData?,
-    inRoomCallsEnabled: Boolean,
-    isCallOngoing: Boolean,
+    callState: RoomCallState,
     onRoomDetailsClicked: () -> Unit,
     onJoinCallClicked: () -> Unit,
     onBackPressed: () -> Unit,
@@ -477,13 +475,11 @@ private fun MessagesViewTopBar(
             }
         },
         actions = {
-            if (inRoomCallsEnabled) {
-                if (isCallOngoing) {
-                    JoinCallMenuItem(onJoinCallClicked = onJoinCallClicked)
-                } else {
-                    IconButton(onClick = onJoinCallClicked) {
-                        Icon(CompoundIcons.VideoCall, contentDescription = stringResource(CommonStrings.a11y_start_call))
-                    }
+            if (callState == RoomCallState.ONGOING) {
+                JoinCallMenuItem(onJoinCallClicked = onJoinCallClicked)
+            } else {
+                IconButton(onClick = onJoinCallClicked, enabled = callState != RoomCallState.DISABLED) {
+                    Icon(CompoundIcons.VideoCall, contentDescription = stringResource(CommonStrings.a11y_start_call))
                 }
             }
             Spacer(Modifier.width(8.dp))

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
@@ -127,9 +127,10 @@ class MessagesPresenterTest {
     }
 
     @Test
-    fun `present - call is disabled if user cannot join it`() = runTest {
+    fun `present - call is disabled if user cannot join it even if there is an ongoing call`() = runTest {
         val room = FakeMatrixRoom().apply {
             givenCanUserJoinCall(Result.success(false))
+            givenRoomInfo(aRoomInfo(hasRoomCall = true))
         }
         val presenter = createMessagesPresenter(matrixRoom = room)
         moleculeFlow(RecompositionMode.Immediate) {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
@@ -99,6 +99,7 @@ import org.junit.Rule
 import org.junit.Test
 import kotlin.time.Duration.Companion.milliseconds
 
+@Suppress("LargeClass")
 class MessagesPresenterTest {
 
     @get:Rule

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -147,7 +147,7 @@ jsoup = "org.jsoup:jsoup:1.17.1"
 appyx_core = { module = "com.bumble.appyx:core", version.ref = "appyx" }
 molecule-runtime = "app.cash.molecule:molecule-runtime:1.3.1"
 timber = "com.jakewharton.timber:timber:5.0.1"
-matrix_sdk = "org.matrix.rustcomponents:sdk-android:0.1.71"
+matrix_sdk = "org.matrix.rustcomponents:sdk-android:0.1.72"
 matrix_richtexteditor = { module = "io.element.android:wysiwyg", version.ref = "wysiwyg" }
 matrix_richtexteditor_compose = { module = "io.element.android:wysiwyg-compose", version.ref = "wysiwyg" }
 sqldelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -132,6 +132,8 @@ interface MatrixRoom : Closeable {
 
     suspend fun canUserTriggerRoomNotification(userId: UserId): Result<Boolean>
 
+    suspend fun canUserJoinCall(userId: UserId): Result<Boolean>
+
     suspend fun updateAvatar(mimeType: String, data: ByteArray): Result<Unit>
 
     suspend fun removeAvatar(): Result<Unit>

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -77,6 +77,7 @@ import org.matrix.rustcomponents.sdk.BackupState
 import org.matrix.rustcomponents.sdk.Client
 import org.matrix.rustcomponents.sdk.ClientDelegate
 import org.matrix.rustcomponents.sdk.NotificationProcessSetup
+import org.matrix.rustcomponents.sdk.PowerLevels
 import org.matrix.rustcomponents.sdk.Room
 import org.matrix.rustcomponents.sdk.RoomListItem
 import org.matrix.rustcomponents.sdk.TaskHandle
@@ -275,6 +276,7 @@ class RustMatrixClient constructor(
                 },
                 invite = createRoomParams.invite?.map { it.value },
                 avatar = createRoomParams.avatar,
+                powerLevelContentOverride = defaultRoomCreationPowerLevels,
             )
             val roomId = RoomId(client.createRoom(rustParams))
 
@@ -297,7 +299,7 @@ class RustMatrixClient constructor(
             isDirect = true,
             visibility = RoomVisibility.PRIVATE,
             preset = RoomPreset.TRUSTED_PRIVATE_CHAT,
-            invite = listOf(userId)
+            invite = listOf(userId),
         )
         return createRoom(createRoomParams)
     }
@@ -482,3 +484,18 @@ class RustMatrixClient constructor(
     }
 }
 
+private val defaultRoomCreationPowerLevels = PowerLevels(
+    usersDefault = null,
+    eventsDefault = null,
+    stateDefault = null,
+    ban = null,
+    kick = null,
+    redact = null,
+    invite = null,
+    notifications = null,
+    users = mapOf(),
+    events = mapOf(
+        "m.call.member" to 0,
+        "org.matrix.msc3401.call.member" to 0,
+    )
+)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -364,6 +364,12 @@ class RustMatrixRoom(
         }
     }
 
+    override suspend fun canUserJoinCall(userId: UserId): Result<Boolean> {
+        return runCatching {
+            innerRoom.canUserSendState(userId.value, StateEventType.ROOM_MEMBER_EVENT.map())
+        }
+    }
+
     override suspend fun sendImage(file: File, thumbnailFile: File, imageInfo: ImageInfo, progressCallback: ProgressCallback?): Result<MediaUploadHandler> {
         return sendAttachment(listOf(file, thumbnailFile)) {
             innerTimeline.sendImage(file.path, thumbnailFile.path, imageInfo.map(), progressCallback?.toProgressWatcher())

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -111,6 +111,7 @@ class FakeMatrixRoom(
     private var generateWidgetWebViewUrlResult = Result.success("https://call.element.io")
     private var getWidgetDriverResult: Result<MatrixWidgetDriver> = Result.success(FakeWidgetDriver())
     private var canUserTriggerRoomNotificationResult: Result<Boolean> = Result.success(true)
+    private var canUserJoinCallResult: Result<Boolean> = Result.success(true)
     var sendMessageMentions = emptyList<Mention>()
     val editMessageCalls = mutableListOf<Pair<String, String?>>()
 
@@ -290,6 +291,10 @@ class FakeMatrixRoom(
 
     override suspend fun canUserTriggerRoomNotification(userId: UserId): Result<Boolean> {
         return canUserTriggerRoomNotificationResult
+    }
+
+    override suspend fun canUserJoinCall(userId: UserId): Result<Boolean> {
+        return canUserJoinCallResult
     }
 
     override suspend fun sendImage(
@@ -472,6 +477,10 @@ class FakeMatrixRoom(
 
     fun givenCanTriggerRoomNotification(result: Result<Boolean>) {
         canUserTriggerRoomNotificationResult = result
+    }
+
+    fun givenCanUserJoinCall(result: Result<Boolean>) {
+        canUserJoinCallResult = result
     }
 
     fun givenIgnoreResult(result: Result<Unit>) {

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl_MessagesView_null_MessagesView-Day-0_0_null_12,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl_MessagesView_null_MessagesView-Day-0_0_null_12,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cabc1dec0b89061db2b9f5301371b839a458e7e5bb6c8bc5b4d2fd4fcc3a179
+size 54275

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl_MessagesView_null_MessagesView-Night-0_1_null_12,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl_MessagesView_null_MessagesView-Night-0_1_null_12,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da867f9dd0e7d21419ce52e2e0eabfc26583e9dfb1523613a932394c307b3e28
+size 52621


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Add `MatrixRoom.canUserJoinCall(UserId)` to check if a user can join a call.
- Create `CallState` enum which reflects 3 possible UI states for this.
- Override the default Rust SDK parameters to create a room so users in a new room will be able to join calls.

## Motivation and context

Addresses:

https://github.com/vector-im/element-meta/issues/2230
https://github.com/vector-im/element-meta/issues/2229

## Screenshots / GIFs

Included in the PR.

## Tests

<!-- Explain how you tested your development -->

- Open an existing room (not a DM). The join call button should be disabled.
- Now create a new room. Users in this room should be able to create and join calls.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
